### PR TITLE
[Docs] Fix table formatting for Chip and FloatingActionButton

### DIFF
--- a/docs/components/Chip.md
+++ b/docs/components/Chip.md
@@ -129,32 +129,15 @@ Feature      | Relevant attributes
 Shape        | `app:chipCornerRadius`
 Size         | `app:chipMinHeight`
 Background   | `app:chipBackgroundColor`
-Border       | `app:chipStrokeColor`
-             | `app:chipStrokeWidth`
+Border       | `app:chipStrokeColor`<br/>`app:chipStrokeWidth`
 Ripple       | `app:rippleColor`
-Label        | `android:text`
-             | `android:textAppearance`
-Chip Icon    | `app:chipIconVisible`
-             | `app:chipIcon`
-             | `app:chipIconTint`
-             | `app:chipIconSize`
-Close Icon   | `app:closeIconVisible`
-             | `app:closeIcon`
-             | `app:closeIconSize`
-             | `app:closeIconTint`
+Label        | `android:text`<br/>`android:textAppearance`
+Chip Icon    | `app:chipIconVisible`<br/>`app:chipIcon`<br/>`app:chipIconTint`<br/>`app:chipIconSize`
+Close Icon   | `app:closeIconVisible`<br/>`app:closeIcon`<br/>`app:closeIconSize`<br/>`app:closeIconTint`
 Checkable    | `app:checkable`
-Checked Icon | `app:checkedIconVisible`
-             | `app:checkedIcon`
-Motion       | `app:showMotionSpec`
-             | `app:hideMotionSpec`
-Paddings     | `app:chipStartPadding`
-             | `app:iconStartPadding`
-             | `app:iconEndPadding`
-             | `app:textStartPadding`
-             | `app:textEndPadding`
-             | `app:closeIconStartPadding`
-             | `app:closeIconEndPadding`
-             | `app:chipEndPadding`
+Checked Icon | `app:checkedIconVisible`<br/>`app:checkedIcon`
+Motion       | `app:showMotionSpec`<br/>`app:hideMotionSpec`
+Paddings     | `app:chipStartPadding`<br/>`app:iconStartPadding`<br/>`app:iconEndPadding`<br/>`app:textStartPadding`<br/>`app:textEndPadding`<br/>`app:closeIconStartPadding`<br/>`app:closeIconEndPadding`<br/>`app:chipEndPadding`
 
 ### Handling Clicks
 

--- a/docs/components/FloatingActionButton.md
+++ b/docs/components/FloatingActionButton.md
@@ -109,19 +109,13 @@ ripple, and motion changes.
 
 Feature    | Relevant attributes
 :--------- | :-------------------------------
-Icon       | `app:srcCompat`
-           | `app:tint`
-           | `app:maxImageSize`
-Size       | `app:fabSize`
-           | `app:fabCustomSize`
+Icon       | `app:srcCompat`<br/>`app:tint`<br/>`app:maxImageSize`
+Size       | `app:fabSize`<br/>`app:fabCustomSize`
 Background | `app:backgroundTint`
 Ripple     | `app:rippleColor`
 Border     | `app:borderWidth`
-Elevation  | `app:elevation`
-           | `app:hoveredFocusedTranslationZ`
-           | `app:pressedTranslationZ`
-Motion     | `app:showMotionSpec`
-           | `app:hideMotionSpec`
+Elevation  | `app:elevation`<br/>`app:hoveredFocusedTranslationZ`<br/>`app:pressedTranslationZ`
+Motion     | `app:showMotionSpec`<br/>`app:hideMotionSpec`
 
 ### Handling Clicks
 


### PR DESCRIPTION
Replaces the newlines with `<br/>` to fix the formatting of the tables.