### PR TITLE
[BaseTransientBottomBar] Fix @Duration annotation definition

### DIFF
--- a/lib/src/android/support/design/widget/BaseTransientBottomBar.java
+++ b/lib/src/android/support/design/widget/BaseTransientBottomBar.java
@@ -134,7 +134,7 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
   /** @hide */
   @RestrictTo(LIBRARY_GROUP)
   @IntDef({LENGTH_INDEFINITE, LENGTH_SHORT, LENGTH_LONG})
-  @IntRange(from = 1)
+  @IntRange(from = -2, to = 0)
   @Retention(RetentionPolicy.SOURCE)
   public @interface Duration {}
 


### PR DESCRIPTION
Adjust the `@IntRange` of the `Duration` annotation, to fix a wrong warning if this annotation is used. (`LENGTH_INDEFINITE`, `LENGTH_SHORT`, `LENGTH_LONG` go from `-2` to `0`, the previous from `1` is out of range)