### PR TITLE
[ChipGroup] Added a method to get the selected ids

### DIFF
--- a/lib/java/com/google/android/material/chip/ChipGroup.java
+++ b/lib/java/com/google/android/material/chip/ChipGroup.java
@@ -35,6 +35,9 @@ import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import com.google.android.material.internal.FlowLayout;
 import com.google.android.material.internal.ThemeEnforcement;
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * A ChipGroup is used to hold multiple {@link Chip}s. By default, the chips are reflowed across
@@ -257,6 +260,7 @@ public class ChipGroup extends FlowLayout {
    * @return the unique id of the selected chip in this group in single selection mode
    * @see #check(int)
    * @see #clearCheck()
+   * @see #getCheckedChipIds()
    * @attr ref R.styleable#ChipGroup_checkedChip
    */
   @IdRes
@@ -265,11 +269,38 @@ public class ChipGroup extends FlowLayout {
   }
 
   /**
+   * Returns the identifiers of the selected {@link Chip}s in this group. Upon empty
+   * selection, the returned value is an empty list.
+   *
+   * @return The unique IDs of the selected {@link Chip}s in this group. When in {@link
+   *     #isSingleSelection() single selection mode}, returns a list with a single ID. When no
+   *     {@link Chip}s are selected, returns an empty list.
+   * @see #check(int)
+   * @see #clearCheck()
+   * @see #getCheckedChipId()
+   */
+  @NonNull
+  public List<Integer> getCheckedChipIds() {
+    ArrayList<Integer> checkedIds = new ArrayList<>();
+    for (int i = 0; i < getChildCount(); i++) {
+      View child = getChildAt(i);
+      if (child instanceof Chip) {
+        if (((Chip) child).isChecked()) {
+          checkedIds.add(child.getId());
+        }
+      }
+    }
+
+    return checkedIds;
+  }
+  
+  /**
    * Clears the selection. When the selection is cleared, no chip in this group is selected and
    * {@link #getCheckedChipId()} returns {@link View#NO_ID}.
    *
    * @see #check(int)
    * @see #getCheckedChipId()
+   * @see #getCheckedChipIds()
    */
   public void clearCheck() {
     protectFromCheckedChange = true;

--- a/lib/java/com/google/android/material/chip/ChipGroup.java
+++ b/lib/java/com/google/android/material/chip/ChipGroup.java
@@ -287,6 +287,7 @@ public class ChipGroup extends FlowLayout {
       if (child instanceof Chip) {
         if (((Chip) child).isChecked()) {
           checkedIds.add(child.getId());
+          if (singleSelection) return  checkedIds;
         }
       }
     }

--- a/lib/javatests/com/google/android/material/chip/ChipGroupTest.java
+++ b/lib/javatests/com/google/android/material/chip/ChipGroupTest.java
@@ -29,6 +29,8 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.internal.DoNotInstrument;
 
+import java.util.List;
+
 /** Tests for {@link com.google.android.material.chip.ChipGroup}. */
 @RunWith(RobolectricTestRunner.class)
 @DoNotInstrument
@@ -64,5 +66,26 @@ public class ChipGroupTest {
     assertThat(chipId).isEqualTo(chipgroup.getCheckedChipId());
     chipgroup.clearCheck();
     assertThat(chipgroup.getCheckedChipId()).isEqualTo(View.NO_ID);
+  }
+
+  @Test
+  public void testMultipleCheckedChip() {
+    int chip1Id = chipgroup.getChildAt(0).getId();
+    chipgroup.check(chip1Id);
+    int chip2Id = chipgroup.getChildAt(1).getId();
+    chipgroup.check(chip2Id);
+    assertThat(chipgroup.getCheckedChipIds()).hasSize(2);
+  }
+
+  @Test
+  public void testSingleCheckedChip() {
+    chipgroup.setSingleSelection(true);
+    int chipId = chipgroup.getChildAt(2).getId();
+    chipgroup.check(chipId);
+    assertThat(chipgroup.getCheckedChipIds()).hasSize(1);
+    //check that for a single checked chip methods should be equivalent
+    Integer checkedId1 = chipgroup.getCheckedChipIds().get(0);
+    int checkedId2 = chipgroup.getCheckedChipId();
+    assertThat(checkedId1).isEqualTo(checkedId2);
   }
 }

--- a/lib/javatests/com/google/android/material/chip/res/layout/test_reflow_chipgroup.xml
+++ b/lib/javatests/com/google/android/material/chip/res/layout/test_reflow_chipgroup.xml
@@ -23,8 +23,21 @@
     android:layout_height="wrap_content"
     android:layout_margin="16dp">
   <com.google.android.material.chip.Chip
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/filter_chip"
+    android:id="@+id/chip1"
+    style="@style/Widget.MaterialComponents.Chip.Filter"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:ellipsize="end"
+    android:text="@string/chip_text"/>
+  <com.google.android.material.chip.Chip
+    android:id="@+id/chip2"
+    style="@style/Widget.MaterialComponents.Chip.Filter"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:ellipsize="end"
+    android:text="@string/chip_text"/>
+  <com.google.android.material.chip.Chip
+    android:id="@+id/chip3"
     style="@style/Widget.MaterialComponents.Chip.Filter"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"


### PR DESCRIPTION
The method returns the unique IDs of the selected chips in this group.
When in single selection mode, returns a list with a single ID. 
When no chips are selected, returns an empty list.

`closes` #197 