### PR TITLE
[BottomNavigationView] Add tablet mode

### DIFF
--- a/lib/res-public/values/public_attrs.xml
+++ b/lib/res-public/values/public_attrs.xml
@@ -51,6 +51,7 @@
     <public type="attr" name="itemIconTint"/>
     <public type="attr" name="itemTextAppearance"/>
     <public type="attr" name="itemTextColor"/>
+    <public type="attr" name="tabletMode"/>
     <public type="attr" name="keylines"/>
     <public type="attr" name="layout_anchor"/>
     <public type="attr" name="layout_anchorGravity"/>

--- a/lib/res/values/attrs.xml
+++ b/lib/res/values/attrs.xml
@@ -470,6 +470,8 @@
         <attr name="itemTextColor"/>
         <attr name="itemBackground"/>
         <attr name="elevation"/>
+        <!-- Flag that indicates if the BottomNavigationView should use tablet mode -->
+        <attr name="tabletMode" format="boolean"/>
     </declare-styleable>
 
 </resources>

--- a/lib/res/values/dimens.xml
+++ b/lib/res/values/dimens.xml
@@ -59,13 +59,18 @@
     <dimen name="design_bottom_sheet_peek_height_min">64dp</dimen>
 
     <dimen name="design_bottom_navigation_height">56dp</dimen>
+    <dimen name="design_bottom_navigation_width">56dp</dimen>
     <dimen name="design_bottom_navigation_elevation">8dp</dimen>
     <dimen name="design_bottom_navigation_shadow_height">1dp</dimen>
+    <dimen name="design_bottom_navigation_shadow_width">1dp</dimen>
     <dimen name="design_bottom_navigation_text_size">12sp</dimen>
     <dimen name="design_bottom_navigation_active_text_size">14sp</dimen>
     <dimen name="design_bottom_navigation_margin">8dp</dimen>
     <dimen name="design_bottom_navigation_item_min_width">56dp</dimen>
     <dimen name="design_bottom_navigation_item_max_width">96dp</dimen>
+    <dimen name="design_bottom_navigation_item_min_height">56dp</dimen>
+    <dimen name="design_bottom_navigation_item_max_height">96dp</dimen>
     <dimen name="design_bottom_navigation_active_item_max_width">168dp</dimen>
+    <dimen name="design_bottom_navigation_active_item_max_height">168dp</dimen>
 
 </resources>

--- a/lib/src/android/support/design/internal/BottomNavigationItemView.java
+++ b/lib/src/android/support/design/internal/BottomNavigationItemView.java
@@ -34,6 +34,7 @@ import android.support.v7.view.menu.MenuView;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.LayoutInflater;
+import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -51,6 +52,7 @@ public class BottomNavigationItemView extends FrameLayout implements MenuView.It
   private final float mScaleDownFactor;
 
   private boolean mShiftingMode;
+  private boolean mTabletMode = false;
 
   private ImageView mIcon;
   private final TextView mSmallLabel;
@@ -110,6 +112,10 @@ public class BottomNavigationItemView extends FrameLayout implements MenuView.It
     mShiftingMode = enabled;
   }
 
+  public void setTabletMode(boolean enabled) {
+    mTabletMode = enabled;
+  }
+
   @Override
   public MenuItemImpl getItemData() {
     return mItemData;
@@ -119,6 +125,10 @@ public class BottomNavigationItemView extends FrameLayout implements MenuView.It
   public void setTitle(CharSequence title) {
     mSmallLabel.setText(title);
     mLargeLabel.setText(title);
+    if (mTabletMode) {
+      mSmallLabel.setVisibility(GONE);
+      mLargeLabel.setVisibility(GONE);
+    }
   }
 
   @Override
@@ -135,7 +145,8 @@ public class BottomNavigationItemView extends FrameLayout implements MenuView.It
     if (mShiftingMode) {
       if (checked) {
         LayoutParams iconParams = (LayoutParams) mIcon.getLayoutParams();
-        iconParams.gravity = Gravity.CENTER_HORIZONTAL | Gravity.TOP;
+        iconParams.gravity = mTabletMode ? Gravity.CENTER :
+                (Gravity.CENTER_HORIZONTAL | Gravity.TOP);
         iconParams.topMargin = mDefaultMargin;
         mIcon.setLayoutParams(iconParams);
         mLargeLabel.setVisibility(VISIBLE);

--- a/lib/src/android/support/design/internal/BottomNavigationMenuView.java
+++ b/lib/src/android/support/design/internal/BottomNavigationMenuView.java
@@ -31,15 +31,21 @@ import android.support.v7.view.menu.MenuBuilder;
 import android.support.v7.view.menu.MenuItemImpl;
 import android.support.v7.view.menu.MenuView;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
 /** @hide For internal use only. */
 @RestrictTo(LIBRARY_GROUP)
 public class BottomNavigationMenuView extends ViewGroup implements MenuView {
   private final int mInactiveItemMaxWidth;
   private final int mInactiveItemMinWidth;
+  private final int mInactiveItemMaxHeight;
+  private final int mInactiveItemMinHeight;
   private final int mActiveItemMaxWidth;
+  private final int mActiveItemMaxHeight;
+  private final int mItemWidth;
   private final int mItemHeight;
   private final OnClickListener mOnClickListener;
   private final BottomNavigationAnimationHelperBase mAnimationHelper;
@@ -47,13 +53,14 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
       new Pools.SynchronizedPool<>(5);
 
   private boolean mShiftingMode = true;
+  private boolean mTabletMode = false;
 
   private BottomNavigationItemView[] mButtons;
   private int mActiveButton = 0;
   private ColorStateList mItemIconTint;
   private ColorStateList mItemTextColor;
   private int mItemBackgroundRes;
-  private int[] mTempChildWidths;
+  private int[] mTempChildSizes;
 
   private BottomNavigationPresenter mPresenter;
   private MenuBuilder mMenu;
@@ -69,9 +76,16 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
         res.getDimensionPixelSize(R.dimen.design_bottom_navigation_item_max_width);
     mInactiveItemMinWidth =
         res.getDimensionPixelSize(R.dimen.design_bottom_navigation_item_min_width);
+    mInactiveItemMaxHeight =
+            res.getDimensionPixelSize(R.dimen.design_bottom_navigation_item_max_height);
+    mInactiveItemMinHeight =
+            res.getDimensionPixelSize(R.dimen.design_bottom_navigation_item_min_height);
     mActiveItemMaxWidth =
         res.getDimensionPixelSize(R.dimen.design_bottom_navigation_active_item_max_width);
+    mActiveItemMaxHeight =
+            res.getDimensionPixelSize(R.dimen.design_bottom_navigation_active_item_max_height);
     mItemHeight = res.getDimensionPixelSize(R.dimen.design_bottom_navigation_height);
+    mItemWidth = res.getDimensionPixelSize(R.dimen.design_bottom_navigation_width);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
       mAnimationHelper = new BottomNavigationAnimationHelperIcs();
@@ -90,7 +104,8 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
             }
           }
         };
-    mTempChildWidths = new int[BottomNavigationMenu.MAX_ITEM_COUNT];
+
+    mTempChildSizes = new int[BottomNavigationMenu.MAX_ITEM_COUNT];
   }
 
   @Override
@@ -105,7 +120,10 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
 
     final int heightSpec = MeasureSpec.makeMeasureSpec(mItemHeight, MeasureSpec.EXACTLY);
 
-    if (mShiftingMode) {
+    if (mTabletMode) {
+      measureTabletMode(heightMeasureSpec);
+      return;
+    } else if (mShiftingMode) {
       final int inactiveCount = count - 1;
       final int activeMaxAvailable = width - inactiveCount * mInactiveItemMinWidth;
       final int activeWidth = Math.min(activeMaxAvailable, mActiveItemMaxWidth);
@@ -113,9 +131,9 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
       final int inactiveWidth = Math.min(inactiveMaxAvailable, mInactiveItemMaxWidth);
       int extra = width - activeWidth - inactiveWidth * inactiveCount;
       for (int i = 0; i < count; i++) {
-        mTempChildWidths[i] = (i == mActiveButton) ? activeWidth : inactiveWidth;
+        mTempChildSizes[i] = (i == mActiveButton) ? activeWidth : inactiveWidth;
         if (extra > 0) {
-          mTempChildWidths[i]++;
+          mTempChildSizes[i]++;
           extra--;
         }
       }
@@ -124,9 +142,9 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
       final int childWidth = Math.min(maxAvailable, mActiveItemMaxWidth);
       int extra = width - childWidth * count;
       for (int i = 0; i < count; i++) {
-        mTempChildWidths[i] = childWidth;
+        mTempChildSizes[i] = childWidth;
         if (extra > 0) {
-          mTempChildWidths[i]++;
+          mTempChildSizes[i]++;
           extra--;
         }
       }
@@ -139,7 +157,7 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
         continue;
       }
       child.measure(
-          MeasureSpec.makeMeasureSpec(mTempChildWidths[i], MeasureSpec.EXACTLY), heightSpec);
+          MeasureSpec.makeMeasureSpec(mTempChildSizes[i], MeasureSpec.EXACTLY), heightSpec);
       ViewGroup.LayoutParams params = child.getLayoutParams();
       params.width = child.getMeasuredWidth();
       totalWidth += child.getMeasuredWidth();
@@ -150,23 +168,96 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
         ViewCompat.resolveSizeAndState(mItemHeight, heightSpec, 0));
   }
 
+  private void measureTabletMode(int heightMeasureSpec) {
+    final int height = MeasureSpec.getSize(heightMeasureSpec);
+    final int count = getChildCount();
+
+    final int widthSpec = MeasureSpec.makeMeasureSpec(mItemWidth, MeasureSpec.EXACTLY);
+
+    if (mShiftingMode) {
+      final int inactiveCount = count - 1;
+      final int activeMaxAvailable = height - inactiveCount * mInactiveItemMinHeight;
+      final int activeHeight = Math.min(activeMaxAvailable, mActiveItemMaxHeight);
+      final int inactiveMaxAvailable = (height - activeHeight) / inactiveCount;
+      final int inactiveHeight = Math.min(inactiveMaxAvailable, mInactiveItemMaxHeight);
+      int extra = height - activeHeight - inactiveHeight * inactiveCount;
+      for (int i = 0; i < count; i++) {
+        mTempChildSizes[i] = (i == mActiveButton) ? activeHeight : inactiveHeight;
+        if (extra > 0) {
+          mTempChildSizes[i]++;
+          extra--;
+        }
+      }
+    } else {
+      final int maxAvailable = height / (count == 0 ? 1 : count);
+      final int childHeight = Math.min(maxAvailable, mActiveItemMaxHeight);
+      int extra = height - childHeight * count;
+      for (int i = 0; i < count; i++) {
+        mTempChildSizes[i] = childHeight;
+        if (extra > 0) {
+          mTempChildSizes[i]++;
+          extra--;
+        }
+      }
+    }
+
+    int totalHeight = 0;
+    for (int i = 0; i < count; i++) {
+      final View child = getChildAt(i);
+      if (child.getVisibility() == GONE) {
+        continue;
+      }
+      child.measure(
+              widthSpec,
+              MeasureSpec.makeMeasureSpec(mTempChildSizes[i], MeasureSpec.EXACTLY));
+      ViewGroup.LayoutParams params = child.getLayoutParams();
+      params.height = child.getMeasuredHeight();
+      totalHeight += child.getMeasuredHeight();
+    }
+
+    setMeasuredDimension(
+            ViewCompat.resolveSizeAndState(mItemWidth, widthSpec, 0),
+            ViewCompat.resolveSizeAndState(
+                    totalHeight, MeasureSpec.makeMeasureSpec(totalHeight, MeasureSpec.EXACTLY), 0)
+            );
+  }
+
   @Override
   protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    if (mTabletMode) {
+      layoutTabletMode(left, right);
+    } else {
+      final int count = getChildCount();
+      final int width = right - left;
+      final int height = bottom - top;
+      int used = 0;
+      for (int i = 0; i < count; i++) {
+        final View child = getChildAt(i);
+        if (child.getVisibility() == GONE) {
+          continue;
+        }
+        if (ViewCompat.getLayoutDirection(this) == ViewCompat.LAYOUT_DIRECTION_RTL) {
+          child.layout(width - used - child.getMeasuredWidth(), 0, width - used, height);
+        } else {
+          child.layout(used, 0, child.getMeasuredWidth() + used, height);
+        }
+        used += child.getMeasuredWidth();
+      }
+    }
+  }
+
+  private void layoutTabletMode(int left, int right) {
     final int count = getChildCount();
     final int width = right - left;
-    final int height = bottom - top;
+
     int used = 0;
     for (int i = 0; i < count; i++) {
       final View child = getChildAt(i);
       if (child.getVisibility() == GONE) {
         continue;
       }
-      if (ViewCompat.getLayoutDirection(this) == ViewCompat.LAYOUT_DIRECTION_RTL) {
-        child.layout(width - used - child.getMeasuredWidth(), 0, width - used, height);
-      } else {
-        child.layout(used, 0, child.getMeasuredWidth() + used, height);
-      }
-      used += child.getMeasuredWidth();
+      child.layout(0, used, width, child.getMeasuredHeight() + used);
+      used += child.getMeasuredHeight();
     }
   }
 
@@ -246,6 +337,14 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
     mPresenter = presenter;
   }
 
+  /**
+   * Sets the tablet mode flag to layout children differently
+   * @param enabled table mode flag value
+   */
+  public void setTabletMode(boolean enabled) {
+    this.mTabletMode = enabled;
+  }
+
   public void buildMenuView() {
     if (mButtons != null) {
       for (BottomNavigationItemView item : mButtons) {
@@ -259,6 +358,11 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
     }
     mButtons = new BottomNavigationItemView[mMenu.size()];
     mShiftingMode = mMenu.size() > 3;
+    if (mTabletMode) {
+      FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) getLayoutParams();
+      params.gravity = mShiftingMode ? Gravity.CENTER : Gravity.TOP;
+      setLayoutParams(params);
+    }
     for (int i = 0; i < mMenu.size(); i++) {
       mPresenter.setUpdateSuspended(true);
       mMenu.getItem(i).setCheckable(true);
@@ -269,6 +373,7 @@ public class BottomNavigationMenuView extends ViewGroup implements MenuView {
       child.setTextColor(mItemTextColor);
       child.setItemBackground(mItemBackgroundRes);
       child.setShiftingMode(mShiftingMode);
+      child.setTabletMode(mTabletMode);
       child.initialize((MenuItemImpl) mMenu.getItem(i), 0);
       child.setItemPosition(i);
       child.setOnClickListener(mOnClickListener);

--- a/lib/src/android/support/design/widget/BottomNavigationView.java
+++ b/lib/src/android/support/design/widget/BottomNavigationView.java
@@ -89,6 +89,7 @@ public class BottomNavigationView extends FrameLayout {
   private final BottomNavigationMenuView mMenuView;
   private final BottomNavigationPresenter mPresenter = new BottomNavigationPresenter();
   private MenuInflater mMenuInflater;
+  private boolean mTabletMode;
 
   private OnNavigationItemSelectedListener mListener;
 
@@ -147,6 +148,11 @@ public class BottomNavigationView extends FrameLayout {
 
     int itemBackground = a.getResourceId(R.styleable.BottomNavigationView_itemBackground, 0);
     mMenuView.setItemBackgroundRes(itemBackground);
+
+    if (a.hasValue(R.styleable.BottomNavigationView_tabletMode)) {
+      mTabletMode = a.getBoolean(R.styleable.BottomNavigationView_tabletMode, false);
+      mMenuView.setTabletMode(mTabletMode);
+    }
 
     if (a.hasValue(R.styleable.BottomNavigationView_menu)) {
       inflateMenu(a.getResourceId(R.styleable.BottomNavigationView_menu, 0));
@@ -288,11 +294,23 @@ public class BottomNavigationView extends FrameLayout {
   private void addCompatibilityTopDivider(Context context) {
     View divider = new View(context);
     divider.setBackgroundColor(
-        ContextCompat.getColor(context, R.color.design_bottom_navigation_shadow_color));
-    FrameLayout.LayoutParams dividerParams =
-        new FrameLayout.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            getResources().getDimensionPixelSize(R.dimen.design_bottom_navigation_shadow_height));
+            ContextCompat.getColor(context, R.color.design_bottom_navigation_shadow_color));
+    FrameLayout.LayoutParams dividerParams;
+    if (mTabletMode) {
+      dividerParams =
+              new FrameLayout.LayoutParams(
+                      getResources()
+                              .getDimensionPixelSize(R.dimen.design_bottom_navigation_shadow_width),
+                      ViewGroup.LayoutParams.MATCH_PARENT);
+      dividerParams.gravity = Gravity.END;
+    } else {
+      dividerParams =
+              new FrameLayout.LayoutParams(
+                      ViewGroup.LayoutParams.MATCH_PARENT,
+                      getResources().getDimensionPixelSize(
+                              R.dimen.design_bottom_navigation_shadow_height
+                      ));
+    }
     divider.setLayoutParams(dividerParams);
     addView(divider);
   }

--- a/lib/tests/AndroidManifest.xml
+++ b/lib/tests/AndroidManifest.xml
@@ -82,6 +82,10 @@
             android:name="android.support.design.widget.BottomNavigationViewActivity"/>
 
         <activity
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:name="android.support.design.widget.BottomNavigationViewTabletActivity"/>
+
+        <activity
               android:theme="@style/Theme.AppCompat.NoActionBar"
               android:name="android.support.design.widget.TextInputLayoutActivity"/>
 

--- a/lib/tests/res/layout/design_bottom_navigation_view_tablet.xml
+++ b/lib/tests/res/layout/design_bottom_navigation_view_tablet.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2016 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.design.widget.BottomNavigationView
+        android:id="@+id/bottom_navigation"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        app:itemBackground="@color/sand_default"
+        app:itemIconTint="@color/emerald_translucent"
+        app:itemTextColor="@color/emerald_text"
+        app:menu="@menu/bottom_navigation_view_content"
+        app:tabletMode="true" />
+</FrameLayout>

--- a/lib/tests/src/android/support/design/widget/BaseBottomNavigationViewTest.java
+++ b/lib/tests/src/android/support/design/widget/BaseBottomNavigationViewTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package android.support.design.widget;
+
+import android.app.Activity;
+import android.content.res.Resources;
+import android.support.annotation.ColorInt;
+import android.support.design.test.R;
+import android.support.design.testutils.TestDrawable;
+import android.support.design.testutils.TestUtilsMatchers;
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.filters.SmallTest;
+import android.support.v4.content.res.ResourcesCompat;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static android.support.design.testutils.BottomNavigationViewActions.setIconForMenuItem;
+import static android.support.design.testutils.BottomNavigationViewActions.setItemIconTintList;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public abstract class BaseBottomNavigationViewTest<T extends Activity>
+    extends BaseInstrumentationTestCase<T> {
+  private static final int[] MENU_CONTENT_ITEM_IDS = {
+    R.id.destination_home, R.id.destination_profile, R.id.destination_people
+  };
+  private Map<Integer, String> mMenuStringContent;
+
+  private BottomNavigationView mBottomNavigation;
+
+  protected BaseBottomNavigationViewTest(Class<T> activityClass) {
+    super(activityClass);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    final T activity = mActivityTestRule.getActivity();
+    mBottomNavigation = (BottomNavigationView) activity.findViewById(R.id.bottom_navigation);
+
+    final Resources res = activity.getResources();
+    mMenuStringContent = new HashMap<>(MENU_CONTENT_ITEM_IDS.length);
+    mMenuStringContent.put(R.id.destination_home, res.getString(R.string.navigate_home));
+    mMenuStringContent.put(R.id.destination_profile, res.getString(R.string.navigate_profile));
+    mMenuStringContent.put(R.id.destination_people, res.getString(R.string.navigate_people));
+  }
+
+  @UiThreadTest
+  @Test
+  @SmallTest
+  public void testAddItemsWithoutMenuInflation() {
+    BottomNavigationView navigation = new BottomNavigationView(mActivityTestRule.getActivity());
+    mActivityTestRule.getActivity().setContentView(navigation);
+    navigation.getMenu().add("Item1");
+    navigation.getMenu().add("Item2");
+    assertEquals(2, navigation.getMenu().size());
+    navigation.getMenu().removeItem(0);
+    navigation.getMenu().removeItem(0);
+    assertEquals(0, navigation.getMenu().size());
+  }
+
+  @Test
+  @SmallTest
+  public void testBasics() {
+    // Check the contents of the Menu object
+    final Menu menu = mBottomNavigation.getMenu();
+    assertNotNull("Menu should not be null", menu);
+    assertEquals("Should have matching number of items", MENU_CONTENT_ITEM_IDS.length, menu.size());
+    for (int i = 0; i < MENU_CONTENT_ITEM_IDS.length; i++) {
+      final MenuItem currItem = menu.getItem(i);
+      assertEquals("ID for Item #" + i, MENU_CONTENT_ITEM_IDS[i], currItem.getItemId());
+    }
+  }
+
+  @Test
+  @SmallTest
+  public void testNavigationSelectionListener() {
+    BottomNavigationView.OnNavigationItemSelectedListener mockedListener =
+            mock(BottomNavigationView.OnNavigationItemSelectedListener.class);
+    mBottomNavigation.setOnNavigationItemSelectedListener(mockedListener);
+
+    // Make the listener return true to allow selecting the item.
+    when(mockedListener.onNavigationItemSelected(any(MenuItem.class))).thenReturn(true);
+    onView(
+            allOf(
+                    withId(R.id.destination_profile),
+                    isDescendantOfA(withId(R.id.bottom_navigation)),
+                    isDisplayed()))
+            .perform(click());
+    // Verify our listener has been notified of the click
+    verify(mockedListener, times(1))
+            .onNavigationItemSelected(mBottomNavigation.getMenu().findItem(R.id.destination_profile));
+    // Verify the item is now selected
+    assertTrue(mBottomNavigation.getMenu().findItem(R.id.destination_profile).isChecked());
+
+    // Make the listener return false to disallow selecting the item.
+    when(mockedListener.onNavigationItemSelected(any(MenuItem.class))).thenReturn(false);
+    onView(
+            allOf(
+                    withId(R.id.destination_people),
+                    isDescendantOfA(withId(R.id.bottom_navigation)),
+                    isDisplayed()))
+            .perform(click());
+    // Verify our listener has been notified of the click
+    verify(mockedListener, times(1))
+            .onNavigationItemSelected(mBottomNavigation.getMenu().findItem(R.id.destination_people));
+    // Verify the previous item is still selected
+    assertFalse(mBottomNavigation.getMenu().findItem(R.id.destination_people).isChecked());
+    assertTrue(mBottomNavigation.getMenu().findItem(R.id.destination_profile).isChecked());
+
+    // Set null listener to test that the next click is not going to notify the
+    // previously set listener and will allow selecting items.
+    mBottomNavigation.setOnNavigationItemSelectedListener(null);
+
+    // Click one of our items
+    onView(
+            allOf(
+                    withId(R.id.destination_home),
+                    isDescendantOfA(withId(R.id.bottom_navigation)),
+                    isDisplayed()))
+            .perform(click());
+    // And that our previous listener has not been notified of the click
+    verifyNoMoreInteractions(mockedListener);
+    // Verify the correct item is now selected.
+    assertTrue(mBottomNavigation.getMenu().findItem(R.id.destination_home).isChecked());
+  }
+
+  @Test
+  @SmallTest
+  public void testIconTinting() {
+    final Resources res = mActivityTestRule.getActivity().getResources();
+    @ColorInt final int redFill = ResourcesCompat.getColor(res, R.color.test_red, null);
+    @ColorInt final int greenFill = ResourcesCompat.getColor(res, R.color.test_green, null);
+    @ColorInt final int blueFill = ResourcesCompat.getColor(res, R.color.test_blue, null);
+    final int iconSize = res.getDimensionPixelSize(R.dimen.drawable_small_size);
+    onView(withId(R.id.bottom_navigation))
+            .perform(
+                    setIconForMenuItem(
+                            R.id.destination_home, new TestDrawable(redFill, iconSize, iconSize)));
+    onView(withId(R.id.bottom_navigation))
+            .perform(
+                    setIconForMenuItem(
+                            R.id.destination_profile, new TestDrawable(greenFill, iconSize, iconSize)));
+    onView(withId(R.id.bottom_navigation))
+            .perform(
+                    setIconForMenuItem(
+                            R.id.destination_people, new TestDrawable(blueFill, iconSize, iconSize)));
+
+    @ColorInt
+    final int defaultTintColor = ResourcesCompat.getColor(res, R.color.emerald_translucent, null);
+
+    // We're allowing a margin of error in checking the color of the items' icons.
+    // This is due to the translucent color being used in the icon tinting
+    // and off-by-one discrepancies of SRC_IN when it's compositing
+    // translucent color. Note that all the checks below are written for the current
+    // logic on BottomNavigationView that uses the default SRC_IN tint mode - effectively
+    // replacing all non-transparent pixels in the destination (original icon) with
+    // our translucent tint color.
+    final int allowedComponentVariance = 1;
+
+    // Note that here we're tying ourselves to the implementation details of the internal
+    // structure of the BottomNavigationView. Specifically, we're checking the drawable the
+    // ImageView with id R.id.icon. If the internal implementation of BottomNavigationView
+    // changes, the second Matcher in the lookups below will need to be tweaked.
+    onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_home))))
+            .check(matches(TestUtilsMatchers.drawable(defaultTintColor, allowedComponentVariance)));
+    onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_profile))))
+            .check(matches(TestUtilsMatchers.drawable(defaultTintColor, allowedComponentVariance)));
+    onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_people))))
+            .check(matches(TestUtilsMatchers.drawable(defaultTintColor, allowedComponentVariance)));
+
+    @ColorInt final int newTintColor = ResourcesCompat.getColor(res, R.color.red_translucent, null);
+    onView(withId(R.id.bottom_navigation))
+            .perform(
+                    setItemIconTintList(
+                            ResourcesCompat.getColorStateList(
+                                    res, R.color.color_state_list_red_translucent, null)));
+    // Check that all menu items with icons now have icons tinted with the newly set color
+    onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_home))))
+            .check(matches(TestUtilsMatchers.drawable(newTintColor, allowedComponentVariance)));
+    onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_profile))))
+            .check(matches(TestUtilsMatchers.drawable(newTintColor, allowedComponentVariance)));
+    onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_people))))
+            .check(matches(TestUtilsMatchers.drawable(newTintColor, allowedComponentVariance)));
+
+    // And now remove all icon tinting
+    onView(withId(R.id.bottom_navigation)).perform(setItemIconTintList(null));
+    // And verify that all menu items with icons now have the original colors for their icons.
+    // Note that since there is no tinting at this point, we don't allow any color variance
+    // in these checks.
+    onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_home))))
+            .check(matches(TestUtilsMatchers.drawable(redFill, allowedComponentVariance)));
+    onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_profile))))
+            .check(matches(TestUtilsMatchers.drawable(greenFill, allowedComponentVariance)));
+    onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_people))))
+            .check(matches(TestUtilsMatchers.drawable(blueFill, allowedComponentVariance)));
+  }
+
+  @UiThreadTest
+  @Test
+  @SmallTest
+  public void testItemChecking() throws Throwable {
+    final Menu menu = mBottomNavigation.getMenu();
+    assertTrue(menu.getItem(0).isChecked());
+    checkAndVerifyExclusiveItem(menu, R.id.destination_home);
+    checkAndVerifyExclusiveItem(menu, R.id.destination_profile);
+    checkAndVerifyExclusiveItem(menu, R.id.destination_people);
+  }
+
+  @UiThreadTest
+  @Test
+  @SmallTest
+  public void testClearingMenu() throws Throwable {
+    mBottomNavigation.getMenu().clear();
+    assertEquals(0, mBottomNavigation.getMenu().size());
+    mBottomNavigation.inflateMenu(R.menu.bottom_navigation_view_content);
+    assertEquals(3, mBottomNavigation.getMenu().size());
+  }
+
+  private void checkAndVerifyExclusiveItem(final Menu menu, final int id) throws Throwable {
+    menu.findItem(id).setChecked(true);
+    for (int i = 0; i < menu.size(); i++) {
+      final MenuItem item = menu.getItem(i);
+      if (item.getItemId() == id) {
+        assertTrue(item.isChecked());
+      } else {
+        assertFalse(item.isChecked());
+      }
+    }
+  }
+}

--- a/lib/tests/src/android/support/design/widget/BottomNavigationViewTabletActivity.java
+++ b/lib/tests/src/android/support/design/widget/BottomNavigationViewTabletActivity.java
@@ -15,10 +15,11 @@
  */
 package android.support.design.widget;
 
-public class BottomNavigationViewTest
-    extends BaseBottomNavigationViewTest<BottomNavigationViewActivity> {
+import android.support.design.test.R;
 
-  public BottomNavigationViewTest() {
-    super(BottomNavigationViewActivity.class);
+public class BottomNavigationViewTabletActivity extends BottomNavigationViewActivity {
+  @Override
+  protected int getContentViewLayoutResId() {
+    return R.layout.design_bottom_navigation_view_tablet;
   }
 }

--- a/lib/tests/src/android/support/design/widget/BottomNavigationViewTabletTest.java
+++ b/lib/tests/src/android/support/design/widget/BottomNavigationViewTabletTest.java
@@ -15,10 +15,10 @@
  */
 package android.support.design.widget;
 
-public class BottomNavigationViewTest
-    extends BaseBottomNavigationViewTest<BottomNavigationViewActivity> {
+public class BottomNavigationViewTabletTest
+        extends BaseBottomNavigationViewTest<BottomNavigationViewTabletActivity> {
 
-  public BottomNavigationViewTest() {
-    super(BottomNavigationViewActivity.class);
-  }
+    public BottomNavigationViewTabletTest() {
+        super(BottomNavigationViewTabletActivity.class);
+    }
 }


### PR DESCRIPTION
Closes #9 

Adds a **tabletMode** attribute in order to have the BottomNavigationView layout the item views in a vertical manner, and not displaying item texts as stated in the specs https://material.io/guidelines/components/bottom-navigation.html#bottom-navigation-usage

It also rearranges the setup of BottomNavigationView tests so they are reused by both mobile and tablet modes