### PR TITLE
[HideBottomViewOnScrollBehavior]Height increase the bottomMargin of the view

### DIFF
--- a/lib/java/com/google/android/material/behavior/HideBottomViewOnScrollBehavior.java
+++ b/lib/java/com/google/android/material/behavior/HideBottomViewOnScrollBehavior.java
@@ -52,7 +52,8 @@ public class HideBottomViewOnScrollBehavior<V extends View> extends CoordinatorL
 
   @Override
   public boolean onLayoutChild(CoordinatorLayout parent, V child, int layoutDirection) {
-    height = child.getMeasuredHeight();
+    ViewGroup.MarginLayoutParams paramsCompat =  (ViewGroup.MarginLayoutParams)child.getLayoutParams();
+    height = child.getMeasuredHeight() + paramsCompat.bottomMargin;
     return super.onLayoutChild(parent, child, layoutDirection);
   }
 


### PR DESCRIPTION
Because the Behavior is to slide down to disappear, the more reasonable sliding distance should be the height of the view plus the bottomMargin of the view.
