### PR TITLE
[TextInputLayout] fix crash when focusing TextInputEditText on Meizu devices

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputEditText.java
+++ b/lib/java/com/google/android/material/textfield/TextInputEditText.java
@@ -21,6 +21,7 @@ import com.google.android.material.R;
 import android.content.Context;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatEditText;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewParent;
@@ -51,9 +52,10 @@ public class TextInputEditText extends AppCompatEditText {
   @Override
   public CharSequence getHint() {
     // Certain test frameworks expect the actionable element to expose its hint as a label. When
-    // TextInputLayout is providing our hint, retrieve it from the parent layout.
+    // TextInputLayout is providing our hint, retrieve it from the parent layout. Excepting for
+    // Meizu devices which doesn't handle this behaviour correctly and crash when getting focus.
     TextInputLayout layout = getTextInputLayout();
-    if ((layout != null) && layout.isProvidingHint()) {
+    if (layout != null && layout.isProvidingHint() && !Build.MANUFACTURER.equals("Meizu")) {
       return layout.getHint();
     }
     return super.getHint();

--- a/lib/java/com/google/android/material/textfield/TextInputEditText.java
+++ b/lib/java/com/google/android/material/textfield/TextInputEditText.java
@@ -21,6 +21,7 @@ import com.google.android.material.R;
 import android.content.Context;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatEditText;
+import android.graphics.Canvas;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
@@ -50,12 +51,25 @@ public class TextInputEditText extends AppCompatEditText {
   }
 
   @Override
+  protected void onDraw(Canvas canvas) {
+    // Meizu devices expect a hintLayout if the hint is not null. In order to avoid crashing,
+    // we force the creation of the hintLayout by setting an empty non null hint.
+    TextInputLayout layout = getTextInputLayout();
+    if (layout != null
+        && layout.isProvidingHint()
+        && super.getHint() == null
+        && Build.MANUFACTURER.equals("Meizu")) {
+      setHint("");
+    }
+    super.onDraw(canvas);
+  }
+
+  @Override
   public CharSequence getHint() {
     // Certain test frameworks expect the actionable element to expose its hint as a label. When
-    // TextInputLayout is providing our hint, retrieve it from the parent layout. Excepting for
-    // Meizu devices which doesn't handle this behaviour correctly and crash when getting focus.
+    // TextInputLayout is providing our hint, retrieve it from the parent layout.
     TextInputLayout layout = getTextInputLayout();
-    if (layout != null && layout.isProvidingHint() && !Build.MANUFACTURER.equals("Meizu")) {
+    if (layout != null && layout.isProvidingHint()) {
       return layout.getHint();
     }
     return super.getHint();

--- a/lib/java/com/google/android/material/textfield/TextInputEditText.java
+++ b/lib/java/com/google/android/material/textfield/TextInputEditText.java
@@ -21,7 +21,6 @@ import com.google.android.material.R;
 import android.content.Context;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatEditText;
-import android.graphics.Canvas;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
@@ -51,7 +50,7 @@ public class TextInputEditText extends AppCompatEditText {
   }
 
   @Override
-  protected void onDraw(Canvas canvas) {
+  protected void onAttachedToWindow() {
     // Meizu devices expect a hintLayout if the hint is not null. In order to avoid crashing,
     // we force the creation of the hintLayout by setting an empty non null hint.
     TextInputLayout layout = getTextInputLayout();
@@ -61,7 +60,7 @@ public class TextInputEditText extends AppCompatEditText {
         && Build.MANUFACTURER.equals("Meizu")) {
       setHint("");
     }
-    super.onDraw(canvas);
+    super.onAttachedToWindow();
   }
 
   @Override


### PR DESCRIPTION
Don't return parent hint from TextInputEditText.getHint() if the manufacturer is Meizu as their modifications in Textview leads to a crash

solve https://issuetracker.google.com/issues/112105087
(closed because duplicated Github issue: #216 )