### PR TITLE
[Snackbar] Update some Javadocs to reflect valid duration values

### DIFF
--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -16,11 +16,6 @@
 
 package com.google.android.material.snackbar;
 
-import com.google.android.material.R;
-
-import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
-import static com.google.android.material.animation.AnimationUtils.FAST_OUT_SLOW_IN_INTERPOLATOR;
-
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
@@ -32,31 +27,28 @@ import android.os.Build.VERSION_CODES;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
-import android.support.annotation.IntDef;
-import android.support.annotation.IntRange;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.RestrictTo;
-import com.google.android.material.behavior.SwipeDismissBehavior;
-import com.google.android.material.internal.ThemeEnforcement;
+import android.support.annotation.*;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.WindowInsetsCompat;
 import android.util.AttributeSet;
-import android.view.Gravity;
-import android.view.LayoutInflater;
-import android.view.MotionEvent;
-import android.view.View;
-import android.view.ViewGroup;
+import android.view.*;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewGroup.MarginLayoutParams;
-import android.view.ViewParent;
 import android.view.accessibility.AccessibilityManager;
 import android.widget.FrameLayout;
+
+import com.google.android.material.R;
+import com.google.android.material.behavior.SwipeDismissBehavior;
+import com.google.android.material.internal.ThemeEnforcement;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.List;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+import static com.google.android.material.animation.AnimationUtils.FAST_OUT_SLOW_IN_INTERPOLATOR;
 
 /**
  * Base class for lightweight transient bars that are displayed along the bottom edge of the
@@ -302,8 +294,8 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
   /**
    * Set how long to show the view for.
    *
-   * @param duration either be one of the predefined lengths: {@link #LENGTH_SHORT}, {@link
-   *     #LENGTH_LONG}, or a custom duration in milliseconds.
+   * @param duration How long to display the message. Can be {@link #LENGTH_SHORT}, {@link
+   *     #LENGTH_LONG}, {@link #LENGTH_INDEFINITE}, or a custom duration in milliseconds.
    */
   @NonNull
   public B setDuration(@Duration int duration) {

--- a/lib/java/com/google/android/material/snackbar/Snackbar.java
+++ b/lib/java/com/google/android/material/snackbar/Snackbar.java
@@ -16,20 +16,9 @@
 
 package com.google.android.material.snackbar;
 
-import com.google.android.material.R;
-
-import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
-
 import android.content.Context;
 import android.content.res.ColorStateList;
-import android.support.annotation.ColorInt;
-import android.support.annotation.IntDef;
-import android.support.annotation.IntRange;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RestrictTo;
-import android.support.annotation.StringRes;
-import com.google.android.material.internal.ThemeEnforcement;
+import android.support.annotation.*;
 import android.support.design.widget.CoordinatorLayout;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -40,8 +29,13 @@ import android.view.ViewParent;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import com.google.android.material.R;
+import com.google.android.material.internal.ThemeEnforcement;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
 /**
  * Snackbars provide lightweight feedback about an operation. They show a brief message at the
@@ -163,8 +157,8 @@ public final class Snackbar extends BaseTransientBottomBar<Snackbar> {
    *
    * @param view The view to find a parent from.
    * @param text The text to show. Can be formatted text.
-   * @param duration How long to display the message. Either {@link #LENGTH_SHORT} or {@link
-   *     #LENGTH_LONG}
+   * @param duration How long to display the message. Can be {@link #LENGTH_SHORT}, {@link
+   *     #LENGTH_LONG}, {@link #LENGTH_INDEFINITE}, or a custom duration in milliseconds.
    */
   @NonNull
   public static Snackbar make(
@@ -204,8 +198,8 @@ public final class Snackbar extends BaseTransientBottomBar<Snackbar> {
    *
    * @param view The view to find a parent from.
    * @param resId The resource id of the string resource to use. Can be formatted text.
-   * @param duration How long to display the message. Either {@link #LENGTH_SHORT} or {@link
-   *     #LENGTH_LONG}
+   * @param duration How long to display the message. Can be {@link #LENGTH_SHORT}, {@link
+   *     #LENGTH_LONG}, {@link #LENGTH_INDEFINITE}, or a custom duration in milliseconds.
    */
   @NonNull
   public static Snackbar make(@NonNull View view, @StringRes int resId, @Duration int duration) {


### PR DESCRIPTION
This small PR updates the Javadocs around `Snackbar` (and `BaseTransientBottomBar`) to be consistent between themselves, and to match the actual behaviour as seen in `SnackbarManager`:

https://github.com/material-components/material-components-android/blob/0801d0e05b9221cc202c08f080dc7bae6eeac0e1/lib/java/com/google/android/material/snackbar/SnackbarManager.java#L220-L234