### PR TITLE
[TextInputLayout] Fixed boxExpandedPaddingBottom.

### DIFF
--- a/lib/java/com/google/android/material/textfield/IndicatorViewController.java
+++ b/lib/java/com/google/android/material/textfield/IndicatorViewController.java
@@ -347,7 +347,7 @@ final class IndicatorViewController {
           ViewCompat.getPaddingStart(textInputView.getEditText()),
           0,
           ViewCompat.getPaddingEnd(textInputView.getEditText()),
-          textInputView.getEditText().getPaddingBottom());
+          0);
     }
   }
 


### PR DESCRIPTION
Changing boxExpandedPaddingBottom resulted in changing the padding bottom of both edit text and helper text. I fixed it.
