### PR TITLE
[AppBarLayout] Update AppBarLayout to use the 3-arg view constructor

### DIFF
--- a/lib/java/com/google/android/material/appbar/AppBarLayout.java
+++ b/lib/java/com/google/android/material/appbar/AppBarLayout.java
@@ -175,9 +175,13 @@ public class AppBarLayout extends LinearLayout {
   public AppBarLayout(Context context) {
     this(context, null);
   }
-
+  
   public AppBarLayout(Context context, AttributeSet attrs) {
-    super(context, attrs);
+    this(context, attrs, 0);
+  }
+
+  public AppBarLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
     setOrientation(VERTICAL);
 
     if (Build.VERSION.SDK_INT >= 21) {
@@ -188,12 +192,12 @@ public class AppBarLayout extends LinearLayout {
       // If we're running on API 21+, we should reset any state list animator from our
       // default style
       ViewUtilsLollipop.setStateListAnimatorFromAttrs(
-          this, attrs, 0, R.style.Widget_Design_AppBarLayout);
+          this, attrs, defStyleAttr, R.style.Widget_Design_AppBarLayout);
     }
 
     final TypedArray a =
         ThemeEnforcement.obtainStyledAttributes(
-            context, attrs, R.styleable.AppBarLayout, 0, R.style.Widget_Design_AppBarLayout);
+            context, attrs, R.styleable.AppBarLayout, defStyleAttr, R.style.Widget_Design_AppBarLayout);
     ViewCompat.setBackground(this, a.getDrawable(R.styleable.AppBarLayout_android_background));
     if (a.hasValue(R.styleable.AppBarLayout_expanded)) {
       setExpanded(


### PR DESCRIPTION
Without this fix, it is impossible for developers to properly make proper use of the `defStyleAttr` view constructor argument.

This PR fixes the bug filed here: https://issuetracker.google.com/issues/117316283

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#pull-requests)
has more information and tips for a great pull request.
