### PR TITLE
[IndicatorViewController] Fix a caption view animations issue when you set two error subsequently.

### DIFF
--- a/lib/java/com/google/android/material/textfield/IndicatorViewController.java
+++ b/lib/java/com/google/android/material/textfield/IndicatorViewController.java
@@ -238,8 +238,8 @@ final class IndicatorViewController {
                 }
               }
               if (captionViewToShow != null) {
-                captionViewToShow.setTranslationY(0);
-                captionViewToShow.setAlpha(1);
+                captionViewToShow.setTranslationY(0f);
+                captionViewToShow.setAlpha(1f);
               }
             }
 

--- a/lib/java/com/google/android/material/textfield/IndicatorViewController.java
+++ b/lib/java/com/google/android/material/textfield/IndicatorViewController.java
@@ -237,6 +237,10 @@ final class IndicatorViewController {
                   errorView.setText(null);
                 }
               }
+              if (captionViewToShow != null) {
+                captionViewToShow.setTranslationY(0);
+                captionViewToShow.setAlpha(1);
+              }
             }
 
             @Override


### PR DESCRIPTION
You can reproduce that if you set different errors simultaneously. Animation is canceled but the caption view is stuck right below the box of TextInputLayout without any appropriate padding.

![image](https://user-images.githubusercontent.com/5305278/50450558-e1f48980-093f-11e9-8e15-bc7ae4dd50ca.png)

