### PR TITLE
[Layouts] Add an InsetDividerLinearLayout component

### DIFF
--- a/lib/res-public/values/public_attrs.xml
+++ b/lib/res-public/values/public_attrs.xml
@@ -47,6 +47,9 @@
     <public type="attr" name="hintAnimationEnabled"/>
     <public type="attr" name="hintEnabled"/>
     <public type="attr" name="hintTextAppearance"/>
+    <public type="attr" name="insetDividers"/>
+    <public type="attr" name="insetDividerStart"/>
+    <public type="attr" name="insetDividerEnd"/>
     <public type="attr" name="itemBackground"/>
     <public type="attr" name="itemIconTint"/>
     <public type="attr" name="itemTextAppearance"/>

--- a/lib/res/values/attrs.xml
+++ b/lib/res/values/attrs.xml
@@ -472,4 +472,18 @@
         <attr name="elevation"/>
     </declare-styleable>
 
+    <declare-styleable name="InsetDividerLinearLayout">
+        <!-- Setting for which dividers to inset. -->
+        <attr name="insetDividers">
+            <flag name="none" value="0" />
+            <flag name="beginning" value="1" />
+            <flag name="middle" value="2" />
+            <flag name="end" value="4" />
+        </attr>
+        <!-- Start inset for dividers. -->
+        <attr name="insetDividerStart" format="dimension" />
+        <!-- End inset for dividers. -->
+        <attr name="insetDividerEnd" format="dimension" />
+    </declare-styleable>
+
 </resources>

--- a/lib/src/android/support/design/widget/InsetDividerLinearLayout.java
+++ b/lib/src/android/support/design/widget/InsetDividerLinearLayout.java
@@ -1,0 +1,393 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.support.design.widget;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.IntDef;
+import android.support.annotation.RestrictTo;
+import android.support.design.R;
+import android.support.v4.view.ViewCompat;
+import android.support.v7.widget.LinearLayoutCompat;
+import android.util.AttributeSet;
+import android.view.View;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * A LinearLayout which supports arbitrary divider insets. Inset dimensions can be set by calling
+ * {@link #setDividerInsetStart(int)} and {@link #setDividerInsetEnd(int)}. You can also specify
+ * which dividers to inset by calling {@link #setApplyInsets(int)}.
+ *
+ * <p>
+ * Differences in behavior between this layout and the standard LinearLayout:
+ * <ul>
+ *     <li>Dividers are drawn on top of child views to avoid disturbing grid alignment.</li>
+ *     <li>Dividers are drawn outside of padding applied to this layout.</li>
+ *     <li>{@link #setDividerPadding(int)} is a shortcut to set equal insets on both ends</li>
+ * </ul>
+ *
+ * <p>
+ * See {@link LinearLayoutCompat} for additional documentation.
+ */
+public class InsetDividerLinearLayout extends LinearLayoutCompat {
+  /** @hide */
+  @RestrictTo(LIBRARY_GROUP)
+  @IntDef(flag = true,
+      value = {
+          INSET_DIVIDER_NONE,
+          INSET_DIVIDER_BEGINNING,
+          INSET_DIVIDER_MIDDLE,
+          INSET_DIVIDER_END
+      })
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface InsetMode {}
+
+  /**
+   * Don't inset any dividers.
+   */
+  public static final int INSET_DIVIDER_NONE = 0;
+  /**
+   * Inset the divider at the beginning of the group.
+   */
+  public static final int INSET_DIVIDER_BEGINNING = 1;
+  /**
+   * Inset dividers between each item in the group.
+   */
+  public static final int INSET_DIVIDER_MIDDLE = 2;
+  /**
+   * Inset the divider at the end of the group.
+   */
+  public static final int INSET_DIVIDER_END = 4;
+
+  private Drawable mDivider;
+  private int mDividerWidth;
+  private int mDividerHeight;
+  private int mDividerOffsetVertical;
+  private int mDividerOffsetHorizontal;
+  private int mDividerInsetStart;
+  private int mDividerInsetEnd;
+  private int mApplyInsets;
+
+  public InsetDividerLinearLayout(Context context) {
+    this(context, null);
+  }
+
+  public InsetDividerLinearLayout(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public InsetDividerLinearLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+
+    final TypedArray a = context.obtainStyledAttributes(attrs,
+        R.styleable.InsetDividerLinearLayout, 0, 0);
+
+    mDividerInsetStart =
+        a.getDimensionPixelSize(R.styleable.InsetDividerLinearLayout_insetDividerStart, 0);
+    mDividerInsetEnd =
+        a.getDimensionPixelSize(R.styleable.InsetDividerLinearLayout_insetDividerEnd, 0);
+    mApplyInsets = a.getInt(R.styleable.InsetDividerLinearLayout_insetDividers,
+        INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END);
+
+    a.recycle();
+  }
+
+  /**
+   * @return the divider Drawable that will divide each item.
+   *
+   * @see #setDividerDrawable(Drawable)
+   */
+  @Override
+  public Drawable getDividerDrawable() {
+    return mDivider;
+  }
+
+  /**
+   * Set a drawable to be used as a divider between items.
+   *
+   * @param divider Drawable that will divide each item.
+   *
+   * @see #setShowDividers(int)
+   */
+  @Override
+  public void setDividerDrawable(Drawable divider) {
+    if (divider == mDivider) {
+      return;
+    }
+    mDivider = divider;
+    if (divider != null) {
+      mDividerWidth = divider.getIntrinsicWidth();
+      mDividerHeight = divider.getIntrinsicHeight();
+      mDividerOffsetVertical = mDividerHeight / 2;
+      mDividerOffsetHorizontal = mDividerWidth / 2;
+    } else {
+      mDividerWidth = 0;
+      mDividerHeight = 0;
+      mDividerOffsetVertical = 0;
+      mDividerOffsetHorizontal = 0;
+    }
+    setWillNotDraw(divider == null);
+    invalidate();
+  }
+
+  /**
+   * Set the inset displayed on the start of dividers.
+   *
+   * @param dividerInsetStart Inset value in pixels that will be applied to the divider start
+   *
+   * @see #setApplyInsets(int)
+   * @see #setDividerDrawable(Drawable)
+   * @see #getDividerInsetStart()
+   */
+  public void setDividerInsetStart(int dividerInsetStart) {
+    if (mDividerInsetStart != dividerInsetStart) {
+      mDividerInsetStart = dividerInsetStart;
+      super.setDividerPadding(0);
+      invalidate();
+    }
+  }
+
+  /**
+   * Return the size used to inset the start of dividers in pixels.
+   *
+   * @see #setApplyInsets(int)
+   * @see #setDividerDrawable(Drawable)
+   * @see #setDividerInsetStart(int)
+   */
+  public int getDividerInsetStart() {
+    return mDividerInsetStart;
+  }
+
+  /**
+   * Set the inset displayed on the end of dividers.
+   *
+   * @param dividerInsetEnd Inset value in pixels that will be applied to the divider end
+   *
+   * @see #setApplyInsets(int)
+   * @see #setDividerDrawable(Drawable)
+   * @see #getDividerInsetStart()
+   */
+  public void setDividerInsetEnd(int dividerInsetEnd) {
+    if (mDividerInsetEnd != dividerInsetEnd) {
+      mDividerInsetEnd = dividerInsetEnd;
+      super.setDividerPadding(0);
+      invalidate();
+    }
+  }
+
+  /**
+   * Return the size used to inset the end of dividers in pixels.
+   *
+   * @see #setApplyInsets(int)
+   * @see #setDividerDrawable(Drawable)
+   * @see #setDividerInsetEnd(int)
+   */
+  public int getDividerInsetEnd() {
+    return mDividerInsetEnd;
+  }
+
+  /**
+   * Set which dividers should be inset by the values set in {@link #setDividerInsetStart(int)}
+   * and {@link #setDividerInsetEnd(int)}. The default is to inset all dividers.
+   *
+   * @param applyInsets One or more of {@link #INSET_DIVIDER_BEGINNING},
+   *                    {@link #INSET_DIVIDER_MIDDLE}, or {@link #INSET_DIVIDER_END},
+   *                    or {@link #INSET_DIVIDER_NONE} to inset no dividers.
+   */
+  public void setApplyInsets(@InsetMode int applyInsets) {
+    if (applyInsets != mApplyInsets) {
+      mApplyInsets = applyInsets;
+      invalidate();
+    }
+  }
+
+  @InsetMode
+  public int getApplyInsets() {
+    return mApplyInsets;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setDividerPadding(int padding) {
+    super.setDividerPadding(padding);
+    mDividerInsetStart = padding;
+    mDividerInsetEnd = padding;
+  }
+
+  @Override
+  protected void dispatchDraw(Canvas canvas) {
+    super.dispatchDraw(canvas);
+
+    if (mDivider == null || getShowDividers() == SHOW_DIVIDER_NONE) {
+      return;
+    }
+
+    if (getOrientation() == VERTICAL) {
+      drawDividersVertical(canvas);
+    } else {
+      drawDividersHorizontal(canvas);
+    }
+  }
+
+  private boolean hasStartDivider() {
+    return (getShowDividers() & SHOW_DIVIDER_BEGINNING) != 0;
+  }
+
+  private boolean hasMiddleDivider() {
+    return (getShowDividers() & SHOW_DIVIDER_MIDDLE) != 0;
+  }
+
+  private boolean hasEndDivider() {
+    return (getShowDividers() & SHOW_DIVIDER_END) != 0;
+  }
+
+  private boolean hasStartDividerInsets() {
+    return (mApplyInsets & INSET_DIVIDER_BEGINNING) != 0;
+  }
+
+  private boolean hasMiddleDividerInsets() {
+    return (mApplyInsets & INSET_DIVIDER_MIDDLE) != 0;
+  }
+
+  private boolean hasEndDividerInsets() {
+    return (mApplyInsets & INSET_DIVIDER_END) != 0;
+  }
+
+  int getFirstVisibleChildIndex() {
+    final int count = getChildCount();
+    for (int i = 0; i < count; i++) {
+      if (getChildAt(i).getVisibility() != GONE) {
+        return i;
+      }
+    }
+    return Integer.MAX_VALUE;
+  }
+
+  int getLastVisibleChildIndex() {
+    final int count = getChildCount();
+    for (int i = count - 1; i >= 0; i--) {
+      if (getChildAt(i).getVisibility() != GONE) {
+        return i;
+      }
+    }
+    return Integer.MIN_VALUE;
+  }
+
+  private void drawDividersVertical(Canvas canvas) {
+    final boolean isLayoutRtl =
+        ViewCompat.getLayoutDirection(this) == ViewCompat.LAYOUT_DIRECTION_RTL;
+
+    final int insetStart = isLayoutRtl ? mDividerInsetEnd : mDividerInsetStart;
+    final int insetEnd = isLayoutRtl ? mDividerInsetStart : mDividerInsetEnd;
+
+    final int indexStart = getFirstVisibleChildIndex();
+    final int indexEnd = getLastVisibleChildIndex();
+
+    if (hasMiddleDivider() && indexStart < indexEnd) {
+      final boolean hasMiddleInsets = hasMiddleDividerInsets();
+      final int insetLeft = hasMiddleInsets ? insetStart : 0;
+      final int insetRight = hasMiddleInsets ? insetEnd : 0;
+
+      for (int i = indexStart + 1; i <= indexEnd; i++) {
+        final View child = getChildAt(i);
+        if (child != null && child.getVisibility() != GONE) {
+          final LayoutParams lp = (LayoutParams) child.getLayoutParams();
+          final int top = child.getTop() - lp.topMargin - mDividerOffsetVertical;
+          drawHorizontalDivider(canvas, top, insetLeft, insetRight);
+        }
+      }
+    }
+
+    if (hasStartDivider()) {
+      final boolean hasInsets = hasStartDividerInsets();
+      drawHorizontalDivider(canvas, 0,
+          hasInsets ? insetStart : 0,
+          hasInsets ? insetEnd : 0);
+    }
+
+    if (hasEndDivider()) {
+      final boolean hasInsets = hasEndDividerInsets();
+      drawHorizontalDivider(canvas, getHeight() - mDividerHeight,
+          hasInsets ? insetStart: 0,
+          hasInsets ? insetEnd : 0);
+    }
+  }
+
+  void drawDividersHorizontal(Canvas canvas) {
+    final boolean isLayoutRtl =
+        ViewCompat.getLayoutDirection(this) == ViewCompat.LAYOUT_DIRECTION_RTL;
+
+    final int insetStart = mDividerInsetStart;
+    final int insetEnd = mDividerInsetEnd;
+
+    final int indexStart = getFirstVisibleChildIndex();
+    final int indexEnd = getLastVisibleChildIndex();
+
+    if (hasMiddleDivider() && indexStart < indexEnd) {
+      final boolean hasMiddleInsets = hasMiddleDividerInsets();
+      final int insetTop = hasMiddleInsets ? insetStart : 0;
+      final int insetBottom = hasMiddleInsets ? insetEnd : 0;
+
+      for (int i = indexStart + 1; i < indexEnd; i++) {
+        final View child = getChildAt(i);
+        if (child != null && child.getVisibility() != GONE) {
+          final LayoutParams lp = (LayoutParams) child.getLayoutParams();
+          final int position;
+          if (isLayoutRtl) {
+            position = child.getRight() + lp.rightMargin;
+          } else {
+            position = child.getLeft() - lp.leftMargin;
+          }
+
+          drawVerticalDivider(canvas, position - mDividerOffsetHorizontal,
+              insetTop, insetBottom);
+        }
+      }
+    }
+
+    if (hasStartDivider()) {
+      final boolean hasInsets = hasStartDividerInsets();
+      drawVerticalDivider(canvas, isLayoutRtl ? getWidth() - mDividerHeight : 0,
+          hasInsets ? mDividerInsetStart : 0,
+          hasInsets ? mDividerInsetEnd : 0);
+    }
+
+    if (hasEndDivider()) {
+      final boolean hasInsets = hasEndDividerInsets();
+      drawVerticalDivider(canvas, isLayoutRtl ? 0 : getWidth() - mDividerHeight,
+          hasInsets ? mDividerInsetStart : 0,
+          hasInsets ? mDividerInsetEnd : 0);
+    }
+  }
+
+  void drawHorizontalDivider(Canvas canvas, int top, int insetLeft, int insetRight) {
+    mDivider.setBounds(insetLeft, top, getWidth() - insetRight, top + mDividerHeight);
+    mDivider.draw(canvas);
+  }
+
+  void drawVerticalDivider(Canvas canvas, int left, int insetTop, int insetBottom) {
+    mDivider.setBounds(left, insetTop, left + mDividerWidth, getHeight() - insetBottom);
+    mDivider.draw(canvas);
+  }
+}

--- a/lib/tests/AndroidManifest.xml
+++ b/lib/tests/AndroidManifest.xml
@@ -75,6 +75,14 @@
 
         <activity
             android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:name="android.support.design.widget.InsetDividerLinearLayoutActivity" />
+
+      <activity
+          android:theme="@style/Theme.AppCompat.NoActionBar"
+          android:name="android.support.design.widget.InsetDividerLinearLayoutWithItemsActivity" />
+
+        <activity
+            android:theme="@style/Theme.AppCompat.NoActionBar"
             android:name="android.support.design.widget.NavigationViewActivity"/>
 
         <activity

--- a/lib/tests/res/layout/design_inset_divider_linear_layout.xml
+++ b/lib/tests/res/layout/design_inset_divider_linear_layout.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<android.support.design.widget.InsetDividerLinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/inset_divider_linear_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical" />

--- a/lib/tests/res/layout/design_inset_divider_linear_layout_items.xml
+++ b/lib/tests/res/layout/design_inset_divider_linear_layout_items.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<android.support.v4.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <android.support.design.widget.InsetDividerLinearLayout
+      android:id="@+id/inset_divider_linear_layout"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      app:divider="?android:listDivider"
+      app:insetDividerStart="@dimen/divider_inset_start"
+      app:insetDividerEnd="@dimen/divider_inset_end"
+      app:showDividers="beginning|middle|end">
+
+    <android.support.v4.widget.Space
+        android:layout_width="@dimen/divider_item_size"
+        android:layout_height="@dimen/divider_item_size" />
+
+    <android.support.v4.widget.Space
+        android:layout_width="@dimen/divider_item_size"
+        android:layout_height="@dimen/divider_item_size" />
+
+    <android.support.v4.widget.Space
+        android:layout_width="@dimen/divider_item_size"
+        android:layout_height="@dimen/divider_item_size" />
+
+    <android.support.v4.widget.Space
+        android:layout_width="@dimen/divider_item_size"
+        android:layout_height="@dimen/divider_item_size" />
+  </android.support.design.widget.InsetDividerLinearLayout>
+</android.support.v4.widget.NestedScrollView>

--- a/lib/tests/res/values/dimens.xml
+++ b/lib/tests/res/values/dimens.xml
@@ -33,4 +33,8 @@
     <dimen name="fab_normal_height">56dip</dimen>
 
     <dimen name="custom_snackbar_max_width">-1px</dimen>
+
+    <dimen name="divider_inset_start">72dip</dimen>
+    <dimen name="divider_inset_end">16dip</dimen>
+    <dimen name="divider_item_size">144dp</dimen>
 </resources>

--- a/lib/tests/src/android/support/design/widget/InsetDividerLinearLayoutActivity.java
+++ b/lib/tests/src/android/support/design/widget/InsetDividerLinearLayoutActivity.java
@@ -1,0 +1,10 @@
+package android.support.design.widget;
+
+import android.support.design.test.R;
+
+public class InsetDividerLinearLayoutActivity extends BaseTestActivity {
+    @Override
+    protected int getContentViewLayoutResId() {
+        return R.layout.design_inset_divider_linear_layout;
+    }
+}

--- a/lib/tests/src/android/support/design/widget/InsetDividerLinearLayoutApplyInsetsTest.java
+++ b/lib/tests/src/android/support/design/widget/InsetDividerLinearLayoutApplyInsetsTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package android.support.design.widget;
+
+import static android.support.design.widget.InsetDividerLinearLayout.INSET_DIVIDER_BEGINNING;
+import static android.support.design.widget.InsetDividerLinearLayout.INSET_DIVIDER_END;
+import static android.support.design.widget.InsetDividerLinearLayout.INSET_DIVIDER_MIDDLE;
+import static android.support.design.widget.InsetDividerLinearLayout.INSET_DIVIDER_NONE;
+import static android.support.design.widget.InsetDividerLinearLayout.InsetMode;
+import static android.support.v4.view.ViewCompat.LAYOUT_DIRECTION_LTR;
+import static android.support.v4.view.ViewCompat.LAYOUT_DIRECTION_RTL;
+import static android.support.v7.widget.LinearLayoutCompat.HORIZONTAL;
+import static android.support.v7.widget.LinearLayoutCompat.OrientationMode;
+import static android.support.v7.widget.LinearLayoutCompat.VERTICAL;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Instrumentation;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.support.design.test.R;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.MediumTest;
+import android.support.v4.view.ViewCompat;
+import android.view.View;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class InsetDividerLinearLayoutApplyInsetsTest
+    extends BaseInstrumentationTestCase<InsetDividerLinearLayoutWithItemsActivity> {
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    // All permutations of inset mode, LinearLayout orientation, and horizontal layout direction.
+    return Arrays.asList(
+        new Object[][]{
+            // Vertical orientation, LTR
+            {INSET_DIVIDER_NONE, VERTICAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_BEGINNING, VERTICAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_MIDDLE, VERTICAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_END, VERTICAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE, VERTICAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_END, VERTICAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END, VERTICAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END, VERTICAL,
+                LAYOUT_DIRECTION_LTR},
+
+            // Horizontal orientation, LTR
+            {INSET_DIVIDER_NONE, HORIZONTAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_BEGINNING, HORIZONTAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_MIDDLE, HORIZONTAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_END, HORIZONTAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE, HORIZONTAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_END, HORIZONTAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END, HORIZONTAL, LAYOUT_DIRECTION_LTR},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END, HORIZONTAL,
+                LAYOUT_DIRECTION_LTR},
+
+            // Vertical orientation, RTL
+            {INSET_DIVIDER_NONE, VERTICAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_BEGINNING, VERTICAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_MIDDLE, VERTICAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_END, VERTICAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE, VERTICAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_END, VERTICAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END, VERTICAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END, VERTICAL,
+                LAYOUT_DIRECTION_RTL},
+
+            // Horizontal orientation, RTL
+            {INSET_DIVIDER_NONE, HORIZONTAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_BEGINNING, HORIZONTAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_MIDDLE, HORIZONTAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_END, HORIZONTAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE, HORIZONTAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_END, HORIZONTAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END, HORIZONTAL, LAYOUT_DIRECTION_RTL},
+            {INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END, HORIZONTAL,
+                LAYOUT_DIRECTION_RTL},
+        });
+  }
+
+  @InsetMode
+  private int mInsetMode;
+
+  @OrientationMode
+  private int mOrientation;
+
+  private int mLayoutDirection;
+
+  private int mInsetStart;
+
+  private int mInsetEnd;
+
+  private int mItemSize;
+
+  public InsetDividerLinearLayoutApplyInsetsTest(@InsetMode int insetMode,
+      @OrientationMode int orientation, int layoutDirection) {
+    super(InsetDividerLinearLayoutWithItemsActivity.class);
+    mInsetMode = insetMode;
+    mOrientation = orientation;
+    mLayoutDirection = layoutDirection;
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    final Resources res = mActivityTestRule.getActivity().getResources();
+    mInsetStart = res.getDimensionPixelSize(R.dimen.divider_inset_start);
+    mInsetEnd = res.getDimensionPixelSize(R.dimen.divider_inset_end);
+    mItemSize = res.getDimensionPixelSize(R.dimen.divider_item_size);
+  }
+
+  @Test
+  @MediumTest
+  public void testApplyInsets() throws Throwable {
+    final InsetDividerLinearLayout layout = mActivityTestRule.getActivity().mLinearLayout;
+    final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+
+    final int count = layout.getChildCount();
+    final int size = count * mItemSize;
+
+    // We'll only test for on/off pixels, which assumes our view and child backgrounds are
+    // transparent, and the divider drawable is non-transparent.
+    final Bitmap b = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_4444);
+
+    mActivityTestRule.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        layout.setApplyInsets(mInsetMode);
+        layout.setOrientation(mOrientation);
+        ViewCompat.setLayoutDirection(layout, mLayoutDirection);
+
+        // Manually rendering this view is a bit wasteful, but it eliminates the problem of
+        // variable test device screen size.
+        layout.measure(View.MeasureSpec.makeMeasureSpec(size, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(size, View.MeasureSpec.EXACTLY));
+        layout.layout(0, 0, size, size);
+        final Canvas c = new Canvas(b);
+        layout.draw(c);
+      }
+    });
+
+    instrumentation.waitForIdleSync();
+
+    if ((mInsetMode & INSET_DIVIDER_BEGINNING) == 0) {
+      assertDividerInset("beginning divider is not inset", layout, b, 0, false);
+    } else {
+      assertDividerInset("beginning divider is inset", layout, b, 0, true);
+    }
+
+    if ((mInsetMode & INSET_DIVIDER_MIDDLE) == 0) {
+      for (int i = 1; i < count - 1; i++) {
+        assertDividerInset("middle divider is not inset", layout, b, mItemSize * i, false);
+      }
+    } else {
+      for (int i = 1; i < count - 1; i++) {
+        assertDividerInset("middle divider is inset", layout, b, mItemSize * i, true);
+      }
+    }
+
+    if ((mInsetMode & INSET_DIVIDER_END) == 0) {
+      assertDividerInset("end divider is not inset", layout, b, mItemSize * count - 1, false);
+    } else {
+      assertDividerInset("end divider is inset", layout, b, mItemSize * count - 1, true);
+    }
+  }
+
+  /**
+   * Test four pixels per divider to assert our inset behavior based on inset rule, orientation,
+   * and layout direction.
+   */
+  private void assertDividerInset(String message, View layout, Bitmap b, int offset,
+      boolean expectedInset) {
+    if (mOrientation == VERTICAL) {
+      final int left = 0;
+      final int right = b.getWidth() - 1;
+      final int insetLeft;
+      final int insetRight;
+
+      if (ViewCompat.getLayoutDirection(layout) == LAYOUT_DIRECTION_LTR) {
+        insetLeft = mInsetStart;
+        insetRight = right - mInsetEnd;
+      } else {
+        insetLeft = mInsetEnd;
+        insetRight = right - mInsetStart;
+      }
+
+      assertPixel(message, b, left, offset, !expectedInset);
+      assertPixel(message, b, insetLeft, offset, true);
+      assertPixel(message, b, insetRight, offset, true);
+      assertPixel(message, b, right, offset, !expectedInset);
+    } else {
+      final int top = 0;
+      final int bottom = b.getHeight() - 1;
+      final int insetTop = mInsetStart;
+      final int insetBottom = bottom - mInsetEnd;
+
+      if (ViewCompat.getLayoutDirection(layout) == LAYOUT_DIRECTION_RTL) {
+        offset = b.getWidth() - offset - 1;
+      }
+
+      assertPixel(message, b, offset, top, !expectedInset);
+      assertPixel(message, b, offset, insetTop, true);
+      assertPixel(message, b, offset, insetBottom, true);
+      assertPixel(message, b, offset, bottom, !expectedInset);
+    }
+  }
+
+  private static void assertPixel(String message, Bitmap b, int x, int y, boolean expected) {
+    final int pixel = b.getPixel(x, y);
+    if (expected) {
+      assertTrue(message, pixel != 0);
+    } else {
+      assertTrue(message, pixel == 0);
+    }
+  }
+}

--- a/lib/tests/src/android/support/design/widget/InsetDividerLinearLayoutTest.java
+++ b/lib/tests/src/android/support/design/widget/InsetDividerLinearLayoutTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package android.support.design.widget;
+
+import static android.support.design.widget.InsetDividerLinearLayout.INSET_DIVIDER_BEGINNING;
+import static android.support.design.widget.InsetDividerLinearLayout.INSET_DIVIDER_END;
+import static android.support.design.widget.InsetDividerLinearLayout.INSET_DIVIDER_MIDDLE;
+import static org.junit.Assert.assertEquals;
+
+import android.app.Instrumentation;
+import android.content.res.Resources;
+import android.support.design.test.R;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.v4.widget.Space;
+import android.support.v7.widget.LinearLayoutCompat;
+import android.view.View;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InsetDividerLinearLayoutTest
+    extends BaseInstrumentationTestCase<InsetDividerLinearLayoutActivity> {
+
+  private InsetDividerLinearLayout mLayout;
+
+  private int mInsetStart;
+
+  private int mInsetEnd;
+
+  private int mItemSize;
+
+  public InsetDividerLinearLayoutTest() {
+    super(InsetDividerLinearLayoutActivity.class);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    final InsetDividerLinearLayoutActivity activity = mActivityTestRule.getActivity();
+    mLayout = (InsetDividerLinearLayout) activity.findViewById(R.id.inset_divider_linear_layout);
+
+    final Resources res = activity.getResources();
+    mInsetStart = res.getDimensionPixelSize(R.dimen.divider_inset_start);
+    mInsetEnd = res.getDimensionPixelSize(R.dimen.divider_inset_end);
+    mItemSize = res.getDimensionPixelSize(R.dimen.divider_item_size);
+  }
+
+  @Test
+  @SmallTest
+  public void testBasics() {
+    // Defaults
+    assertEquals("Should have no start inset", mLayout.getDividerInsetStart(), 0);
+    assertEquals("Should have no end inset", mLayout.getDividerInsetEnd(), 0);
+    assertEquals("Should apply all insets", mLayout.getApplyInsets(),
+        INSET_DIVIDER_BEGINNING | INSET_DIVIDER_MIDDLE | INSET_DIVIDER_END);
+  }
+
+  @Test
+  @SmallTest
+  public void testDividerPaddingCompatibility() {
+    mLayout.setDividerPadding(mInsetStart);
+
+    assertEquals("Padding should apply start inset", mLayout.getDividerInsetStart(), mInsetStart);
+    assertEquals("Padding should apply end inset", mLayout.getDividerInsetEnd(), mInsetStart);
+    assertEquals("Padding should be set on super", mLayout.getDividerPadding(), mInsetStart);
+
+    mLayout.setDividerInsetEnd(mInsetEnd);
+    assertEquals("Insets should override padding", mLayout.getDividerInsetEnd(), mInsetEnd);
+    assertEquals("Insets should clear padding", mLayout.getDividerPadding(), 0);
+  }
+
+  @Test
+  @SmallTest
+  public void testChildVisibility() throws Throwable {
+    final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+
+    mActivityTestRule.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        addChildWithVisibility(View.GONE);
+        addChildWithVisibility(View.VISIBLE);
+        addChildWithVisibility(View.GONE);
+        addChildWithVisibility(View.VISIBLE);
+        addChildWithVisibility(View.GONE);
+      }
+    });
+
+    instrumentation.waitForIdleSync();
+
+    assertEquals("first visible child index", mLayout.getFirstVisibleChildIndex(), 1);
+    assertEquals("last visible child index", mLayout.getLastVisibleChildIndex(), 3);
+
+    mActivityTestRule.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        mLayout.removeAllViews();
+      }
+    });
+
+    instrumentation.waitForIdleSync();
+  }
+
+  private void addChildWithVisibility(int visibility) {
+    View child = new Space(mLayout.getContext());
+    child.setVisibility(visibility);
+    mLayout.addView(child, new LinearLayoutCompat.LayoutParams(mItemSize, mItemSize));
+  }
+}

--- a/lib/tests/src/android/support/design/widget/InsetDividerLinearLayoutWithItemsActivity.java
+++ b/lib/tests/src/android/support/design/widget/InsetDividerLinearLayoutWithItemsActivity.java
@@ -1,0 +1,18 @@
+package android.support.design.widget;
+
+import android.support.design.test.R;
+
+public class InsetDividerLinearLayoutWithItemsActivity extends BaseTestActivity {
+
+  public InsetDividerLinearLayout mLinearLayout;
+
+  @Override
+  protected int getContentViewLayoutResId() {
+    return R.layout.design_inset_divider_linear_layout_items;
+  }
+
+  @Override
+  protected void onContentViewSet() {
+    mLinearLayout = (InsetDividerLinearLayout) findViewById(R.id.inset_divider_linear_layout);
+  }
+}


### PR DESCRIPTION
Ref #7

Adds a standalone modification to LinearLayoutCompat which allows for
control over divider insets. Users may specify "start" and "end" insets,
which affect the appropriate dimension in both horizontal and vertical
orientations, as well as LTR and RTL layout directions. Users may also
specify which dividers to inset, similar to the `showDividers`
attribute.

To make it easier to adhere to the Material Design baseline grid,
dividers are drawn over child views instead of offsetting them. This
also allows for backgrounds to be set directly on children without
leaving gaps where they would normally be offset.

* https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids

Additionally, start/end dividers are drawn outside of the layout's
padding by ignoring child dimensions and simply drawing them along the
top/bottom (in vertical orientation) or left/right (in horizontal
orientation) edges of the layout. This makes it easier to apply the
recommended top/bottom padding to the layout per the Lists spec.

* https://material.io/guidelines/components/lists.html#lists-specs

Tests were added to verify some basic behavior as well as covering all
permutations of inset mode, orientation, and layout direction. These
pass on emulators from platform versions 2.3.7 to 7.1.1.