### PR TITLE
[BottomSheetBehavior] Fix halfExpandedOffset calculation

### DIFF
--- a/catalog/java/io/material/catalog/bottomsheet/BottomSheetMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/bottomsheet/BottomSheetMainDemoFragment.java
@@ -34,6 +34,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.FrameLayout;
 import android.widget.Switch;
 import android.widget.TextView;
 import io.material.catalog.feature.DemoFragment;
@@ -75,13 +76,19 @@ public class BottomSheetMainDemoFragment extends DemoFragment {
 
             View bottomSheetChildView = view.findViewById(R.id.bottom_drawer);
             ViewGroup.LayoutParams params = bottomSheetChildView.getLayoutParams();
+            BottomSheetBehavior<View> bottomSheetBehavior = BottomSheetBehavior.from(bottomSheetChildView);
             View modalBottomSheetChildView = bottomSheetDialog.findViewById(R.id.bottom_drawer_2);
             ViewGroup.LayoutParams layoutParams = modalBottomSheetChildView.getLayoutParams();
+            BottomSheetBehavior<FrameLayout> modalBottomSheetBehavior = bottomSheetDialog.getBehavior();
+            boolean fitToContents = true;
+            float halfExpandedRatio = 0.5f;
 
             if (params != null && layoutParams != null) {
               if (isChecked) {
                 params.height = windowHeight;
                 layoutParams.height = windowHeight;
+                fitToContents = false;
+                halfExpandedRatio = 0.7f;
 
               } else {
                 params.height = (windowHeight * 3 / 5);
@@ -89,6 +96,10 @@ public class BottomSheetMainDemoFragment extends DemoFragment {
               }
               bottomSheetChildView.setLayoutParams(params);
               modalBottomSheetChildView.setLayoutParams(layoutParams);
+              bottomSheetBehavior.setFitToContents(fitToContents);
+              modalBottomSheetBehavior.setFitToContents(fitToContents);
+              bottomSheetBehavior.setHalfExpandedRatio(halfExpandedRatio);
+              modalBottomSheetBehavior.setHalfExpandedRatio(halfExpandedRatio);
             }
           }
         });
@@ -125,6 +136,10 @@ public class BottomSheetMainDemoFragment extends DemoFragment {
                 break;
               case BottomSheetBehavior.STATE_COLLAPSED:
                 text.setText(R.string.cat_bottomsheet_state_collapsed);
+                break;
+              case BottomSheetBehavior.STATE_HALF_EXPANDED:
+                BottomSheetBehavior<View> bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet);
+                text.setText(getString(R.string.cat_bottomsheet_state_half_expanded, bottomSheetBehavior.getHalfExpandedRatio()));
                 break;
               default:
                 break;

--- a/catalog/java/io/material/catalog/bottomsheet/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/bottomsheet/res/values/strings.xml
@@ -34,6 +34,9 @@
   <string name="cat_bottomsheet_state_expanded" translatable="false">
     STATE_EXPANDED
   </string>
+  <string name="cat_bottomsheet_state_half_expanded" translatable="false">
+    STATE_HALF_EXPANDED\nhalfExpandedRatio = %.2f
+  </string>
   <string name="cat_bottomsheet_persistent">
     Persistent Bottomsheet
   </string>

--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -925,7 +925,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
   }
 
   private void calculateHalfExpandedOffset() {
-      this.halfExpandedOffset = (int) (parentHeight * halfExpandedRatio);
+      this.halfExpandedOffset = (int) (parentHeight * (1 - halfExpandedRatio));
   }
 
   private void reset() {


### PR DESCRIPTION
This fixes the calculation of the half-expanded size of a Bottom Sheet when using the new `halfExpandedRatio` attribute. It also adds support for this in the catalog Bottom Sheet demo.

No related GitHub issue, but please see: https://issuetracker.google.com/issues/129457530

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#pull-requests)
has more information and tips for a great pull request.
