### PR TITLE
[Snackbar] Add support for changing text & background tint color at runtime

### DIFF
--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -40,6 +40,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+
+import androidx.annotation.ColorInt;
 import androidx.annotation.IdRes;
 import androidx.annotation.IntDef;
 import androidx.annotation.IntRange;
@@ -362,6 +364,21 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
     background.setColor(backgroundColor);
     background.setCornerRadius(cornerRadius);
     return background;
+  }
+
+  void updateThemedBackgroundOverlayColor(@ColorInt int overlayColor) {
+    int backgroundColor = MaterialColors.getColor(view, R.attr.colorSurface);
+    updateThemedBackgroundColors(backgroundColor, overlayColor);
+  }
+
+  private void updateThemedBackgroundColors(@ColorInt int backgroundColor, @ColorInt int overlayColor) {
+    if (!(view.getBackground() instanceof GradientDrawable)) return;
+    int color =
+        MaterialColors.layer(
+            backgroundColor,
+            overlayColor,
+            view.getBackgroundOverlayColorAlpha());
+    ((GradientDrawable) view.getBackground()).setColor(color);
   }
 
   private void updateBottomMargin() {

--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -40,8 +40,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
-
-import androidx.annotation.ColorInt;
 import androidx.annotation.IdRes;
 import androidx.annotation.IntDef;
 import androidx.annotation.IntRange;
@@ -364,21 +362,6 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
     background.setColor(backgroundColor);
     background.setCornerRadius(cornerRadius);
     return background;
-  }
-
-  void updateThemedBackgroundOverlayColor(@ColorInt int overlayColor) {
-    int backgroundColor = MaterialColors.getColor(view, R.attr.colorSurface);
-    updateThemedBackgroundColors(backgroundColor, overlayColor);
-  }
-
-  private void updateThemedBackgroundColors(@ColorInt int backgroundColor, @ColorInt int overlayColor) {
-    if (!(view.getBackground() instanceof GradientDrawable)) return;
-    int color =
-        MaterialColors.layer(
-            backgroundColor,
-            overlayColor,
-            view.getBackgroundOverlayColorAlpha());
-    ((GradientDrawable) view.getBackground()).setColor(color);
   }
 
   private void updateBottomMargin() {

--- a/lib/java/com/google/android/material/snackbar/Snackbar.java
+++ b/lib/java/com/google/android/material/snackbar/Snackbar.java
@@ -387,7 +387,7 @@ public class Snackbar extends BaseTransientBottomBar<Snackbar> {
    * Sets the tint color of the background Drawable.
    */
   @NonNull
-  public Snackbar setBackgroundTintColor(@ColorInt int color) {
+  public Snackbar setBackgroundTint(@ColorInt int color) {
     if (view.getBackground() != null) {
       // Drawable doesn't implement setTint in API 21 and Snackbar does not yet use
       // MaterialShapeDrawable as its background (i.e. TintAwareDrawable)

--- a/lib/java/com/google/android/material/snackbar/Snackbar.java
+++ b/lib/java/com/google/android/material/snackbar/Snackbar.java
@@ -31,6 +31,10 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.StringRes;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.graphics.drawable.DrawableCompat;
+
+import android.graphics.PorterDuff;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -380,11 +384,19 @@ public class Snackbar extends BaseTransientBottomBar<Snackbar> {
   }
 
   /**
-   * Sets the overlay color of the background Drawable.
+   * Sets the tint color of the background Drawable.
    */
   @NonNull
-  public Snackbar setBackgroundOverlayColor(@ColorInt int color) {
-    updateThemedBackgroundOverlayColor(color);
+  public Snackbar setBackgroundTintColor(@ColorInt int color) {
+    if (view.getBackground() != null) {
+      // Drawable doesn't implement setTint in API 21 and Snackbar does not yet use
+      // MaterialShapeDrawable as its background (i.e. TintAwareDrawable)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+        DrawableCompat.setTint(view.getBackground(), color);
+      } else {
+        view.getBackground().setColorFilter(color, PorterDuff.Mode.SRC_IN);
+      }
+    }
     return this;
   }
 

--- a/lib/java/com/google/android/material/snackbar/Snackbar.java
+++ b/lib/java/com/google/android/material/snackbar/Snackbar.java
@@ -332,6 +332,30 @@ public class Snackbar extends BaseTransientBottomBar<Snackbar> {
   }
 
   /**
+   * Sets the text color of the message specified in {@link #setText(CharSequence)}
+   * and {@link #setText(int)}.
+   */
+  @NonNull
+  public Snackbar setTextColor(ColorStateList colors) {
+    final SnackbarContentLayout contentLayout = (SnackbarContentLayout) view.getChildAt(0);
+    final TextView tv = contentLayout.getMessageView();
+    tv.setTextColor(colors);
+    return this;
+  }
+
+  /**
+   * Sets the text color of the message specified in {@link #setText(CharSequence)}
+   * and {@link #setText(int)}.
+   */
+  @NonNull
+  public Snackbar setTextColor(@ColorInt int color) {
+    final SnackbarContentLayout contentLayout = (SnackbarContentLayout) view.getChildAt(0);
+    final TextView tv = contentLayout.getMessageView();
+    tv.setTextColor(color);
+    return this;
+  }
+
+  /**
    * Sets the text color of the action specified in {@link #setAction(CharSequence,
    * View.OnClickListener)}.
    */
@@ -352,6 +376,15 @@ public class Snackbar extends BaseTransientBottomBar<Snackbar> {
     final SnackbarContentLayout contentLayout = (SnackbarContentLayout) view.getChildAt(0);
     final TextView tv = contentLayout.getActionView();
     tv.setTextColor(color);
+    return this;
+  }
+
+  /**
+   * Sets the overlay color of the background Drawable.
+   */
+  @NonNull
+  public Snackbar setBackgroundOverlayColor(@ColorInt int color) {
+    updateThemedBackgroundOverlayColor(color);
     return this;
   }
 

--- a/lib/java/com/google/android/material/snackbar/Snackbar.java
+++ b/lib/java/com/google/android/material/snackbar/Snackbar.java
@@ -34,6 +34,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.graphics.drawable.DrawableCompat;
 
 import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -388,13 +389,14 @@ public class Snackbar extends BaseTransientBottomBar<Snackbar> {
    */
   @NonNull
   public Snackbar setBackgroundTint(@ColorInt int color) {
-    if (view.getBackground() != null) {
+    Drawable background = view.getBackground();
+    if (background != null) {
       // Drawable doesn't implement setTint in API 21 and Snackbar does not yet use
       // MaterialShapeDrawable as its background (i.e. TintAwareDrawable)
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-        DrawableCompat.setTint(view.getBackground(), color);
+        DrawableCompat.setTint(background, color);
       } else {
-        view.getBackground().setColorFilter(color, PorterDuff.Mode.SRC_IN);
+        background.setColorFilter(color, PorterDuff.Mode.SRC_IN);
       }
     }
     return this;


### PR DESCRIPTION
This adds support to `BaseTransientBottomBar` and `Snackbar` to allow for changing of the message text and background overlay color at runtime. The implementations and method names attempt to stay as close as possible to the existing `Snackbar#setActionTextColor` method.

No related GitHub issue, but please see: https://issuetracker.google.com/issues/132576777

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#pull-requests)
has more information and tips for a great pull request.
