### PR TITLE
[TextField] Fix typo in strings.xml

### DIFF
--- a/material-theme-builder/src/main/res/values/strings.xml
+++ b/material-theme-builder/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
 
     <string name="drawer_label_title">Drawer</string>
 
-    <string name="text_field_label_title">Text filed</string>
+    <string name="text_field_label_title">Text field</string>
     <string name="text_field_hint_text">Label</string>
 
     <string name="bottom_nav_label_title">Bottom navigation</string>


### PR DESCRIPTION
This fixes a typo in `strings.xml`

No related GitHub issue.

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.
