### PR TITLE
[TextInputLayout] Public method for borderStroke to be able to change colors dynamically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: generic
 
 env:
   global:
+  - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
   - ABI="google_apis;armeabi-v7a"
   - BUILD_TOOLS_VERSION=28.0.3
   - ADB_INSTALL_TIMEOUT=25
@@ -14,6 +15,10 @@ env:
     - EMULATOR_API=24
 
 install:
+  - sudo apt-get -y remove default-jdk default-jre default-jdk-headless default-jre-headless ca-certificates-java openjdk-8-jdk openjdk-8-jdk-headless openjdk-8-jre openjdk-8-jre-headless
+  - sudo rm -rf /usr/local/lib/jvm
+  - sudo apt-get -y update && sudo apt-get -y install openjdk-8-jdk java-common
+  - java -version
   - export ANDROID_HOME=~/android-sdk-linux
   - wget -q "https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip" -O android-sdk-tools.zip
   - unzip -q android-sdk-tools.zip -d ${ANDROID_HOME}

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -854,7 +854,7 @@ public class TextInputLayout extends LinearLayout {
   /**
    * Set the box's stroke color state list.
    *
-   * @param boStrokeColorStateList the color state list to use for the box's stroke
+   * @param boxStrokeColorStateList the color state list to use for the box's stroke
    */
   public void setBoxStrokeColorStateList(ColorStateList boxStrokeColorStateList) {
     if (boxStrokeColorStateList != null && boxStrokeColorStateList.isStateful()) {

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -374,7 +374,7 @@ public class TextInputLayout extends LinearLayout {
   @ColorInt private final int disabledFilledBackgroundColor;
   @ColorInt private final int hoveredFilledBackgroundColor;
 
-  @ColorInt private final int disabledColor;
+  @ColorInt private int disabledColor;
 
   // Only used for testing
   private boolean hintExpanded;

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -873,7 +873,7 @@ public class TextInputLayout extends LinearLayout {
       hoveredStrokeColor =
           ContextCompat.getColor(getContext(), R.color.mtrl_textinput_hovered_box_stroke_color);
     }
-	updateTextInputBoxState();
+    updateTextInputBoxState();
   }
 
   /**

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -366,8 +366,8 @@ public class TextInputLayout extends LinearLayout {
   private ColorStateList defaultHintTextColor;
   private ColorStateList focusedTextColor;
 
-  @ColorInt private final int defaultStrokeColor;
-  @ColorInt private final int hoveredStrokeColor;
+  @ColorInt private int defaultStrokeColor;
+  @ColorInt private int hoveredStrokeColor;
   @ColorInt private int focusedStrokeColor;
 
   @ColorInt private int defaultFilledBackgroundColor;

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -852,6 +852,31 @@ public class TextInputLayout extends LinearLayout {
   }
 
   /**
+   * Set the box's stroke color state list.
+   *
+   * @param boStrokeColorStateList the color state list to use for the box's stroke
+   */
+  public void setBoxStrokeColorStateList(ColorStateList boxStrokeColorStateList) {
+    if (boxStrokeColorStateList != null && boxStrokeColorStateList.isStateful()) {
+      defaultStrokeColor = boxStrokeColorStateList.getDefaultColor();
+      disabledColor =
+          boxStrokeColorStateList.getColorForState(new int[] {-android.R.attr.state_enabled}, -1);
+      hoveredStrokeColor =
+          boxStrokeColorStateList.getColorForState(new int[] {android.R.attr.state_hovered}, -1);
+      focusedStrokeColor =
+          boxStrokeColorStateList.getColorForState(new int[] {android.R.attr.state_focused}, -1);
+    } else {
+      focusedStrokeColor = boxStrokeColorStateList.getDefaultColor();
+      defaultStrokeColor =
+          ContextCompat.getColor(getContext(), R.color.mtrl_textinput_default_box_stroke_color);
+      disabledColor = ContextCompat.getColor(getContext(), R.color.mtrl_textinput_disabled_color);
+      hoveredStrokeColor =
+          ContextCompat.getColor(getContext(), R.color.mtrl_textinput_hovered_box_stroke_color);
+    }
+	updateTextInputBoxState();
+  }
+
+  /**
    * Set the resource used for the filled box's background color.
    *
    * <p>Note: The background color is only supported for filled boxes. When used with box variants


### PR DESCRIPTION
Currently there are two ways to change borderStroke colors;
- via xml (initial object creation)
- by calling setBorderStrokeColor

The issue with first one is that it is not possible to change color programmatically.
The issue with second is that it changes only *focusedColor* (despite API method name and some doc).

Proposed is the public method which updates all stroke-colors (similar logic to what is in inflater).

Basically, proposed method should've been primary method of the public API (instead of setBoxStrokeColor).
But to keep backward compatibility, let's at least have additional method to override any state of the stroke color.

Thank you