### PR TITLE
[CoordinatorLayout] Fix saved state restoration on API<13 devices

### DIFF
--- a/lib/src/android/support/design/widget/CoordinatorLayout.java
+++ b/lib/src/android/support/design/widget/CoordinatorLayout.java
@@ -3045,6 +3045,9 @@ public class CoordinatorLayout extends ViewGroup implements NestedScrollingParen
 
     public SavedState(Parcel source, ClassLoader loader) {
       super(source, loader);
+      if (loader == null) {
+        loader = getClass().getClassLoader();
+      }
 
       final int size = source.readInt();
 


### PR DESCRIPTION
On API<13 devices, we always get a `null` ClassLoader in the `CoordinatorLayout.SavedState` constructor. Provide a default one in that case so the Behavior states can be properly restored instead of crashing with a "`ClassNotFoundException when unmarshalling ...`" error.

This is basically the same behavior as other components of the support library like `ViewPager` and `RecyclerView`.

- Related issues on the Android bug tracker: [#196430](https://code.google.com/p/android/issues/detail?id=196430#c14), [#232471](https://code.google.com/p/android/issues/detail?id=232471)