### PR TITLE
[ChipGroup], [FlowLayout] BottomPadding is ignored. Closes Issue 112570300: 

### DIFF
--- a/lib/java/com/google/android/material/internal/FlowLayout.java
+++ b/lib/java/com/google/android/material/internal/FlowLayout.java
@@ -150,6 +150,9 @@ public class FlowLayout extends ViewGroup {
       childLeft += (leftMargin + rightMargin + child.getMeasuredWidth()) + itemSpacing;
     }
 
+    maxChildRight += getPaddingRight();
+    childBottom += getPaddingBottom();
+
     int finalWidth = getMeasuredDimension(width, widthMode, maxChildRight);
     int finalHeight = getMeasuredDimension(height, heightMode, childBottom);
     setMeasuredDimension(finalWidth, finalHeight);


### PR DESCRIPTION
Bottom (& right) padding is ignored in Views extending FlowLayout

FlowLayout.onMeasure():
added paddingRight and paddingBottom to measurement

Issue:
https://issuetracker.google.com/issues/112570300