### PR TITLE
Updates link in docsite-index.md

### DIFF
--- a/docs/docsite-index.md
+++ b/docs/docsite-index.md
@@ -69,7 +69,7 @@ to help developers easily create beautiful apps.
 
 4.  {: .step-list-item } ### What's next?
 
-    * [View the components](./catalog)
+    * [View the components](./docsite-components.md)
     * [Contributing](./contributing.md)
     * [Class documentation](https://developer.android.com/reference/android/support/design/widget/package-summary.html)
     * [MDC-Android on Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components+android)


### PR DESCRIPTION
A stricter link checker now enforces that relative links point to files in the repo. The links are rewritten during the generation process to point to the target file's location in the site (its path).