### PR TITLE
[BottomSheetBehavior] Fix wrong position and state when touches settling view

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -288,10 +288,12 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
       case MotionEvent.ACTION_DOWN:
         int initialX = (int) event.getX();
         initialY = (int) event.getY();
-        View scroll = nestedScrollingChildRef != null ? nestedScrollingChildRef.get() : null;
-        if (scroll != null && parent.isPointInChildBounds(scroll, initialX, initialY)) {
-          activePointerId = event.getPointerId(event.getActionIndex());
-          touchingScrollingChild = true;
+        if (state != STATE_SETTLING) {
+          View scroll = nestedScrollingChildRef != null ? nestedScrollingChildRef.get() : null;
+          if (scroll != null && parent.isPointInChildBounds(scroll, initialX, initialY)) {
+            activePointerId = event.getPointerId(event.getActionIndex());
+            touchingScrollingChild = true;
+          }
         }
         ignoreEvents =
             activePointerId == MotionEvent.INVALID_POINTER_ID
@@ -944,7 +946,9 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
       if (viewDragHelper != null && viewDragHelper.continueSettling(true)) {
         ViewCompat.postOnAnimation(view, this);
       } else {
-        setStateInternal(targetState);
+        if (state == STATE_SETTLING) {
+          setStateInternal(targetState);
+        }
       }
     }
   }


### PR DESCRIPTION
**Issues when user touches the settling bottom sheet**
**https://issuetracker.google.com/issues/119289861**

&nbsp;

### 1. When touches normal child view in settling bottom sheet
User starts dragging the sheet and the settling animation is stopped immediately,
but the state of the sheet goes wrong to STATE_EXPANDED or STATE_COLLAPSED while dragging.

STATE_SETTLING > STATE_DRAGGING > STATE_EXPANDED or STATE_COLLAPSED (by `SettleRunnable`)

`SettleRunnable`'s `targetState` should be ignored when settling is aborted.
And the state should be remained STATE_DRAGGING.

- Videos
**[Before]** https://drive.google.com/open?id=1vvlI7_AtiAze1PcBfElRolC_LQvAVmQt
**[After(Fixed)]** https://drive.google.com/open?id=1G9387bRw4EzI7XOMLF-Hm2ro1627hsll

&nbsp;

### 2. When touches nested scroll child view in settling bottom sheet
User starts dragging the sheet, but the settling animation is not stopped,
and after the animation finished, the sheet's position is suddenly changed.
And also, nested scroll view could be scrolled while settling.

In settling state, the child view should be captured by `ViewDragHelper`, not the nested scroll child view.

- Videos
**[Before]** https://drive.google.com/open?id=1Q80Cuam0_5kjntzWySJKZoHBS1lq9OHb
**[After(Fixed)]** https://drive.google.com/open?id=1AORJELc322sg-daapgfpZyIevo5V1kEy