### PR TITLE
[NavigationMenu] Don't rebind/relayout/reinflate any views after clicking a menu item

### DIFF
--- a/lib/java/android/support/design/internal/NavigationMenuPresenter.java
+++ b/lib/java/android/support/design/internal/NavigationMenuPresenter.java
@@ -323,13 +323,16 @@ public class NavigationMenuPresenter implements MenuPresenter {
           setUpdateSuspended(true);
           MenuItemImpl item = itemView.getItemData();
           boolean result = menu.performItemAction(item, NavigationMenuPresenter.this, 0);
+          boolean checkStateChanged = false;
           if (item != null && item.isCheckable() && result) {
             adapter.setCheckedItem(item);
+            checkStateChanged = true;
           }
           setUpdateSuspended(false);
-          updateMenuView(false);
+          if (checkStateChanged) {
+            updateMenuView(false);
+          }
         }
-      };
 
   private class NavigationMenuAdapter extends RecyclerView.Adapter<ViewHolder> {
 


### PR DESCRIPTION
If none of the check state has changed let's not update the menu. While larger improvements may make sense, this diff is designed to mitigate the most serious issue in a way that doesn't create risk.

Background for this diff is at https://github.com/material-components/material-components-android/issues/61. This diff should close the issue.

Test: used these modified classes inside the Android Uber app and ran a profiler. The problematic 50ms delay caused by this bug was fixed. You can see the before/after traces in https://issuetracker.google.com/issues/73723207.