### PR TITLE
[AppBar] AppBarLayout + WindowInset handling fixes

### DIFF
--- a/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_fragment.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_fragment.xml
@@ -15,42 +15,46 @@
   limitations under the License.
   -->
 <androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:fitsSystemWindows="true">
 
-  <androidx.core.widget.NestedScrollView
+  <com.google.android.material.appbar.AppBarLayout
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/cat_topappbar_tall_toolbar_height"
+    android:fitsSystemWindows="true">
+
+    <com.google.android.material.appbar.CollapsingToolbarLayout
+      style="?attr/catalogToolbarStyle"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      app:layout_behavior="@string/appbar_scrolling_view_behavior">
+      app:collapsedTitleTextAppearance="?attr/textAppearanceHeadline6"
+      app:expandedTitleGravity="bottom"
+      app:expandedTitleMarginBottom="24dp"
+      app:expandedTitleMarginStart="16dp"
+      app:expandedTitleTextAppearance="?attr/textAppearanceHeadline5"
+      app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
+
+      <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        style="?attr/catalogToolbarWithCloseButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:elevation="0dp"
+        app:layout_collapseMode="pin"
+        app:title="@string/cat_topappbar_collapsing_demo_toolbar_title"/>
+
+    </com.google.android.material.appbar.CollapsingToolbarLayout>
+  </com.google.android.material.appbar.AppBarLayout>
+
+  <androidx.core.widget.NestedScrollView
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <include layout="@layout/cat_topappbar_filler_text_view"/>
   </androidx.core.widget.NestedScrollView>
 
-  <com.google.android.material.appbar.AppBarLayout
-      android:layout_width="match_parent"
-      android:layout_height="@dimen/cat_topappbar_tall_toolbar_height">
-
-    <com.google.android.material.appbar.CollapsingToolbarLayout
-        style="?attr/catalogToolbarStyle"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:collapsedTitleTextAppearance="?attr/textAppearanceHeadline6"
-        app:contentScrim="?attr/colorPrimary"
-        app:expandedTitleGravity="bottom"
-        app:expandedTitleMarginBottom="24dp"
-        app:expandedTitleMarginStart="16dp"
-        app:expandedTitleTextAppearance="?attr/textAppearanceHeadline5"
-        app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
-
-      <androidx.appcompat.widget.Toolbar
-          android:id="@+id/toolbar"
-          style="?attr/catalogToolbarWithCloseButtonStyle"
-          android:layout_width="match_parent"
-          android:layout_height="?attr/actionBarSize"
-          app:layout_collapseMode="pin"
-          app:title="@string/cat_topappbar_collapsing_demo_toolbar_title"/>
-    </com.google.android.material.appbar.CollapsingToolbarLayout>
-  </com.google.android.material.appbar.AppBarLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_scrolling_fragment.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_scrolling_fragment.xml
@@ -18,19 +18,13 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-  <androidx.core.widget.NestedScrollView
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-    <include layout="@layout/cat_topappbar_filler_text_view"/>
-  </androidx.core.widget.NestedScrollView>
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
   <com.google.android.material.appbar.AppBarLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="wrap_content"
+      android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
@@ -40,4 +34,13 @@
         app:layout_scrollFlags="scroll|enterAlways|snap"
         app:title="@string/cat_topappbar_scrolling_demo_toolbar_title"/>
   </com.google.android.material.appbar.AppBarLayout>
+
+  <androidx.core.widget.NestedScrollView
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <include layout="@layout/cat_topappbar_filler_text_view"/>
+  </androidx.core.widget.NestedScrollView>
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/lib/java/com/google/android/material/appbar/HeaderScrollingViewBehavior.java
+++ b/lib/java/com/google/android/material/appbar/HeaderScrollingViewBehavior.java
@@ -65,20 +65,16 @@ abstract class HeaderScrollingViewBehavior extends ViewOffsetBehavior<View> {
       final List<View> dependencies = parent.getDependencies(child);
       final View header = findFirstDependency(dependencies);
       if (header != null) {
-        if (ViewCompat.getFitsSystemWindows(header) && !ViewCompat.getFitsSystemWindows(child)) {
-          // If the header is fitting system windows then we need to also,
-          // otherwise we'll get CoL's compatible measuring
-          ViewCompat.setFitsSystemWindows(child, true);
-
-          if (ViewCompat.getFitsSystemWindows(child)) {
-            // If the set succeeded, trigger a new layout and return true
-            child.requestLayout();
-            return true;
-          }
-        }
-
         int availableHeight = View.MeasureSpec.getSize(parentHeightMeasureSpec);
-        if (availableHeight == 0) {
+        if (availableHeight > 0) {
+          if (ViewCompat.getFitsSystemWindows(header)) {
+            final WindowInsetsCompat parentInsets = parent.getLastWindowInsets();
+            if (parentInsets != null) {
+              availableHeight += parentInsets.getSystemWindowInsetTop();
+              availableHeight += parentInsets.getSystemWindowInsetBottom();
+            }
+          }
+        } else {
           // If the measure spec doesn't specify a size, use the current height
           availableHeight = parent.getHeight();
         }


### PR DESCRIPTION
When AppBarLayout is used with a CollapsingToolbarLayout child, it currently does not handle WindowInsets very well. This commit fixes that by properly handling
insets.

The primary issue is when an AppBarLayout is used with a single Toolbar (very common use case), where the Toolbar will be displayed behind the status bar.

Another issue is with HeaderScrollingViewBehavior. To workaround CoordinatorLayout using its 'compatible measuring' for insets, it manually sets the scrolling view to fit system windows. This has other issues though because by default that view will get padded in. Fixed by manually adding the insets back into the measured dimensions.