### PR TITLE
[MaterialButton] Possible typo? Using `colorOnSurface` instead of `colorSurface` as the button's background

### DIFF
--- a/lib/java/com/google/android/material/button/res/color/mtrl_text_btn_text_color_selector.xml
+++ b/lib/java/com/google/android/material/button/res/color/mtrl_text_btn_text_color_selector.xml
@@ -17,5 +17,5 @@
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:color="?attr/colorPrimary" android:state_enabled="true"/>
-  <item android:alpha="0.38" android:color="?attr/colorOnSurface"/>
+  <item android:alpha="0.38" android:color="?attr/colorSurface"/>
 </selector>


### PR DESCRIPTION
My understanding of these attributes is that the "on" attributes (i.e. `colorOnPrimary`, `colorOnSurface`, etc.) are supposed to be used to describe text/icons when displayed on top of a background... and that the others (i.e. `colorPrimary`, `colorSurface`, etc.) are supposed to be used to describe the actual backgrounds.

If this is true, is it possible that there is a typo here and that you meant to use `colorSurface` instead?

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#pull-requests)
has more information and tips for a great pull request.
