### PR TITLE
[CollapsingToolbarLayout] Allow multiple lines of text in expanded state

### DIFF
--- a/catalog/java/io/material/catalog/bottomsheet/res/values/styles.xml
+++ b/catalog/java/io/material/catalog/bottomsheet/res/values/styles.xml
@@ -23,4 +23,19 @@
     <item name="android:drawablePadding">8dp</item>
     <item name="android:background">?attr/selectableItemBackground</item>
   </style>
+
+  <style name="TextAppearance.Test.CollapsingToolbar.Expanded" parent="">
+    <item name="fontFamily">serif</item>
+    <item name="android:fontFamily">serif</item>
+    <item name="android:textColor">@android:color/white</item>
+    <item name="android:textSize">28sp</item>
+    <item name="android:textStyle">italic</item>
+  </style>
+
+  <style name="TextAppearance.Test.CollapsingToolbar.Collapsed" parent="">
+    <item name="fontFamily">monospace</item>
+    <item name="android:fontFamily">monospace</item>
+    <item name="android:textSize">20sp</item>
+    <item name="android:textColor">@android:color/holo_blue_bright</item>
+  </style>
 </resources>

--- a/catalog/java/io/material/catalog/topappbar/TopAppBarCollapsingMultilineDemoFragment.java
+++ b/catalog/java/io/material/catalog/topappbar/TopAppBarCollapsingMultilineDemoFragment.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.material.catalog.topappbar;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import io.material.catalog.R;
+import io.material.catalog.feature.DemoFragment;
+
+/** A fragment that displays a collapsing Top App Bar demo for the Catalog app. */
+public class TopAppBarCollapsingMultilineDemoFragment extends DemoFragment {
+
+  @Override
+  public View onCreateDemoView(
+      LayoutInflater layoutInflater, @Nullable ViewGroup viewGroup, @Nullable Bundle bundle) {
+    View view =
+        layoutInflater.inflate(R.layout.cat_topappbar_collapsing_multiline_fragment, viewGroup,
+            false);
+
+    Toolbar toolbar = view.findViewById(R.id.toolbar);
+    AppCompatActivity activity = (AppCompatActivity) getActivity();
+    activity.setSupportActionBar(toolbar);
+
+    return view;
+  }
+
+  @Override
+  public boolean shouldShowDefaultDemoActionBar() {
+    return false;
+  }
+}

--- a/catalog/java/io/material/catalog/topappbar/TopAppBarFragment.java
+++ b/catalog/java/io/material/catalog/topappbar/TopAppBarFragment.java
@@ -79,6 +79,13 @@ public class TopAppBarFragment extends DemoLandingFragment {
             return new TopAppBarCollapsingDemoFragment();
           }
         });
+    additionalDemos.add(
+        new Demo(R.string.cat_topappbar_collapsing_multiline_title) {
+          @Override
+          public Fragment createFragment() {
+            return new TopAppBarCollapsingMultilineDemoFragment();
+          }
+        });
     additionalDemos.add(getToolbarDemo());
     additionalDemos.addAll(getActionBarDemos());
     return additionalDemos;

--- a/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_fragment.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_fragment.xml
@@ -32,11 +32,8 @@
         android:id="@+id/collapsingtoolbarlayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:collapsedTitleTextAppearance="?attr/textAppearanceHeadline6"
-        app:expandedTitleGravity="bottom"
-        app:expandedTitleMarginBottom="24dp"
-        app:expandedTitleMarginStart="16dp"
-        app:expandedTitleTextAppearance="?attr/textAppearanceHeadline5"
+      app:collapsedTitleTextAppearance="@style/TextAppearance.Test.CollapsingToolbar.Collapsed"
+      app:expandedTitleTextAppearance="@style/TextAppearance.Test.CollapsingToolbar.Expanded"
         app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
 
       <androidx.appcompat.widget.Toolbar
@@ -46,7 +43,7 @@
           android:layout_height="?attr/actionBarSize"
           android:elevation="0dp"
           app:layout_collapseMode="pin"
-          app:title="@string/cat_topappbar_collapsing_demo_toolbar_title"/>
+          app:title="Lorem Ipsum"/>
     </com.google.android.material.appbar.CollapsingToolbarLayout>
   </com.google.android.material.appbar.AppBarLayout>
 

--- a/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_multiline_fragment.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_multiline_fragment.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+  <com.google.android.material.appbar.AppBarLayout
+      android:id="@+id/appbarlayout"
+      android:layout_width="match_parent"
+      android:layout_height="@dimen/cat_topappbar_tall_toolbar_height"
+      android:fitsSystemWindows="true">
+
+    <com.google.android.material.appbar.CollapsingToolbarLayout
+        android:id="@+id/collapsingtoolbarlayout"
+        style="?attr/catalogToolbarStyle"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:collapsedTitleTextAppearance="?attr/textAppearanceHeadline6"
+        app:expandedTitleGravity="bottom"
+        app:expandedTitleMarginBottom="24dp"
+        app:expandedTitleMarginStart="16dp"
+        app:expandedTitleTextAppearance="?attr/textAppearanceHeadline5"
+        app:maxLines="3"
+        app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
+
+      <androidx.appcompat.widget.Toolbar
+          android:id="@+id/toolbar"
+          style="?attr/catalogToolbarWithCloseButtonStyle"
+          android:layout_width="match_parent"
+          android:layout_height="?attr/actionBarSize"
+          android:elevation="0dp"
+          app:layout_collapseMode="pin"
+          app:title="@string/cat_topappbar_collapsing_multiline_demo_toolbar_title"/>
+    </com.google.android.material.appbar.CollapsingToolbarLayout>
+  </com.google.android.material.appbar.AppBarLayout>
+
+  <androidx.core.widget.NestedScrollView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <include layout="@layout/cat_topappbar_filler_text_view"/>
+  </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_multiline_fragment.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_multiline_fragment.xml
@@ -39,6 +39,7 @@
         app:expandedTitleMarginBottom="24dp"
         app:expandedTitleMarginStart="16dp"
         app:expandedTitleTextAppearance="?attr/textAppearanceHeadline5"
+        app:multiline="true"
         app:maxLines="3"
         app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
 

--- a/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_multiline_fragment.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_multiline_fragment.xml
@@ -26,7 +26,8 @@
       android:id="@+id/appbarlayout"
       android:layout_width="match_parent"
       android:layout_height="@dimen/cat_topappbar_tall_toolbar_height"
-      android:fitsSystemWindows="true">
+      android:fitsSystemWindows="true"
+      android:theme="@style/ThemeOverlay.Catalog.AppBarLayout">
 
     <com.google.android.material.appbar.CollapsingToolbarLayout
         android:id="@+id/collapsingtoolbarlayout"

--- a/catalog/java/io/material/catalog/topappbar/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/values/strings.xml
@@ -21,6 +21,7 @@
   <string name="cat_topappbar_scrolling_title">Scrolling Demo</string>
   <string name="cat_topappbar_scrolling_transparent_title">Scrolling Demo (transparent status bar)</string>
   <string name="cat_topappbar_collapsing_title">Collapsing Demo</string>
+  <string name="cat_topappbar_collapsing_multiline_title">Collapsing Demo (Multiline title)</string>
   <string name="cat_topappbar_toolbar_title" translatable="false">Toolbar Demo</string>
   <string name="cat_topappbar_action_bar_title">Action Bar Demo</string>
   <string name="cat_topappbar_dark_action_bar_title">Dark Action Bar Demo</string>
@@ -35,6 +36,8 @@
   <string name="cat_topappbar_main_demo_toolbar_title">Regular Title</string>
   <string name="cat_topappbar_scrolling_demo_toolbar_title">Scrolling Title</string>
   <string name="cat_topappbar_collapsing_demo_toolbar_title">Collapsing Title</string>
+  <string name="cat_topappbar_collapsing_multiline_demo_toolbar_title">This Collapsing Title is
+    extremely long and thus will be displayed in multiple lines.</string>
 
   <string name="cat_topappbar_edit_menu_item_title">Edit</string>
   <string name="cat_topappbar_favorite_menu_item_title">Favorite</string>

--- a/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
+++ b/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
@@ -217,6 +217,20 @@ public class CollapsingToolbarLayout extends FrameLayout {
           a.getResourceId(R.styleable.CollapsingToolbarLayout_collapsedTitleTextAppearance, 0));
     }
 
+    if (a.hasValue(R.styleable.CollapsingToolbarLayout_maxLines)) {
+      collapsingTextHelper.setMaxLines(a.getInt(R.styleable.CollapsingToolbarLayout_maxLines, 1));
+    }
+
+    if (a.hasValue(R.styleable.CollapsingToolbarLayout_lineSpacingExtra)) {
+      collapsingTextHelper.setLineSpacingExtra(
+          a.getDimensionPixelSize(R.styleable.CollapsingToolbarLayout_lineSpacingExtra, 0));
+    }
+
+    if (a.hasValue(R.styleable.CollapsingToolbarLayout_lineSpacingMultiplier)) {
+      collapsingTextHelper.setLineSpacingMultiplier(
+          a.getDimensionPixelSize(R.styleable.CollapsingToolbarLayout_lineSpacingMultiplier, 1));
+    }
+
     scrimVisibleHeightTrigger =
         a.getDimensionPixelSize(R.styleable.CollapsingToolbarLayout_scrimVisibleHeightTrigger, -1);
 
@@ -1041,6 +1055,48 @@ public class CollapsingToolbarLayout extends FrameLayout {
   public void setExpandedTitleMarginBottom(int margin) {
     expandedMarginBottom = margin;
     requestLayout();
+  }
+
+  /**
+   * Sets the maximum number of lines to display in the expanded state.
+   */
+  public void setMaxLines(int maxLines) {
+    collapsingTextHelper.setMaxLines(maxLines);
+  }
+
+  /**
+   * Gets the maximum number of lines to display in the expanded state.
+   */
+  public int getMaxLines() {
+    return collapsingTextHelper.getMaxLines();
+  }
+
+  /**
+   * Set line spacing extra applied to each line in the expanded state.
+   */
+  void setLineSpacingExtra(float lineSpacingExtra) {
+    collapsingTextHelper.setLineSpacingExtra(lineSpacingExtra);
+  }
+
+  /**
+   * Gets the line spacing extra applied to each line in the expanded state.
+   */
+  float getLineSpacingExtra() {
+    return collapsingTextHelper.getLineSpacingExtra();
+  }
+
+  /**
+   * Sets the line spacing multiplier applied to each line in the expanded state.
+   */
+  void setLineSpacingMultiplier(float lineSpacingMultiplier) {
+    collapsingTextHelper.setLineSpacingMultiplier(lineSpacingMultiplier);
+  }
+
+  /**
+   * Gets the line spacing multiplier applied to each line in the expanded state.
+   */
+  float getLineSpacingMultiplier() {
+    return collapsingTextHelper.getLineSpacingMultiplier();
   }
 
   /**

--- a/lib/java/com/google/android/material/appbar/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/appbar/res/values/attrs.xml
@@ -194,6 +194,12 @@
     <attr name="titleEnabled" format="boolean"/>
     <!-- The title to show when titleEnabled is set to true. -->
     <attr name="title"/>
+    <!-- The maximum number of lines of text to show in the expanded state -->
+    <attr name="maxLines" format="integer" />
+    <!-- Extra spacing between lines of text. -->
+    <attr name="lineSpacingExtra" format="float"/>
+    <!-- Extra spacing between lines of text, as a multiplier. -->
+    <attr name="lineSpacingMultiplier" format="float"/>
   </declare-styleable>
 
   <declare-styleable name="CollapsingToolbarLayout_Layout">

--- a/lib/java/com/google/android/material/appbar/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/appbar/res/values/attrs.xml
@@ -194,6 +194,8 @@
     <attr name="titleEnabled" format="boolean"/>
     <!-- The title to show when titleEnabled is set to true. -->
     <attr name="title"/>
+    <!-- Enables support for multiple lines in the expanded state -->
+    <attr name="multiline" format="boolean" />
     <!-- The maximum number of lines of text to show in the expanded state -->
     <attr name="maxLines" format="integer" />
     <!-- Extra spacing between lines of text. -->

--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -279,6 +279,9 @@ public final class CollapsingTextHelper {
   }
 
   public void setExpandedTextGravity(int gravity) {
+    if ((gravity & GravityCompat.RELATIVE_HORIZONTAL_GRAVITY_MASK) == 0) {
+      gravity |= GravityCompat.START;
+    }
     if (expandedTextGravity != gravity) {
       expandedTextGravity = gravity;
       recalculate();
@@ -290,6 +293,9 @@ public final class CollapsingTextHelper {
   }
 
   public void setCollapsedTextGravity(int gravity) {
+    if ((gravity & GravityCompat.RELATIVE_HORIZONTAL_GRAVITY_MASK) == 0) {
+      gravity |= GravityCompat.START;
+    }
     if (collapsedTextGravity != gravity) {
       collapsedTextGravity = gravity;
       recalculate();

--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -720,17 +720,18 @@ public final class CollapsingTextHelper {
           canvas.drawText(textToDrawCollapsed, 0, textToDrawCollapsed.length(), x,
               y - ascent / scale, textPaint);
         } else {
+          int originalAlpha = textPaint.getAlpha();
           // positon expanded text appropriately
           canvas.translate(currentExpandedX, y);
           // Expanded text
-          textPaint.setAlpha((int) (expandedTextBlend * 255));
+          textPaint.setAlpha((int) (expandedTextBlend * originalAlpha));
           textLayout.draw(canvas);
 
           // position the overlays
           canvas.translate(x - currentExpandedX, 0);
 
           // Collapsed text
-          textPaint.setAlpha((int) (collapsedTextBlend * 255));
+          textPaint.setAlpha((int) (collapsedTextBlend * originalAlpha));
           canvas.drawText(textToDrawCollapsed, 0, textToDrawCollapsed.length(), 0,
               -ascent / scale, textPaint);
           // Remove ellipsis for Cross-section animation
@@ -738,8 +739,8 @@ public final class CollapsingTextHelper {
           if (tmp.endsWith("\u2026")) {
             tmp = tmp.substring(0, tmp.length() - 1);
           }
-          // Cross-section between both texts (should stay at alpha = 255)
-          textPaint.setAlpha(255);
+          // Cross-section between both texts (should stay at original alpha)
+          textPaint.setAlpha(originalAlpha);
           canvas.drawText(tmp, 0, textLayout.getLineEnd(0) <= tmp.length() ?
               textLayout.getLineEnd(0) : tmp.length(), 0, -ascent / scale, textPaint);
         }

--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -797,11 +797,6 @@ public final class CollapsingTextHelper {
         scale = textSize / expandedTextSize;
       }
 
-      final float textSizeRatio = collapsedTextSize / expandedTextSize;
-      // This is the size of the expanded bounds when it is scaled to match the
-      // collapsed text size
-      final float scaledDownWidth = expandedWidth * textSizeRatio;
-
       availableWidth = expandedWidth;
       maxLines = this.maxLines;
     }

--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -624,7 +624,7 @@ public final class CollapsingTextHelper {
     textHeight = textLayout != null ? textLayout.getHeight() : 0;
     switch (expandedAbsGravity & Gravity.VERTICAL_GRAVITY_MASK) {
       case Gravity.BOTTOM:
-        expandedDrawY = expandedBounds.bottom - textHeight;
+        expandedDrawY = expandedBounds.bottom - textHeight + textPaint.descent();
         break;
       case Gravity.TOP:
         expandedDrawY = expandedBounds.top;

--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -659,7 +659,8 @@ public final class CollapsingTextHelper {
       float x = currentDrawX;
       float y = currentDrawY;
 
-      final boolean drawTexture = useTexture && expandedTitleTexture != null;
+      final boolean drawTexture = useTexture && expandedTitleTexture != null
+          && collapsedTitleTexture != null && crossSectionTitleTexture != null;
 
       final float ascent;
       // Update the TextPaint to the current text size

--- a/lib/java/com/google/android/material/internal/MultilineCollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/MultilineCollapsingTextHelper.java
@@ -36,6 +36,8 @@ import androidx.core.math.MathUtils;
 import androidx.core.text.TextDirectionHeuristicsCompat;
 import androidx.core.view.GravityCompat;
 import androidx.core.view.ViewCompat;
+import android.text.Layout;
+import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.view.Gravity;
@@ -51,7 +53,7 @@ import com.google.android.material.resources.TextAppearance;
  * @hide
  */
 @RestrictTo(LIBRARY_GROUP)
-public final class CollapsingTextHelper {
+public final class MultilineCollapsingTextHelper {
 
   // Pre-JB-MR2 doesn't support HW accelerated canvas scaled text so we will workaround it
   // by using our own texture
@@ -97,16 +99,20 @@ public final class CollapsingTextHelper {
 
   @Nullable private CharSequence text;
   @Nullable private CharSequence textToDraw;
+  @Nullable private CharSequence textToDrawCollapsed;
   private boolean isRtl;
 
   private boolean useTexture;
   @Nullable private Bitmap expandedTitleTexture;
+  @Nullable private Bitmap collapsedTitleTexture;
+  @Nullable private Bitmap crossSectionTitleTexture;
   private Paint texturePaint;
-  private float textureAscent;
-  private float textureDescent;
 
   private float scale;
   private float currentTextSize;
+  private float collapsedTextBlend;
+  private float expandedTextBlend;
+  private float expandedFirstLineDrawX;
 
   private int[] state;
 
@@ -128,7 +134,12 @@ public final class CollapsingTextHelper {
   private float expandedShadowDy;
   private ColorStateList expandedShadowColor;
 
-  public CollapsingTextHelper(View view) {
+  private StaticLayout textLayout;
+  private int maxLines = 1;
+  private float lineSpacingExtra = 0;
+  private float lineSpacingMultiplier = 1;
+
+  public MultilineCollapsingTextHelper(View view) {
     this.view = view;
 
     textPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG | Paint.SUBPIXEL_TEXT_FLAG);
@@ -268,6 +279,9 @@ public final class CollapsingTextHelper {
   }
 
   public void setExpandedTextGravity(int gravity) {
+    if ((gravity & GravityCompat.RELATIVE_HORIZONTAL_GRAVITY_MASK) == 0) {
+      gravity |= GravityCompat.START;
+    }
     if (expandedTextGravity != gravity) {
       expandedTextGravity = gravity;
       recalculate();
@@ -279,6 +293,9 @@ public final class CollapsingTextHelper {
   }
 
   public void setCollapsedTextGravity(int gravity) {
+    if ((gravity & GravityCompat.RELATIVE_HORIZONTAL_GRAVITY_MASK) == 0) {
+      gravity |= GravityCompat.START;
+    }
     if (collapsedTextGravity != gravity) {
       collapsedTextGravity = gravity;
       recalculate();
@@ -354,6 +371,42 @@ public final class CollapsingTextHelper {
     textAppearance.getFontAsync(view.getContext(), expandedFontCallback);
 
     recalculate();
+  }
+
+  public void setMaxLines(int maxLines) {
+    if (maxLines != this.maxLines) {
+      this.maxLines = maxLines;
+      clearTexture();
+      recalculate();
+    }
+  }
+
+  public int getMaxLines() {
+    return maxLines;
+  }
+
+  public void setLineSpacingExtra(float lineSpacingExtra) {
+    if (lineSpacingExtra != this.lineSpacingExtra) {
+      this.lineSpacingExtra = lineSpacingExtra;
+      clearTexture();
+      recalculate();
+    }
+  }
+
+  public float getLineSpacingExtra() {
+    return lineSpacingExtra;
+  }
+
+  public void setLineSpacingMultiplier(float lineSpacingMultiplier) {
+    if (lineSpacingMultiplier != this.lineSpacingMultiplier) {
+      this.lineSpacingMultiplier = lineSpacingMultiplier;
+      clearTexture();
+      recalculate();
+    }
+  }
+
+  public float getLineSpacingMultiplier() {
+    return lineSpacingMultiplier;
   }
 
   public void setCollapsedTypeface(Typeface typeface) {
@@ -468,6 +521,11 @@ public final class CollapsingTextHelper {
     setInterpolatedTextSize(
         lerp(expandedTextSize, collapsedTextSize, fraction, textSizeInterpolator));
 
+    setCollapsedTextBlend(1 - lerp(0, 1, 1 - fraction, AnimationUtils
+        .FAST_OUT_SLOW_IN_INTERPOLATOR));
+    setExpandedTextBlend(lerp(1, 0, fraction, AnimationUtils
+        .FAST_OUT_SLOW_IN_INTERPOLATOR));
+
     if (collapsedTextColor != expandedTextColor) {
       // If the collapsed and expanded text colors are different, blend them based on the
       // fraction
@@ -513,26 +571,30 @@ public final class CollapsingTextHelper {
 
     // We then calculate the collapsed text size, using the same logic
     calculateUsingTextSize(collapsedTextSize);
-    float width =
-        textToDraw != null ? textPaint.measureText(textToDraw, 0, textToDraw.length()) : 0;
+    textToDrawCollapsed = textToDraw;
+    float width = textToDrawCollapsed != null ?
+        textPaint.measureText(textToDrawCollapsed, 0, textToDrawCollapsed.length()) : 0;
     final int collapsedAbsGravity =
         GravityCompat.getAbsoluteGravity(
             collapsedTextGravity,
             isRtl ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR);
+
+    float textHeight = textLayout != null ? textLayout.getHeight() : 0;
+
     switch (collapsedAbsGravity & Gravity.VERTICAL_GRAVITY_MASK) {
       case Gravity.BOTTOM:
-        collapsedDrawY = collapsedBounds.bottom;
+        collapsedDrawY = collapsedBounds.bottom - textHeight;
         break;
       case Gravity.TOP:
-        collapsedDrawY = collapsedBounds.top - textPaint.ascent();
+        collapsedDrawY = collapsedBounds.top;
         break;
       case Gravity.CENTER_VERTICAL:
       default:
-        float textHeight = textPaint.descent() - textPaint.ascent();
-        float textOffset = (textHeight / 2) - textPaint.descent();
-        collapsedDrawY = collapsedBounds.centerY() + textOffset;
+        float textOffset = (textHeight / 2);
+        collapsedDrawY = collapsedBounds.centerY() - textOffset;
         break;
     }
+
     switch (collapsedAbsGravity & GravityCompat.RELATIVE_HORIZONTAL_GRAVITY_MASK) {
       case Gravity.CENTER_HORIZONTAL:
         collapsedDrawX = collapsedBounds.centerX() - (width / 2);
@@ -547,23 +609,30 @@ public final class CollapsingTextHelper {
     }
 
     calculateUsingTextSize(expandedTextSize);
-    width = textToDraw != null ? textPaint.measureText(textToDraw, 0, textToDraw.length()) : 0;
+    if (isRtl) {
+      // fallback for RTL
+      width = textToDrawCollapsed != null ? textPaint.measureText(textToDrawCollapsed, 0,
+          textToDrawCollapsed.length()) : 0;
+    } else {
+      width = textLayout != null ? textLayout.getLineWidth(0) : 0;
+    }
+    expandedFirstLineDrawX = textLayout != null ? textLayout.getLineLeft(0) : 0;
     final int expandedAbsGravity =
         GravityCompat.getAbsoluteGravity(
             expandedTextGravity,
             isRtl ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR);
+    textHeight = textLayout != null ? textLayout.getHeight() : 0;
     switch (expandedAbsGravity & Gravity.VERTICAL_GRAVITY_MASK) {
       case Gravity.BOTTOM:
-        expandedDrawY = expandedBounds.bottom;
+        expandedDrawY = expandedBounds.bottom - textHeight + textPaint.descent();
         break;
       case Gravity.TOP:
-        expandedDrawY = expandedBounds.top - textPaint.ascent();
+        expandedDrawY = expandedBounds.top;
         break;
       case Gravity.CENTER_VERTICAL:
       default:
-        float textHeight = textPaint.descent() - textPaint.ascent();
-        float textOffset = (textHeight / 2) - textPaint.descent();
-        expandedDrawY = expandedBounds.centerY() + textOffset;
+        float textOffset = (textHeight / 2);
+        expandedDrawY = expandedBounds.centerY() - textOffset;
         break;
     }
     switch (expandedAbsGravity & GravityCompat.RELATIVE_HORIZONTAL_GRAVITY_MASK) {
@@ -602,37 +671,79 @@ public final class CollapsingTextHelper {
       float x = currentDrawX;
       float y = currentDrawY;
 
-      final boolean drawTexture = useTexture && expandedTitleTexture != null;
+      final boolean drawTexture = useTexture && expandedTitleTexture != null
+          && collapsedTitleTexture != null && crossSectionTitleTexture != null;
 
       final float ascent;
-      final float descent;
+      // Update the TextPaint to the current text size
+      textPaint.setTextSize(currentTextSize);
+
       if (drawTexture) {
-        ascent = textureAscent * scale;
-        descent = textureDescent * scale;
+        ascent = 0;
       } else {
         ascent = textPaint.ascent() * scale;
-        descent = textPaint.descent() * scale;
       }
 
       if (DEBUG_DRAW) {
         // Just a debug tool, which drawn a magenta rect in the text bounds
-        canvas.drawRect(
-            currentBounds.left, y + ascent, currentBounds.right, y + descent, DEBUG_DRAW_PAINT);
+        canvas.drawRect(currentBounds.left, y, currentBounds.right,
+            y + textLayout.getHeight() * scale,
+            DEBUG_DRAW_PAINT);
       }
-
-      if (drawTexture) {
-        y += ascent;
-      }
-
       if (scale != 1f) {
         canvas.scale(scale, scale, x, y);
       }
 
+      // Compute where to draw textLayout for this frame
+      final float currentExpandedX =
+          currentDrawX + textLayout.getLineLeft(0) - expandedFirstLineDrawX * 2;
       if (drawTexture) {
         // If we should use a texture, draw it instead of text
-        canvas.drawBitmap(expandedTitleTexture, x, y, texturePaint);
+        if (isRtl) {
+          // fallback for RTL: draw only collapsed text
+          texturePaint.setAlpha(255);
+          canvas.drawBitmap(collapsedTitleTexture, x, y, texturePaint);
+        } else {
+          // Expanded text
+          texturePaint.setAlpha((int) (expandedTextBlend * 255));
+          canvas.drawBitmap(expandedTitleTexture, currentExpandedX, y, texturePaint);
+          // Collapsed text
+          texturePaint.setAlpha((int) (collapsedTextBlend * 255));
+          canvas.drawBitmap(collapsedTitleTexture, x, y, texturePaint);
+          // Cross-section between both texts (should stay at alpha = 255)
+          texturePaint.setAlpha(255);
+          canvas.drawBitmap(crossSectionTitleTexture, x, y, texturePaint);
+        }
       } else {
-        canvas.drawText(textToDraw, 0, textToDraw.length(), x, y, textPaint);
+        if (isRtl) {
+          // fallback for RTL: draw only collapsed text
+          canvas.drawText(textToDrawCollapsed, 0, textToDrawCollapsed.length(), x,
+              y - ascent / scale, textPaint);
+        } else {
+          int originalAlpha = textPaint.getAlpha();
+          // positon expanded text appropriately
+          canvas.translate(currentExpandedX, y);
+          // Expanded text
+          textPaint.setAlpha((int) (expandedTextBlend * originalAlpha));
+          textLayout.draw(canvas);
+
+          // position the overlays
+          canvas.translate(x - currentExpandedX, 0);
+
+          // Collapsed text
+          textPaint.setAlpha((int) (collapsedTextBlend * originalAlpha));
+          canvas.drawText(textToDrawCollapsed, 0, textToDrawCollapsed.length(), 0,
+              -ascent / scale, textPaint);
+          // Remove ellipsis for Cross-section animation
+          String tmp = textToDrawCollapsed.toString().trim();
+          if (tmp.endsWith("\u2026")) {
+            tmp = tmp.substring(0, tmp.length() - 1);
+          }
+          // Cross-section between both texts (should stay at original alpha)
+          textPaint.setAlpha(originalAlpha);
+          canvas.drawText(tmp, 0, textLayout.getLineEnd(0) <= tmp.length() ?
+              textLayout.getLineEnd(0) : tmp.length(), 0, -ascent / scale, textPaint);
+        }
       }
     }
 
@@ -657,8 +768,20 @@ public final class CollapsingTextHelper {
     if (useTexture) {
       // Make sure we have an expanded texture if needed
       ensureExpandedTexture();
+      ensureCollapsedTexture();
+      ensureCrossSectionTexture();
     }
 
+    ViewCompat.postInvalidateOnAnimation(view);
+  }
+
+  private void setCollapsedTextBlend(float blend) {
+    collapsedTextBlend = blend;
+    ViewCompat.postInvalidateOnAnimation(view);
+  }
+
+  private void setExpandedTextBlend(float blend) {
+    expandedTextBlend = blend;
     ViewCompat.postInvalidateOnAnimation(view);
   }
 
@@ -674,6 +797,7 @@ public final class CollapsingTextHelper {
     final float availableWidth;
     final float newTextSize;
     boolean updateDrawText = false;
+    int maxLines;
 
     if (isClose(textSize, collapsedTextSize)) {
       newTextSize = collapsedTextSize;
@@ -683,6 +807,7 @@ public final class CollapsingTextHelper {
         updateDrawText = true;
       }
       availableWidth = collapsedWidth;
+      maxLines = 1;
     } else {
       newTextSize = expandedTextSize;
       if (currentTypeface != expandedTypeface) {
@@ -697,20 +822,9 @@ public final class CollapsingTextHelper {
         scale = textSize / expandedTextSize;
       }
 
-      final float textSizeRatio = collapsedTextSize / expandedTextSize;
-      // This is the size of the expanded bounds when it is scaled to match the
-      // collapsed text size
-      final float scaledDownWidth = expandedWidth * textSizeRatio;
-
-      if (scaledDownWidth > collapsedWidth) {
-        // If the scaled down size is larger than the actual collapsed width, we need to
-        // cap the available width so that when the expanded text scales down, it matches
-        // the collapsed width
-        availableWidth = Math.min(collapsedWidth / textSizeRatio, expandedWidth);
-      } else {
-        // Otherwise we'll just use the expanded width
-        availableWidth = expandedWidth;
-      }
+      availableWidth = expandedWidth;
+      // fallback for RTL: draw only one line
+      maxLines = isRtl ? 1 : this.maxLines;
     }
 
     if (availableWidth > 0) {
@@ -725,13 +839,56 @@ public final class CollapsingTextHelper {
       // Use linear text scaling if we're scaling the canvas
       textPaint.setLinearText(scale != 1f);
 
-      // If we don't currently have text to draw, or the text size has changed, ellipsize...
-      final CharSequence title =
-          TextUtils.ellipsize(text, textPaint, availableWidth, TextUtils.TruncateAt.END);
-      if (!TextUtils.equals(title, textToDraw)) {
-        textToDraw = title;
+      StaticLayout layout = new StaticLayout(text, textPaint, (int) availableWidth,
+          Layout.Alignment.ALIGN_NORMAL, lineSpacingMultiplier, lineSpacingExtra, false);
+      CharSequence truncatedText;
+      if (layout.getLineCount() > maxLines) {
+        int lastLine = maxLines - 1;
+        CharSequence textBefore =
+            lastLine > 0 ? text.subSequence(0, layout.getLineEnd(lastLine - 1)) : "";
+        CharSequence lineText = text.subSequence(layout.getLineStart(lastLine),
+            layout.getLineEnd(lastLine));
+        // if last char in line is space, move it behind the ellipsis
+        CharSequence lineEnd = "";
+        if (lineText.charAt(lineText.length() - 1) == ' ') {
+          lineEnd = lineText.subSequence(lineText.length() - 1, lineText.length());
+          lineText = lineText.subSequence(0, lineText.length() - 1);
+        }
+        // insert ellipsis character
+        lineText = TextUtils.concat(lineText, "\u2026", lineEnd);
+        // if the text is too long, truncate it
+        CharSequence truncatedLineText = TextUtils.ellipsize(lineText, textPaint,
+            availableWidth, TextUtils.TruncateAt.END);
+        truncatedText = TextUtils.concat(textBefore, truncatedLineText);
+
+      } else {
+        truncatedText = text;
+      }
+      if (!TextUtils.equals(truncatedText, textToDraw)) {
+        textToDraw = truncatedText;
         isRtl = calculateIsRtl(textToDraw);
       }
+
+      final Layout.Alignment alignment;
+
+      // Don't rectify gravity for RTL languages, Layout.Alignment does it already.
+      switch (expandedTextGravity & GravityCompat.RELATIVE_HORIZONTAL_GRAVITY_MASK) {
+        case Gravity.CENTER_HORIZONTAL:
+          alignment = Layout.Alignment.ALIGN_CENTER;
+          break;
+        case Gravity.RIGHT:
+        case Gravity.END:
+          alignment = Layout.Alignment.ALIGN_OPPOSITE;
+          break;
+        case Gravity.LEFT:
+        case Gravity.START:
+        default:
+          alignment = Layout.Alignment.ALIGN_NORMAL;
+          break;
+      }
+
+      textLayout = new StaticLayout(textToDraw, textPaint, (int) availableWidth,
+          alignment, lineSpacingMultiplier, lineSpacingExtra, false);
     }
   }
 
@@ -741,11 +898,8 @@ public final class CollapsingTextHelper {
     }
 
     calculateOffsets(0f);
-    textureAscent = textPaint.ascent();
-    textureDescent = textPaint.descent();
-
-    final int w = Math.round(textPaint.measureText(textToDraw, 0, textToDraw.length()));
-    final int h = Math.round(textureDescent - textureAscent);
+    final int w = textLayout.getWidth();
+    final int h = textLayout.getHeight();
 
     if (w <= 0 || h <= 0) {
       return; // If the width or height are 0, return
@@ -754,8 +908,56 @@ public final class CollapsingTextHelper {
     expandedTitleTexture = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
 
     Canvas c = new Canvas(expandedTitleTexture);
-    c.drawText(textToDraw, 0, textToDraw.length(), 0, h - textPaint.descent(), textPaint);
+    textLayout.draw(c);
 
+    if (texturePaint == null) {
+      // Make sure we have a paint
+      texturePaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
+    }
+  }
+
+  private void ensureCollapsedTexture() {
+    if (collapsedTitleTexture != null || collapsedBounds.isEmpty()
+        || TextUtils.isEmpty(textToDraw)) {
+      return;
+    }
+    calculateOffsets(0f);
+    final int w = Math.round(textPaint.measureText(textToDraw, 0, textToDraw.length()));
+    final int h = Math.round(textPaint.descent() - textPaint.ascent());
+    if (w <= 0 && h <= 0) {
+      return; // If the width or height are 0, return
+    }
+    collapsedTitleTexture = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+    Canvas c = new Canvas(collapsedTitleTexture);
+    c.drawText(textToDrawCollapsed, 0, textToDrawCollapsed.length(), 0,
+        -textPaint.ascent() / scale, textPaint);
+    if (texturePaint == null) {
+      // Make sure we have a paint
+      texturePaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
+    }
+  }
+
+  private void ensureCrossSectionTexture() {
+    if (crossSectionTitleTexture != null || collapsedBounds.isEmpty()
+        || TextUtils.isEmpty(textToDraw)) {
+      return;
+    }
+    calculateOffsets(0f);
+    final int w = Math.round(textPaint.measureText(textToDraw, textLayout.getLineStart(0),
+        textLayout.getLineEnd(0)));
+    final int h = Math.round(textPaint.descent() - textPaint.ascent());
+    if (w <= 0 && h <= 0) {
+      return; // If the width or height are 0, return
+    }
+    crossSectionTitleTexture = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+    Canvas c = new Canvas(crossSectionTitleTexture);
+    String tmp = textToDrawCollapsed.toString().trim();
+    if (tmp.endsWith("\u2026")) {
+      tmp = tmp.substring(0, tmp.length() - 1);
+    }
+    c.drawText(tmp, 0,
+        textLayout.getLineEnd(0) <= tmp.length() ? textLayout.getLineEnd(0) : tmp.length(), 0,
+        -textPaint.ascent() / scale, textPaint);
     if (texturePaint == null) {
       // Make sure we have a paint
       texturePaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
@@ -794,6 +996,14 @@ public final class CollapsingTextHelper {
     if (expandedTitleTexture != null) {
       expandedTitleTexture.recycle();
       expandedTitleTexture = null;
+    }
+    if (collapsedTitleTexture != null) {
+      collapsedTitleTexture.recycle();
+      collapsedTitleTexture = null;
+    }
+    if (crossSectionTitleTexture != null) {
+      crossSectionTitleTexture.recycle();
+      crossSectionTitleTexture = null;
     }
   }
 


### PR DESCRIPTION
closes #6 and was also discussed in https://issuetracker.google.com/issues/136120586, where you said you would welcome a PR.

We have implemented the possibility to use multiple lines of text as a title in the collapsing app bar. The additional lines are displayed in the expanded state and will be hidden in the collapsed state, like this:

![Demo image](https://raw.githubusercontent.com/opacapp/multiline-collapsingtoolbar/master/demo.gif)

This is based on the work of @raphaelm and me as well as a few [contributors](https://github.com/opacapp/multiline-collapsingtoolbar/graphs/contributors) in the [multiline-collapsingtoolbar](https://github.com/opacapp/multiline-collapsingtoolbar) library, which is based on the CollapsingToolbarLayout code of the Android Design Support library (predecessor of Material Components) and has already become quite popular.

However, as discussed in https://github.com/opacapp/multiline-collapsingtoolbar/issues/62, it would be quite difficult to update our library with support for the new Material Components and AndroidX libraries, as many of the interfaces we are calling are not part of the public API and thus can only be called from the Material Components library itself. Therefore, it would be great if this feature could instead be included in the official Material Components library.

In addition to copying over the adjustments from our library into the CollapsingTextHelper codebase, I also added a demo in the catalog app to showcase this new feature.