### PR TITLE
[NavigationView] Set separator height to wrap_content

### DIFF
--- a/lib/java/com/google/android/material/internal/res/layout/design_navigation_item_separator.xml
+++ b/lib/java/com/google/android/material/internal/res/layout/design_navigation_item_separator.xml
@@ -20,7 +20,7 @@
 
   <View
       android:layout_width="match_parent"
-      android:layout_height="1dp"
+      android:layout_height="wrap_content"
       android:background="?android:attr/listDivider"/>
 
 </FrameLayout>


### PR DESCRIPTION
Fixes: #662 

As far as I'm aware, the divider drawables set by the platform themes have always specified both a width and height, so this should be safe unless the user has set `?android:listDivider` to a drawable with no intrinsic height.
