### PR TITLE
focusedStrokeColor should take into account the enabled color

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -943,7 +943,8 @@ public class TextInputLayout extends LinearLayout {
       hoveredStrokeColor =
           boxStrokeColorStateList.getColorForState(new int[] {android.R.attr.state_hovered}, -1);
       focusedStrokeColor =
-          boxStrokeColorStateList.getColorForState(new int[] {android.R.attr.state_focused}, -1);
+          boxStrokeColorStateList.getColorForState(
+              new int[] {android.R.attr.state_focused, android.R.attr.state_enabled}, -1);
     } else if (focusedStrokeColor != boxStrokeColorStateList.getDefaultColor()) {
       // If attribute boxStrokeColor is not a color state list but only a single value, its value
       // will be applied to the box's focus state.


### PR DESCRIPTION
While calculating the value for `boxStrokeColor` we should take into account the enabled color too while evaluating `focusedStrokeColor`.

This should align the stroke color logic to the one used to set the field `focusedFilledBackgroundColor` [here](https://github.com/material-components/material-components-android/blob/7bcd5f606e3c6ffe912204b4e35fc1b75d023a0b/lib/java/com/google/android/material/textfield/TextInputLayout.java#L524)

Closes #733 
