### PR TITLE
[BottomNavigationView] Added bottom navigation behavior and scrims fix.

### DIFF
--- a/lib/res/anim/design_bottomnav_in.xml
+++ b/lib/res/anim/design_bottomnav_in.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+           android:fromYDelta="100%"
+           android:toYDelta="0"/>

--- a/lib/res/anim/design_bottomnav_out.xml
+++ b/lib/res/anim/design_bottomnav_out.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+           android:fromYDelta="0"
+           android:toYDelta="100%"/>

--- a/lib/res/values/attrs.xml
+++ b/lib/res/values/attrs.xml
@@ -16,6 +16,8 @@
 -->
 <resources>
 
+  <attr name="behavior_autoHide" format="boolean" />
+
     <declare-styleable name="FloatingActionButton">
         <!-- Background for the FloatingActionButton -->
         <attr name="backgroundTint"/>
@@ -44,7 +46,12 @@
 
     <declare-styleable name="FloatingActionButton_Behavior_Layout">
         <!-- Whether the FAB should automatically hide when there is no space for it. -->
-        <attr name="behavior_autoHide" format="boolean"/>
+        <attr name="behavior_autoHide"/>
+    </declare-styleable>
+
+    <declare-styleable name="NavigationView_Behavior_Layout">
+        <!-- Whether the navigation view should automatically hide when there is no space for it. -->
+        <attr name="behavior_autoHide" />
     </declare-styleable>
 
     <declare-styleable name="ScrimInsetsFrameLayout">


### PR DESCRIPTION
**NOTE** work in progress!

Added API for show/hide BottomNavigationView in reaction to nested scrolling (with default Behavior) and support to translucent navigation bar.

The last thing remaining is to fix the Snackbar and make it dodge the navigation view!
Attached video with features + bug. I think the FAB shouldn't fall under navigation bar, but maybe is a fault of my demo app. 

https://youtu.be/2CCYDU6R9Ik

Here is the layout used in the demo:
```xml
<android.support.design.widget.CoordinatorLayout ...>
...
<android.support.design.widget.BottomNavigationView
        android:id="@+id/bottom_navigation"
        android:layout_width="match_parent"
        android:layout_height="wrap_content"
        android:layout_gravity="bottom"
        android:background="@color/colorPrimary"
        app:elevation="8dp"
        app:itemBackground="@color/colorPrimary"
        app:itemIconTint="@android:color/white"
        app:itemTextColor="@android:color/white"
        app:menu="@menu/navigation" />
</android.support.design.widget.CoordinatorLayout>
```