### PR TITLE
Update AndroidX and Kotlin dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlinVersion = '1.3.21'
+  ext.kotlinVersion = '1.3.50'
   repositories {
     google()
     jcenter()
@@ -25,22 +25,23 @@ ext {
   targetSdkVersion = 27
 
   androidXVersions = [
-    annotation            : '1.0.1',
-    appCompat             : '1.1.0-rc01', // Needed for CSL + theme attr fixes
+    annotation            : '1.1.0',
+    appCompat             : '1.1.0',
     cardView              : '1.0.0',
+    constraintlayout      : '1.1.3',
     coordinatorlayout     : '1.1.0-beta01', // Needed for NestedScrolling3 APIs
-    core                  : '1.1.0-rc03', // Needed for CSL + theme attr fixes
-    fragment              : '1.0.0',
-    lifecycle             : "2.0.0",
+    core                  : '1.1.0',
+    fragment              : '1.1.0',
+    lifecycle             : '2.1.0',
     recyclerView          : '1.0.0',
     recyclerViewSelection : '1.0.0',
-    transition            : '1.0.1',
-    vectorDrawable        : '1.1.0-rc01', // Needed for CSL + theme attr fixes
-    viewpager2            : '1.0.0-beta03', // Needed for TabLayout and MaterialCalendar
+    transition            : '1.1.0',
+    vectorDrawable        : '1.1.0',
+    viewpager2            : '1.0.0-beta04', // Needed for TabLayout and MaterialCalendar
   ]
 
-  testRunnerVersion = '1.1.0'
-  espressoVersion = '3.1.0'
+  testRunnerVersion = '1.2.0'
+  espressoVersion = '3.2.0'
   mockitoCoreVersion = '2.25.0'
   truthVersion = '0.45'
 
@@ -96,6 +97,8 @@ def compatibility(name) {
       return "androidx.appcompat:appcompat:${androidXVersions.appCompat}"
     case "cardview":
       return "androidx.cardview:cardview:${androidXVersions.cardView}"
+    case "constraintlayout":
+      return "androidx.constraintlayout:constraintlayout:${androidXVersions.constraintlayout}"
     case "coordinatorlayout":
       return "androidx.coordinatorlayout:coordinatorlayout:${androidXVersions.coordinatorlayout}"
     case "core":

--- a/material-theme-builder/build.gradle
+++ b/material-theme-builder/build.gradle
@@ -28,6 +28,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
     // AndroidX
-    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation compatibility("appcompat")
+    implementation compatibility("constraintlayout")
 }


### PR DESCRIPTION
This PR updates the following dependencies:

|Dependency|Previous version|New version|
|-----|-----|-----|
|`Kotlin`|1.3.21|1.3.50|
|`annotation`|1.0.1|1.1.0|
|`appCompat`|1.1.0-rc01|1.1.0|
|`core`|1.1.0-rc03|1.1.0|
|`fragment`|1.0.0|1.1.0|
|`lifecycle`|2.0.0|2.1.0|
|`transition`|1.0.1|1.1.0|
|`vectorDrawable`|1.1.0-rc01|1.1.0|
|`viewpager2`|1.0.0-beta03|1.0.0-beta04|

Now only two dependencies are used in a non-stable version: `coordinatorlayout` (1.1.0-beta01) and `viewpager2` (1.0.0-beta04).