### PR TITLE
[TextInputLayout] Creates attr defaultBoxStrokeColor for TextInputLayout

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -313,8 +313,13 @@ public class TextInputLayout extends LinearLayout {
       defaultHintTextColor =
           focusedTextColor = a.getColorStateList(R.styleable.TextInputLayout_android_textColorHint);
     }
-    defaultStrokeColor =
-        ContextCompat.getColor(context, R.color.mtrl_textinput_default_box_stroke_color);
+    if (a.hasValue(R.styleable.TextInputLayout_defaultBoxStrokeColor)) {
+      defaultStrokeColor =
+          a.getColor(R.styleable.TextInputLayout_defaultBoxStrokeColor, Color.TRANSPARENT);
+    } else {
+      defaultStrokeColor =
+          ContextCompat.getColor(context, R.color.mtrl_textinput_default_box_stroke_color);
+    }
     disabledColor = ContextCompat.getColor(context, R.color.mtrl_textinput_disabled_color);
     hoveredStrokeColor =
         ContextCompat.getColor(context, R.color.mtrl_textinput_hovered_box_stroke_color);

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -313,13 +313,10 @@ public class TextInputLayout extends LinearLayout {
       defaultHintTextColor =
           focusedTextColor = a.getColorStateList(R.styleable.TextInputLayout_android_textColorHint);
     }
-    if (a.hasValue(R.styleable.TextInputLayout_defaultBoxStrokeColor)) {
       defaultStrokeColor =
-          a.getColor(R.styleable.TextInputLayout_defaultBoxStrokeColor, Color.TRANSPARENT);
-    } else {
-      defaultStrokeColor =
-          ContextCompat.getColor(context, R.color.mtrl_textinput_default_box_stroke_color);
-    }
+          a.getColor(R.styleable.TextInputLayout_defaultBoxStrokeColor,
+              ContextCompat.getColor(context, R.color.mtrl_textinput_default_box_stroke_color));
+
     disabledColor = ContextCompat.getColor(context, R.color.mtrl_textinput_disabled_color);
     hoveredStrokeColor =
         ContextCompat.getColor(context, R.color.mtrl_textinput_hovered_box_stroke_color);

--- a/lib/java/com/google/android/material/textfield/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/textfield/res-public/values/public.xml
@@ -35,6 +35,7 @@
   <public name="boxPaddingBottom" type="attr"/>
   <public name="boxStrokeColor" type="attr"/>
   <public name="boxStrokeWidth" type="attr"/>
+  <public name="defaultBoxStrokeColor" type="attr"/>
 
   <public name="counterEnabled" type="attr"/>
   <public name="counterMaxLength" type="attr"/>

--- a/lib/java/com/google/android/material/textfield/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/attrs.xml
@@ -104,6 +104,9 @@
     <attr name="boxBackgroundColor" format="color"/>
     <!-- The value to use for the box's stroke when in outline box mode. -->
     <attr name="boxStrokeWidth" format="dimension"/>
+    <!-- The default color to use for the box's stroke color. -->
+    <attr name="defaultBoxStrokeColor" format="color"/>
+
   </declare-styleable>
 
 </resources>


### PR DESCRIPTION
This PR closes https://github.com/material-components/material-components-android/issues/112
by adding `defaultBoxStrokeColor` in TextInputLayout attr.