### PR TITLE
[build.gradle, cat_transformation_fragment.xml] fixed bug with Vector Drawable in Android SDK < 21

### DIFF
--- a/catalog/build.gradle
+++ b/catalog/build.gradle
@@ -51,6 +51,7 @@ def srcDirs = [
 
 android {
   defaultConfig {
+    vectorDrawables.useSupportLibrary = true
     manifestPlaceholders = [
       application_name             : 'CatalogApplication',
       application_theme            : 'Catalog',

--- a/catalog/java/io/material/catalog/transformation/res/layout/cat_transformation_fragment.xml
+++ b/catalog/java/io/material/catalog/transformation/res/layout/cat_transformation_fragment.xml
@@ -78,8 +78,8 @@
           android:background="?selectableItemBackgroundBorderless"
           android:contentDescription="@string/close_sheet"
           android:scaleType="fitCenter"
-          android:src="@drawable/ic_close_vd_theme_24px"
-          android:tint="?attr/colorOnSurface"/>
+          android:tint="?attr/colorOnSurface"
+          app:srcCompat="@drawable/ic_close_vd_theme_24px"/>
 
       <TextView
           android:layout_width="wrap_content"


### PR DESCRIPTION
* for appropriate work vector on Android SDK < 21 in XML use app:srcCompat="@drawable/example"
