### PR TITLE
[BottomNavigationView] Add state save/restore to keep selected tab

### DIFF
--- a/lib/src/android/support/design/internal/BottomNavigationPresenter.java
+++ b/lib/src/android/support/design/internal/BottomNavigationPresenter.java
@@ -19,6 +19,8 @@ package android.support.design.internal;
 import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
 import android.content.Context;
+import android.os.Build;
+import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.RestrictTo;
 import android.support.v7.view.menu.MenuBuilder;
@@ -26,14 +28,19 @@ import android.support.v7.view.menu.MenuItemImpl;
 import android.support.v7.view.menu.MenuPresenter;
 import android.support.v7.view.menu.MenuView;
 import android.support.v7.view.menu.SubMenuBuilder;
+import android.util.SparseArray;
 import android.view.ViewGroup;
 
 /** @hide */
 @RestrictTo(LIBRARY_GROUP)
 public class BottomNavigationPresenter implements MenuPresenter {
+
+  private static final String STATE_HIERARCHY = "android:menu:items";
+
   private MenuBuilder mMenu;
   private BottomNavigationMenuView mMenuView;
   private boolean mUpdateSuspended = false;
+  private int mId;
 
   public void setBottomNavigationMenuView(BottomNavigationMenuView menuView) {
     mMenuView = menuView;
@@ -88,16 +95,40 @@ public class BottomNavigationPresenter implements MenuPresenter {
 
   @Override
   public int getId() {
-    return -1;
+    return mId;
+  }
+
+  public void setId(int id) {
+    mId = id;
   }
 
   @Override
   public Parcelable onSaveInstanceState() {
+    if (Build.VERSION.SDK_INT >= 11) {
+      // API 9-10 does not support ClassLoaderCreator, therefore things can crash if they're
+      // loaded via different loaders. Rather than crash we just won't save state on those
+      // platforms
+      final Bundle state = new Bundle();
+      if (mMenuView != null) {
+        SparseArray<Parcelable> hierarchy = new SparseArray<>();
+        mMenuView.saveHierarchyState(hierarchy);
+        state.putSparseParcelableArray(STATE_HIERARCHY, hierarchy);
+      }
+      return state;
+    }
     return null;
   }
 
   @Override
-  public void onRestoreInstanceState(Parcelable state) {}
+  public void onRestoreInstanceState(Parcelable parcelable) {
+    if (parcelable instanceof Bundle) {
+      Bundle state = (Bundle) parcelable;
+      SparseArray<Parcelable> hierarchy = state.getSparseParcelableArray(STATE_HIERARCHY);
+      if (hierarchy != null) {
+        mMenuView.restoreHierarchyState(hierarchy);
+      }
+    }
+  }
 
   public void setUpdateSuspended(boolean updateSuspended) {
     mUpdateSuspended = updateSuspended;

--- a/lib/src/android/support/design/widget/BottomNavigationView.java
+++ b/lib/src/android/support/design/widget/BottomNavigationView.java
@@ -19,6 +19,9 @@ package android.support.design.widget;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.os.Build;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -27,6 +30,9 @@ import android.support.design.internal.BottomNavigationMenu;
 import android.support.design.internal.BottomNavigationMenuView;
 import android.support.design.internal.BottomNavigationPresenter;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.os.ParcelableCompat;
+import android.support.v4.os.ParcelableCompatCreatorCallbacks;
+import android.support.v4.view.AbsSavedState;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.content.res.AppCompatResources;
 import android.support.v7.view.SupportMenuInflater;
@@ -85,6 +91,9 @@ public class BottomNavigationView extends FrameLayout {
   private static final int[] CHECKED_STATE_SET = {android.R.attr.state_checked};
   private static final int[] DISABLED_STATE_SET = {-android.R.attr.state_enabled};
 
+  private static final int PRESENTER_BOTTOM_NAVIGATION_VIEW_ID = 1;
+  private static final String STATE_TAB = "tab";
+
   private final MenuBuilder mMenu;
   private final BottomNavigationMenuView mMenuView;
   private final BottomNavigationPresenter mPresenter = new BottomNavigationPresenter();
@@ -116,6 +125,7 @@ public class BottomNavigationView extends FrameLayout {
     mMenuView.setLayoutParams(params);
 
     mPresenter.setBottomNavigationMenuView(mMenuView);
+    mPresenter.setId(PRESENTER_BOTTOM_NAVIGATION_VIEW_ID);
     mMenuView.setPresenter(mPresenter);
     mMenu.addMenuPresenter(mPresenter);
     mPresenter.initForMenu(getContext(), mMenu);
@@ -322,5 +332,70 @@ public class BottomNavigationView extends FrameLayout {
         new int[] {
           baseColor.getColorForState(DISABLED_STATE_SET, defaultColor), colorPrimary, defaultColor
         });
+  }
+
+  @Override
+  protected Parcelable onSaveInstanceState() {
+    Parcelable superState = super.onSaveInstanceState();
+    SavedState state = new SavedState(superState);
+    Bundle bundle = new Bundle();
+    for (int i = 0; i < mMenu.size(); i++) {
+      MenuItem item = mMenu.getItem(i);
+      if (item.isChecked()) {
+        bundle.putInt(STATE_TAB, item.getItemId());
+      }
+    }
+    state.bottomNavigationState = bundle;
+    mMenu.savePresenterStates(state.bottomNavigationState);
+
+    return state;
+  }
+
+  @Override
+  protected void onRestoreInstanceState(Parcelable savedState) {
+    if (!(savedState instanceof SavedState)) {
+      super.onRestoreInstanceState(savedState);
+      return;
+    }
+    SavedState state = (SavedState) savedState;
+    super.onRestoreInstanceState(state.getSuperState());
+    mMenu.restorePresenterStates(state.bottomNavigationState);
+    mMenu.findItem(state.bottomNavigationState.getInt(STATE_TAB)).setChecked(true);
+  }
+
+  /**
+   * User interface state that is stored by BottomNavigationView for implementing onSaveInstanceState().
+   */
+  public static class SavedState extends AbsSavedState {
+    public Bundle bottomNavigationState;
+
+    public SavedState(Parcel in, ClassLoader loader) {
+      super(in, loader);
+      bottomNavigationState = in.readBundle(loader);
+    }
+
+    public SavedState(Parcelable superState) {
+      super(superState);
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+      super.writeToParcel(dest, flags);
+      dest.writeBundle(bottomNavigationState);
+    }
+
+    public static final Parcelable.Creator<SavedState> CREATOR =
+            ParcelableCompat.newCreator(
+                    new ParcelableCompatCreatorCallbacks<SavedState>() {
+                      @Override
+                      public SavedState createFromParcel(Parcel parcel, ClassLoader loader) {
+                        return new SavedState(parcel, loader);
+                      }
+
+                      @Override
+                      public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                      }
+                    });
   }
 }

--- a/lib/tests/src/android/support/design/testutils/TestUtils.java
+++ b/lib/tests/src/android/support/design/testutils/TestUtils.java
@@ -16,7 +16,10 @@
 
 package android.support.design.testutils;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -25,6 +28,8 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
+import android.support.test.InstrumentationRegistry;
+
 import junit.framework.Assert;
 
 public class TestUtils {
@@ -160,5 +165,15 @@ public class TestUtils {
         a.recycle();
       }
     }
+  }
+  public static void rotateScreen(Activity activity) {
+    Context context = InstrumentationRegistry.getTargetContext();
+    int orientation
+            = context.getResources().getConfiguration().orientation;
+
+    activity.setRequestedOrientation(
+            (orientation == Configuration.ORIENTATION_PORTRAIT) ?
+                    ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE :
+                    ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
   }
 }

--- a/lib/tests/src/android/support/design/widget/BottomNavigationViewTest.java
+++ b/lib/tests/src/android/support/design/widget/BottomNavigationViewTest.java
@@ -17,6 +17,7 @@ package android.support.design.widget;
 
 import static android.support.design.testutils.BottomNavigationViewActions.setIconForMenuItem;
 import static android.support.design.testutils.BottomNavigationViewActions.setItemIconTintList;
+import static android.support.design.testutils.TestUtils.rotateScreen;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
@@ -225,6 +226,24 @@ public class BottomNavigationViewTest
         .check(matches(TestUtilsMatchers.drawable(greenFill, allowedComponentVariance)));
     onView(allOf(withId(R.id.icon), isDescendantOfA(withId(R.id.destination_people))))
         .check(matches(TestUtilsMatchers.drawable(blueFill, allowedComponentVariance)));
+  }
+
+  @Test
+  public void testSelectedTabState() {
+
+    // check profile item
+    onView(
+            allOf(
+                    withId(R.id.destination_profile),
+                    isDescendantOfA(withId(R.id.bottom_navigation)),
+                    isDisplayed()))
+            .perform(click());
+
+    // rotate screen to trigger configuration change
+    rotateScreen(mActivityTestRule.getActivity());
+
+    // Confirm that the state was restored
+    assertTrue(mBottomNavigation.getMenu().findItem(R.id.destination_profile).isChecked());
   }
 
   @UiThreadTest


### PR DESCRIPTION
Closes #17 

Adds save/restore state to BottomNavigationView by keeping track of the selected tab id, and resetting it's state to checked when is being restored. Note this does not trigger a call to **OnNavigationItemSelectedListener::onNavigationItemSelected()** which I think it should be the right behavior