### PR TITLE
Update on meizu crash with TextInputEditText:

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputEditText.java
+++ b/lib/java/com/google/android/material/textfield/TextInputEditText.java
@@ -60,7 +60,7 @@ public class TextInputEditText extends AppCompatEditText {
     if (layout != null
         && layout.isProvidingHint()
         && super.getHint() == null
-        && Build.MANUFACTURER.equals("Meizu")) {
+        && Build.MANUFACTURER.toLowerCase().equals("meizu")) {
       setHint("");
     }
   }

--- a/lib/java/com/google/android/material/textfield/TextInputEditText.java
+++ b/lib/java/com/google/android/material/textfield/TextInputEditText.java
@@ -60,7 +60,7 @@ public class TextInputEditText extends AppCompatEditText {
     if (layout != null
         && layout.isProvidingHint()
         && super.getHint() == null
-        && Build.MANUFACTURER.toLowerCase().equals("meizu")) {
+        && Build.MANUFACTURER.equalsIgnoreCase("Meizu")) {
       setHint("");
     }
   }


### PR DESCRIPTION
Some Meizu devices use "meizu" as manufacturer, instead of "Meizu":
16s (meizu_16s_CN) cf https://github.com/TadiT7/meizu_16s_dump/blob/8b4700d1bbcd3d9fac9dde0e7d609a875f986e0b/system/system/build.prop

Note9 (meizu_Note9_CN) cf https://github.com/TadiT7/meizu_note9_dump/blob/38957f57a325e1c0d3ba173242f5b2451af5c249/system/system/build.prop

This leads this crash to still occurs on this phones: https://github.com/material-components/material-components-android/pull/358

This PR fixes this problem testing the manufacturer using `Build.MANUFACTURER.toLowerCase().equals("meizu")`.
