### PR TITLE
[CardView] Fix potential Proguard/Dexguard/R8(?) optimization problem

### DIFF
--- a/lib/java/com/google/android/material/card/MaterialCardView.java
+++ b/lib/java/com/google/android/material/card/MaterialCardView.java
@@ -97,7 +97,7 @@ public class MaterialCardView extends CardView implements Checkable, Shapeable {
    * Keep track of when {@link CardView} is done initializing because we don't want to use the
    * {@link Drawable} that it passes to {@link #setBackground(Drawable)}.
    */
-  private final boolean isParentCardViewDoneInitializing;
+  private boolean isParentCardViewDoneInitializing;
 
   private boolean checked = false;
   private boolean dragged = false;


### PR DESCRIPTION
If using Proguard/Dexguard optimization and enabling all optimizations (e.g. not using default `getDefaultProguardFile('proguard-android-optimize.txt')` it would optimize `isParentCardViewDoneInitializing` away as it is final and thus can be inlined (as `true` because that i what it is set to in the initializer).
However this code assumes that it is `false` during the `super(...)` call and thus using Progurad/Dexguard optimization on this will cause an NPE in `setBackgroundDrawable(...)`.
One could argue that this is a bug in Proguard/Dexguard but it is also not a good design to use a final field and rely on it having different values during runtime.

I did not test this with R8 but did so with Proguard and Dexguard

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
