### PR TITLE
[dialog] Fix multichoice and singlechoice alert dialog in rtl mode of old api

### DIFF
--- a/lib/java/com/google/android/material/dialog/res/layout/mtrl_alert_select_dialog_multichoice.xml
+++ b/lib/java/com/google/android/material/dialog/res/layout/mtrl_alert_select_dialog_multichoice.xml
@@ -15,17 +15,31 @@
      limitations under the License.
 -->
 
+<!--
+    This layout file is used by the AlertDialog when displaying a multi select list of items.
+
+    A left android:gravity will handle text alignemnt on API 16 and below while
+    android:textAlignemnt will be used on 17+. A start android:gravity is not added
+    to avoid text being aligned right while a drawable is aligned left in RTL configurations
+    on API 16 and below.
+
+    app:drawableLeftCompat (and app:drawableStartCompat) used instead of android:drawableLeft
+    (and android:drawableStart) because of bug on api 17 that aligned drawable both left and
+    right when in RTL configurations
+-->
 <CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@android:id/text1"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?attr/listPreferredItemHeightSmall"
-    android:gravity="center_vertical"
+    android:gravity="left|center_vertical"
+    android:textAlignment="viewStart"
     android:paddingLeft="@dimen/abc_select_dialog_padding_start_material"
     android:paddingRight="?attr/dialogPreferredPadding"
     android:paddingStart="@dimen/abc_select_dialog_padding_start_material"
     android:paddingEnd="?attr/dialogPreferredPadding"
-    android:drawableLeft="?android:attr/listChoiceIndicatorMultiple"
-    android:drawableStart="?android:attr/listChoiceIndicatorMultiple"
+    app:drawableLeftCompat="?android:attr/listChoiceIndicatorMultiple"
+    app:drawableStartCompat="?android:attr/listChoiceIndicatorMultiple"
     android:drawablePadding="20dp"
     android:ellipsize="marquee" />

--- a/lib/java/com/google/android/material/dialog/res/layout/mtrl_alert_select_dialog_singlechoice.xml
+++ b/lib/java/com/google/android/material/dialog/res/layout/mtrl_alert_select_dialog_singlechoice.xml
@@ -15,17 +15,31 @@
      limitations under the License.
 -->
 
+<!--
+    This layout file is used by the AlertDialog when displaying a single select list of items.
+
+    A left android:gravity will handle text alignemnt on API 16 and below while
+    android:textAlignemnt will be used on 17+. A start android:gravity is not added
+    to avoid text being aligned right while a drawable is aligned left in RTL configurations
+    on API 16 and below.
+
+    app:drawableLeftCompat (and app:drawableStartCompat) used instead of android:drawableLeft
+    (and android:drawableStart) because of bug on api 17 that aligned drawable both left and
+    right when in RTL configurations
+-->
 <CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@android:id/text1"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?attr/listPreferredItemHeightSmall"
-    android:gravity="center_vertical"
+    android:gravity="left|center_vertical"
+    android:textAlignment="viewStart"
     android:paddingLeft="@dimen/abc_select_dialog_padding_start_material"
     android:paddingRight="?attr/dialogPreferredPadding"
     android:paddingStart="@dimen/abc_select_dialog_padding_start_material"
     android:paddingEnd="?attr/dialogPreferredPadding"
-    android:drawableLeft="?android:attr/listChoiceIndicatorSingle"
-    android:drawableStart="?android:attr/listChoiceIndicatorSingle"
+    app:drawableLeftCompat="?android:attr/listChoiceIndicatorSingle"
+    app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle"
     android:drawablePadding="20dp"
     android:ellipsize="marquee" />


### PR DESCRIPTION
Hi
Single and multi choice alert dialog have some issue with rtl language like persian and arabic on api 16,17,18 (I test this three version)
api 16 not support rtl then drawable always in left but if I use persian work this happend:
![screenshot-2019-11-10_21 35 10 649](https://user-images.githubusercontent.com/22843329/68549069-4fe75980-0409-11ea-8730-2d0aeb9f2525.png)
api 18 support rtl then drawable on change to right when set locale to "fa" but if use persian and English word together this happend:
![screenshot-2019-11-10_21 30 33 637](https://user-images.githubusercontent.com/22843329/68549102-bb312b80-0409-11ea-85cd-206c7e74c54c.png)

 on api 17 there is a strange bug. the same bug like above exist and there are two drawable in both right and left when locale set to "fa":
![screenshot-2019-11-10_21 41 54 908](https://user-images.githubusercontent.com/22843329/68549125-0fd4a680-040a-11ea-87b4-ae356449a5a7.png)

then I change xml layout of single and multi choice alert dialog to fix this problem, also separate layout of api 17 and above from default layout
after this commit ui on api 17 :
![screenshot-2019-11-10_21 44 46 97](https://user-images.githubusercontent.com/22843329/68549259-8920c900-040b-11ea-80e0-9249ec3eff17.png)

I also check this code on api 16,17,18,23 on both ltr and rtl language and every thing is normal