### PR TITLE
[Gradle] Disable warnings on project configuration step

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,6 @@ org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableUnitTestBinaryResources=true
+
+# Disable "The option setting 'android.enableUnitTestBinaryResources=true' is experimental and unsupported" warning
+android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarnings,android.enableUnitTestBinaryResources


### PR DESCRIPTION
Resolves #551
Removes spam like this on every project configuration:
```
> Configure project :catalog
WARNING: The option setting 'android.enableUnitTestBinaryResources=true' is experimental and unsupported.
The current default is 'false'.
```

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components/blob/develop/CONTRIBUTING.md#pull-requests)
has more information and tips for a great pull request.
