### PR TITLE
[CircularRevealHelper] Make CircularRevealHelper.Delegate public

### DIFF
--- a/lib/java/com/google/android/material/circularreveal/CircularRevealHelper.java
+++ b/lib/java/com/google/android/material/circularreveal/CircularRevealHelper.java
@@ -54,7 +54,7 @@ public class CircularRevealHelper {
   /**
    * Delegate interface to be implemented by the {@link CircularRevealWidget} that owns this helper.
    */
-  interface Delegate {
+  public interface Delegate {
 
     /**
      * Calls {@link View#draw(Canvas) super#draw(Canvas)}.


### PR DESCRIPTION
### Thanks for starting a pull request on Material Components!
Current CicularRevealHelper.Delegate access level is package-private, so we cannot instantiate CircularRevealHelper whose constructor requires  CicularRevealHelper.Delegate when writing in Kotlin (java.lang.IllegalAccessError: Illegal class access: )
Make CicularRevealHelper.Delegate to public then we can use CircularRevealHelper in our custom CircularRevealWidget.

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#pull-requests)
has more information and tips for a great pull request.