### PR TITLE
[Snackbar] Fix Snackbar not animating in some cases

### DIFF
--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -644,7 +644,7 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
   /** Returns true if we should animate the Snackbar view in/out. */
   boolean shouldAnimate() {
     final int feedbackFlags = AccessibilityServiceInfo.FEEDBACK_SPOKEN;
-    return mAccessibilityManager.getEnabledAccessibilityServiceList(feedbackFlags).isEmpty();
+    return accessibilityManager.getEnabledAccessibilityServiceList(feedbackFlags).isEmpty();
   }
 
   /** @hide */

--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -643,7 +643,8 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
 
   /** Returns true if we should animate the Snackbar view in/out. */
   boolean shouldAnimate() {
-    return !accessibilityManager.isEnabled();
+    final int feedbackFlags = AccessibilityServiceInfo.FEEDBACK_SPOKEN;
+    return mAccessibilityManager.getEnabledAccessibilityServiceList(feedbackFlags).isEmpty();
   }
 
   /** @hide */


### PR DESCRIPTION
Snackbar should not animate if Talkback or another spoken feedback
AccessibilityService is enabled, but it should animate otherwise.
This PR adds a filter for spoken feedback accessibility services in the
shouldAnimate() method to bring a correct behavior.

Related to this issue: https://issuetracker.google.com/issues/72245698

Closes #88