### PR TITLE
[MaterialButton] Use Layout#getWidth instead of Paint#measureText

### DIFF
--- a/lib/java/com/google/android/material/button/MaterialButton.java
+++ b/lib/java/com/google/android/material/button/MaterialButton.java
@@ -333,7 +333,8 @@ public class MaterialButton extends AppCompatButton {
     }
 
     Paint textPaint = getPaint();
-    int textWidth = getLayout().getWidth();
+    int textWidth = 
+        Math.min((int) textPaint.measureText(getText().toString()), getLayout().getWidth());
     int localIconSize = iconSize == 0 ? icon.getIntrinsicWidth() : iconSize;
     int newIconLeft =
         (getMeasuredWidth()

--- a/lib/java/com/google/android/material/button/MaterialButton.java
+++ b/lib/java/com/google/android/material/button/MaterialButton.java
@@ -333,7 +333,7 @@ public class MaterialButton extends AppCompatButton {
     }
 
     Paint textPaint = getPaint();
-    int textWidth = (int) textPaint.measureText(getText().toString());
+    int textWidth = getLayout().getWidth();
     int localIconSize = iconSize == 0 ? icon.getIntrinsicWidth() : iconSize;
     int newIconLeft =
         (getMeasuredWidth()


### PR DESCRIPTION
Using `Paint#measureText()` to measure the text's visual width is definitely wrong here, because that method will return the total length of the text regardless of how it is laid out (Paint doesn't know anything about how the text ends up using line breaks and stuff like that).

Using the text view's Layout object is necessary in order to obtain a reliable measurement of the text's visual width.

This PR fixes the bug filed here: https://issuetracker.google.com/issues/117365856

Here is a before vs. after screenshot:

![material-button-icon-bug](https://user-images.githubusercontent.com/1380747/46584830-087be600-ca1d-11e8-8b1a-6072e1e2e463.png)

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#pull-requests)
has more information and tips for a great pull request.
