### PR TITLE
[Bottom Navigation] Add tooltip fallback to Bottom Navigation item titles

### DIFF
--- a/lib/java/com/google/android/material/bottomnavigation/BottomNavigationItemView.java
+++ b/lib/java/com/google/android/material/bottomnavigation/BottomNavigationItemView.java
@@ -126,7 +126,11 @@ public class BottomNavigationItemView extends FrameLayout implements MenuView.It
     if (!TextUtils.isEmpty(itemData.getContentDescription())) {
       setContentDescription(itemData.getContentDescription());
     }
-    TooltipCompat.setTooltipText(this, itemData.getTooltipText());
+    if (!TextUtils.isEmpty(itemData.getTooltipText())) {
+      TooltipCompat.setTooltipText(this, itemData.getTooltipText());
+    } else {
+      TooltipCompat.setTooltipText(this, itemData.getTitle());
+    }
     setVisibility(itemData.isVisible() ? View.VISIBLE : View.GONE);
   }
 
@@ -171,6 +175,11 @@ public class BottomNavigationItemView extends FrameLayout implements MenuView.It
     largeLabel.setText(title);
     if (itemData == null || TextUtils.isEmpty(itemData.getContentDescription())) {
       setContentDescription(title);
+    }
+    if (!TextUtils.isEmpty(itemData.getTooltipText())) {
+      TooltipCompat.setTooltipText(this, itemData.getTooltipText());
+    } else {
+      TooltipCompat.setTooltipText(this, title);
     }
   }
 

--- a/lib/javatests/com/google/android/material/bottomnavigation/BottomNavigationItemViewTest.java
+++ b/lib/javatests/com/google/android/material/bottomnavigation/BottomNavigationItemViewTest.java
@@ -16,12 +16,8 @@
 package com.google.android.material.bottomnavigation;
 
 import android.content.Context;
-import android.view.Menu;
-import android.view.MenuItem;
 
-import androidx.appcompat.view.menu.MenuBuilder;
 import androidx.appcompat.view.menu.MenuItemImpl;
-import androidx.appcompat.widget.TooltipCompat;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.google.android.material.R;

--- a/lib/javatests/com/google/android/material/bottomnavigation/BottomNavigationItemViewTest.java
+++ b/lib/javatests/com/google/android/material/bottomnavigation/BottomNavigationItemViewTest.java
@@ -30,13 +30,14 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.internal.DoNotInstrument;
 
+import static android.os.Build.VERSION_CODES.O;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link BottomNavigationItemView}. */
 @RunWith(RobolectricTestRunner.class)
 @DoNotInstrument
-@Config(sdk = 26)
+@Config(sdk = O)
 public final class BottomNavigationItemViewTest {
 
   private static final int MENU_TYPE = 0;

--- a/lib/javatests/com/google/android/material/bottomnavigation/BottomNavigationItemViewTest.java
+++ b/lib/javatests/com/google/android/material/bottomnavigation/BottomNavigationItemViewTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.material.bottomnavigation;
+
+import android.content.Context;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import androidx.appcompat.view.menu.MenuBuilder;
+import androidx.appcompat.view.menu.MenuItemImpl;
+import androidx.appcompat.widget.TooltipCompat;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.google.android.material.R;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.internal.DoNotInstrument;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link BottomNavigationItemView}. */
+@RunWith(RobolectricTestRunner.class)
+@DoNotInstrument
+@Config(sdk = 26)
+public final class BottomNavigationItemViewTest {
+
+  private static final int MENU_TYPE = 0;
+
+  private final Context context = ApplicationProvider.getApplicationContext();
+
+  @Before
+  public void themeApplicationContext() {
+    context.setTheme(R.style.Theme_MaterialComponents_Light);
+  }
+
+  @Test
+  public void testSetTooltip_itemHasTooltip() {
+    String tooltip = "menu item tooltip";
+    MenuItemImpl menuItem = createMenuItemImpl("menu item title", tooltip);
+    BottomNavigationItemView itemView = new BottomNavigationItemView(context);
+
+    itemView.initialize(menuItem, MENU_TYPE);
+
+    assertThat(itemView.getTooltipText()).isEqualTo(tooltip);
+  }
+
+  @Test
+  public void testMissingTooltip_itemFallsBackToTitle() {
+    String title = "menu item title";
+    MenuItemImpl menuItem = createMenuItemImpl(title, null);
+    BottomNavigationItemView itemView = new BottomNavigationItemView(context);
+
+    itemView.initialize(menuItem, MENU_TYPE);
+
+    assertThat(itemView.getTooltipText()).isEqualTo(title);
+  }
+
+  @Test
+  public void testSetTitle_updatesTooltip() {
+    MenuItemImpl menuItem = createMenuItemImpl("menu item title", null);
+    BottomNavigationItemView itemView = new BottomNavigationItemView(context);
+    itemView.initialize(menuItem, MENU_TYPE);
+
+    CharSequence updatedTitle = "menu item title updated";
+    itemView.setTitle(updatedTitle);
+
+    assertThat(itemView.getTooltipText()).isEqualTo(updatedTitle);
+  }
+
+  private MenuItemImpl createMenuItemImpl(CharSequence title, CharSequence tooltip) {
+    MenuItemImpl menuItem = Mockito.mock(MenuItemImpl.class);
+    when(menuItem.getTooltipText()).thenReturn(tooltip);
+    when(menuItem.getTitle()).thenReturn(title);
+    return menuItem;
+  }
+}


### PR DESCRIPTION
Bottom navigation tab titles can get truncated/clipped if they're too long or if the user's text size is set as large:

![image](https://user-images.githubusercontent.com/2678555/59956246-27c18300-9487-11e9-9afe-6b54641cc5fb.png)

One way to mitigate this is to use tooltips, like AppBar's `ActionMenuItemView`. `BottomNavigationItemView` already sets the tooltip if one is available, but the tooltip property needs to be explicitly set by the client.

This PR adds similar behaviour to the `ActionMenuItemView`: fall back to the title if the tooltip is not present.

Before | After
---|---
![tooltips-before](https://user-images.githubusercontent.com/2678555/59956221-f6e14e00-9486-11e9-968d-98f6895fbd62.gif) | ![tooltips-after](https://user-images.githubusercontent.com/2678555/59956222-f6e14e00-9486-11e9-90f5-c994d9e6eaaf.gif)
