### PR TITLE
[WIP][TextInputLayout] helperText disappear after calling setError(null)

### DIFF
--- a/lib/java/com/google/android/material/textfield/IndicatorViewController.java
+++ b/lib/java/com/google/android/material/textfield/IndicatorViewController.java
@@ -141,6 +141,10 @@ final class IndicatorViewController {
     if (captionDisplayed == CAPTION_STATE_HELPER_TEXT) {
       captionToShow = CAPTION_STATE_NONE;
     }
+    if (captionToShow == captionDisplayed) {
+      // Do not proceed switching caption texts because there is no need
+      return;
+    }
     updateCaptionViewsVisibility(
         captionDisplayed, captionToShow, shouldAnimateCaptionView(helperTextView, null));
   }
@@ -170,6 +174,10 @@ final class IndicatorViewController {
         // Otherwise, just hide the error.
         captionToShow = CAPTION_STATE_NONE;
       }
+    }
+    if (captionToShow == captionDisplayed) {
+      // Do not proceed switching caption texts because there is no need
+      return;
     }
     updateCaptionViewsVisibility(
         captionDisplayed, captionToShow, shouldAnimateCaptionView(errorView, null));


### PR DESCRIPTION
This should fix the `setError(null)` bug where the helperText disappears.

The PR is in WIP because even if it solves the main problem maybe does not cover all the cases.

For example if I do something like this: 
```
inputLayout.setHelperTextEnabled(false);
inputLayout.setError("byebye");
```
The `errorView` is not showing the error text (but showing the error icon drawable) only the first time the above methods are called, if I call them again it works fine. 
I need to check if this is another separate bug or is related to my changes.

Closes #525