### PR TITLE
[MaterialButton] Fixed issue 531 by removing unnecessary calls to set compound drawables

### DIFF
--- a/lib/java/com/google/android/material/button/MaterialButton.java
+++ b/lib/java/com/google/android/material/button/MaterialButton.java
@@ -663,7 +663,18 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
       icon.setBounds(iconLeft, 0, iconLeft + width, height);
     }
 
-    if (iconGravity == ICON_GRAVITY_START || iconGravity == ICON_GRAVITY_TEXT_START) {
+    // Only update if the icon or the position has changed
+    boolean iconStart = iconGravity == ICON_GRAVITY_START || iconGravity == ICON_GRAVITY_TEXT_START;
+    Drawable[] existingDrawables = TextViewCompat.getCompoundDrawablesRelative(this);
+    Drawable drawableStart = existingDrawables[0];
+    Drawable drawableEnd = existingDrawables[2];
+    boolean hasIconChanged = iconStart && drawableStart != icon || !iconStart && drawableEnd != icon;
+
+    if(!hasIconChanged) {
+      return;
+    }
+
+    if (iconStart) {
       TextViewCompat.setCompoundDrawablesRelative(this, icon, null, null, null);
     } else {
       TextViewCompat.setCompoundDrawablesRelative(this, null, null, icon, null);

--- a/lib/java/com/google/android/material/button/MaterialButton.java
+++ b/lib/java/com/google/android/material/button/MaterialButton.java
@@ -664,17 +664,17 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
     }
 
     // Only update if the icon or the position has changed
-    boolean iconStart = iconGravity == ICON_GRAVITY_START || iconGravity == ICON_GRAVITY_TEXT_START;
+    boolean isIconStart = iconGravity == ICON_GRAVITY_START || iconGravity == ICON_GRAVITY_TEXT_START;
     Drawable[] existingDrawables = TextViewCompat.getCompoundDrawablesRelative(this);
     Drawable drawableStart = existingDrawables[0];
     Drawable drawableEnd = existingDrawables[2];
-    boolean hasIconChanged = iconStart && drawableStart != icon || !iconStart && drawableEnd != icon;
+    boolean hasIconChanged = isIconStart && drawableStart != icon || !isIconStart && drawableEnd != icon;
 
     if(!hasIconChanged) {
       return;
     }
 
-    if (iconStart) {
+    if (isIconStart) {
       TextViewCompat.setCompoundDrawablesRelative(this, icon, null, null, null);
     } else {
       TextViewCompat.setCompoundDrawablesRelative(this, null, null, icon, null);

--- a/lib/javatests/com/google/android/material/button/MaterialButtonTest.java
+++ b/lib/javatests/com/google/android/material/button/MaterialButtonTest.java
@@ -24,12 +24,15 @@ import com.google.android.material.shape.CornerFamily;
 import com.google.android.material.shape.CornerTreatment;
 import com.google.android.material.shape.CutCornerTreatment;
 import com.google.android.material.shape.ShapeAppearanceModel;
+import androidx.core.content.ContextCompat;
 import androidx.test.core.app.ApplicationProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.internal.DoNotInstrument;
+import android.graphics.drawable.Drawable;
+import android.view.View.MeasureSpec;
 
 /** Tests for {@link com.google.android.material.button.MaterialButton}. */
 @RunWith(RobolectricTestRunner.class)
@@ -82,6 +85,27 @@ public class MaterialButtonTest {
 
     assertThatCornerFamilyMatches(
         materialButton.getShapeAppearanceModel(), CUT_CORNER_FAMILY_CLASS);
+  }
+
+  @Test
+  public void setIcon_IconUpdated_whenCalledTwice() {
+    MaterialButton materialButton = new MaterialButton(context);
+    materialButton.setText("test");
+    int measureSpec =
+        MeasureSpec.makeMeasureSpec(200, MeasureSpec.AT_MOST);
+
+    Drawable drawable1 = ContextCompat.getDrawable(context, android.R.drawable.btn_plus);
+    materialButton.setIcon(drawable1);
+    materialButton.setIconGravity(MaterialButton.ICON_GRAVITY_START);
+    materialButton.measure(measureSpec, measureSpec);
+
+    assertThat(materialButton.getIcon()).isEqualTo(drawable1);
+
+    Drawable drawable2 = ContextCompat.getDrawable(context, android.R.drawable.btn_minus);
+    materialButton.setIcon(drawable2);
+    materialButton.measure(measureSpec, measureSpec);
+
+    assertThat(materialButton.getIcon()).isEqualTo(drawable2);
   }
 
   private void assertThatCornerFamilyMatches(


### PR DESCRIPTION
Closes #531 

Unnecessary calls to setCompoundDrawablesRelative caused animated state list drawables to be interrupted. If there were a checkable MaterialButton with an animated state list drawable as the icon and you also changed the text of the button then the animation wouldn't play. This PR fixes it by first checking if the compound drawables are already in the right configuration before setting it.
