### PR TITLE
[MaterialDatePicker][MaterialCalender] Fix laggs after choosing year

### DIFF
--- a/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
@@ -15,13 +15,19 @@
  */
 package com.google.android.material.datepicker;
 
-import com.google.android.material.R;
-
 import android.content.Context;
 import android.graphics.Canvas;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityEvent;
+import android.widget.GridView;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
@@ -39,14 +45,10 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.RecyclerView.ItemDecoration;
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener;
 import androidx.recyclerview.widget.RecyclerView.State;
-import android.view.ContextThemeWrapper;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.View.OnClickListener;
-import android.view.ViewGroup;
-import android.view.accessibility.AccessibilityEvent;
-import android.widget.GridView;
+
+import com.google.android.material.R;
 import com.google.android.material.button.MaterialButton;
+
 import java.util.Calendar;
 
 /**
@@ -164,10 +166,12 @@ public final class MaterialCalendar<S> extends PickerFragment<S> {
 
     recyclerView = root.findViewById(R.id.mtrl_calendar_months);
 
-    LinearLayoutManager layoutManager =
-        new LinearLayoutManager(getContext(), orientation, false) {
+    SmoothCalendarLayoutManager layoutManager =
+        new SmoothCalendarLayoutManager(getContext(), orientation, false) {
           @Override
-          protected void calculateExtraLayoutSpace(@NonNull State state, @NonNull int[] ints) {
+          protected void calculateExtraLayoutSpace(
+              @NonNull State state,
+              @NonNull int[] ints) {
             if (orientation == LinearLayoutManager.HORIZONTAL) {
               ints[0] = recyclerView.getWidth();
               ints[1] = recyclerView.getWidth();
@@ -304,12 +308,12 @@ public final class MaterialCalendar<S> extends PickerFragment<S> {
     current = moveTo;
     if (jump && isForward) {
       recyclerView.scrollToPosition(moveToPosition - SMOOTH_SCROLL_MAX);
-      recyclerView.smoothScrollToPosition(moveToPosition);
+      postSmoothRecyclerViewScroll(moveToPosition);
     } else if (jump) {
       recyclerView.scrollToPosition(moveToPosition + SMOOTH_SCROLL_MAX);
-      recyclerView.smoothScrollToPosition(moveToPosition);
+      postSmoothRecyclerViewScroll(moveToPosition);
     } else {
-      recyclerView.smoothScrollToPosition(moveToPosition);
+      postSmoothRecyclerViewScroll(moveToPosition);
     }
   }
 
@@ -443,6 +447,15 @@ public final class MaterialCalendar<S> extends PickerFragment<S> {
             }
           }
         });
+  }
+
+  private void postSmoothRecyclerViewScroll(final int position) {
+    recyclerView.post(new Runnable() {
+      @Override
+      public void run() {
+        recyclerView.smoothScrollToPosition(position);
+      }
+    });
   }
 
   @NonNull

--- a/lib/java/com/google/android/material/datepicker/SmoothCalendarLayoutManager.java
+++ b/lib/java/com/google/android/material/datepicker/SmoothCalendarLayoutManager.java
@@ -1,0 +1,65 @@
+package com.google.android.material.datepicker;
+
+import android.content.Context;
+import android.graphics.PointF;
+import android.util.AttributeSet;
+import android.util.DisplayMetrics;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.LinearSmoothScroller;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * Layout manager for {@link MaterialCalendar} with smooth scroll
+ * as default one is too fast and doesn't looks like a "smooth" one
+ */
+class SmoothCalendarLayoutManager extends LinearLayoutManager {
+
+  /**
+   * Default value in {@link LinearSmoothScroller} is 25f
+   */
+  private static final float MILLISECONDS_PER_INCH = 100f;
+
+  SmoothCalendarLayoutManager(Context context) {
+    super(context);
+  }
+
+  SmoothCalendarLayoutManager(
+      Context context,
+      int orientation,
+      boolean reverseLayout) {
+    super(context, orientation, reverseLayout);
+  }
+
+  SmoothCalendarLayoutManager(
+      Context context,
+      AttributeSet attrs,
+      int defStyleAttr,
+      int defStyleRes) {
+    super(context, attrs, defStyleAttr, defStyleRes);
+  }
+
+  @Override
+  public void smoothScrollToPosition(
+      RecyclerView recyclerView,
+      RecyclerView.State state,
+      int position) {
+    final LinearSmoothScroller linearSmoothScroller =
+        new LinearSmoothScroller(recyclerView.getContext()) {
+
+          @Override
+          public PointF computeScrollVectorForPosition(int targetPosition) {
+            return SmoothCalendarLayoutManager.this
+                .computeScrollVectorForPosition(targetPosition);
+          }
+
+          @Override
+          protected float calculateSpeedPerPixel(DisplayMetrics displayMetrics) {
+            return MILLISECONDS_PER_INCH / displayMetrics.densityDpi;
+          }
+        };
+    linearSmoothScroller.setTargetPosition(position);
+    startSmoothScroll(linearSmoothScroller);
+  }
+
+}


### PR DESCRIPTION
This pull request closes #707 and also added smoother behavior for MaterialCalendar.  Anyway, it still has laggs on weak devices but looks better now. Anyway, if you prefer, I can remove SmoothCalendarLayoutManager

![device-2019-10-24-222723](https://user-images.githubusercontent.com/16122829/67518580-bbad9080-f6ad-11e9-8c60-5522d29be94c.gif)

I tried not to change other code, but it would be a great idea to rename `recyclerView` like a `calendarMonths` or smth like that. At least it will help for new ones to understand faster what this view is.