### PR TITLE
[BottomSheet] Remove rounded bottom corners of bottomsheets

### DIFF
--- a/catalog/java/io/material/catalog/shapetheming/res/values/styles.xml
+++ b/catalog/java/io/material/catalog/shapetheming/res/values/styles.xml
@@ -221,8 +221,6 @@
   <style name="ShapeAppearanceOverlay.Crane.BottomSheet" parent="">
      <item name="cornerSizeTopRight">20dp</item>
      <item name="cornerSizeTopLeft">20dp</item>
-     <item name="cornerSizeBottomRight">0dp</item>
-     <item name="cornerSizeBottomLeft">0dp</item>
      <item name="cornerFamilyTopLeft">rounded</item>
      <item name="cornerFamilyTopRight">rounded</item>
    </style>

--- a/lib/java/com/google/android/material/bottomsheet/res/values/styles.xml
+++ b/lib/java/com/google/android/material/bottomsheet/res/values/styles.xml
@@ -44,6 +44,7 @@
     <item name="enforceMaterialTheme">true</item>
     <item name="android:background">@null</item>
     <item name="shapeAppearance">?attr/shapeAppearanceLargeComponent</item>
+    <item name="shapeAppearanceOverlay">@style/ShapeAppearanceOverlay.MaterialComponents.BottomSheet</item>
     <item name="backgroundTint">?attr/colorSurface</item>
     <item name="android:elevation" tools:ignore="NewApi">
       @dimen/design_bottom_sheet_elevation
@@ -54,6 +55,11 @@
     <item name="android:elevation" tools:ignore="NewApi">
       @dimen/design_bottom_sheet_modal_elevation
     </item>
+  </style>
+
+  <style name="ShapeAppearanceOverlay.MaterialComponents.BottomSheet" parent="">
+    <item name="cornerSizeBottomRight">0dp</item>
+    <item name="cornerSizeBottomLeft">0dp</item>
   </style>
 
  </resources>


### PR DESCRIPTION
This PR removes bottom corners of bottomsheet. They shouldn't be shaped at all, as [specified in material docs](https://material.io/design/components/sheets-bottom.html#theming).

> *Bottom sheets can only be shaped on the top left and top right corners.

The current bug can be reproduced in catalog app. Maybe this styling was intentional purpose of this [reverted commit](https://github.com/material-components/material-components-android/commit/2fda77a6ab0f4619992cedeace08f6fc67afd133) that actually removed shaping on the top and not the bottom.