### PR TITLE
[TextInputLayout] run the captionViewToShow logic whenever there is a view

### DIFF
--- a/lib/java/com/google/android/material/textfield/IndicatorViewController.java
+++ b/lib/java/com/google/android/material/textfield/IndicatorViewController.java
@@ -232,11 +232,11 @@ final class IndicatorViewController {
                 if (captionToHide == CAPTION_STATE_ERROR && errorView != null) {
                   errorView.setText(null);
                 }
+              }
 
-                if (captionViewToShow != null) {
-                  captionViewToShow.setTranslationY(0f);
-                  captionViewToShow.setAlpha(1f);
-                }
+              if (captionViewToShow != null) {
+                captionViewToShow.setTranslationY(0f);
+                captionViewToShow.setAlpha(1f);
               }
             }
 


### PR DESCRIPTION
Previously this logic would only run if there was also a captionViewToHide.
This led to the error message maintaining the -5dp translationY in my app because I was only showing the error message and not hiding any other helper message.

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.
