### PR TITLE
Update Getting Started doc to use alpha07

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,7 @@ To use it:
     ```groovy
       dependencies {
         // ...
-        implementation 'com.google.android.material:material:1.1.0-alpha06'
+        implementation 'com.google.android.material:material:1.1.0-alpha07'
         // ...
       }
     ```


### PR DESCRIPTION
Looks like the Getting Started doc is still suggesting to use the
alpha06 of MDC. Given that the alpha07 was released several weeks ago,
I'm updating the gradle implementation line to use the latest version of
MDC.
