### PR TITLE
[AppBar] appbar_scrolling_view_behavior as public res

### DIFF
--- a/lib/java/com/google/android/material/appbar/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/appbar/res-public/values/public.xml
@@ -30,5 +30,6 @@
   <public name="Widget.Design.AppBarLayout" type="style"/>
   <public name="Widget.Design.CollapsingToolbar" type="style"/>
   <public name="TextAppearance.Design.CollapsingToolbar.Expanded" type="style"/>
+  <public name="appbar_scrolling_view_behavior" type="string"/>
 </resources>
 


### PR DESCRIPTION
this declaration is missing causing Android Studio to complain
it existed previously as seen in https://android.googlesource.com/platform/frameworks/support.git/+/android-p-preview-3/design/res-public/values/public_strings.xml

Fix #154 

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#pull-requests)
has more information and tips for a great pull request.
