### PR TITLE
[MaterialButtonToggleGroup] Clean up

### DIFF
--- a/lib/java/com/google/android/material/button/MaterialButtonToggleGroup.java
+++ b/lib/java/com/google/android/material/button/MaterialButtonToggleGroup.java
@@ -364,7 +364,7 @@ public class MaterialButtonToggleGroup extends LinearLayout {
    */
   @NonNull
   public List<Integer> getCheckedButtonIds() {
-    ArrayList<Integer> checkedIds = new ArrayList<>();
+    List<Integer> checkedIds = new ArrayList<>();
     for (int i = 0; i < getChildCount(); i++) {
       MaterialButton child = getChildButton(i);
       if (child.isChecked()) {
@@ -477,7 +477,7 @@ public class MaterialButtonToggleGroup extends LinearLayout {
    * Sets a negative marginStart on all but the first child, if two adjacent children both have a
    * stroke width greater than 0. This prevents a double-width stroke from being drawn for two
    * adjacent stroked children, and instead draws the adjacent strokes directly on top of each
-   * another.
+   * other.
    *
    * <p>The negative margin adjustment amount will be equal to the smaller of the two adjacent
    * stroke widths.
@@ -643,7 +643,7 @@ public class MaterialButtonToggleGroup extends LinearLayout {
 
     // un select previous selection
     if (childIsChecked && singleSelection) {
-      checkedButtonIds.remove((Object) childId);
+      checkedButtonIds.remove((Integer) childId);
       for (int buttonId : checkedButtonIds) {
         setCheckedStateForView(buttonId, false);
         dispatchOnButtonChecked(buttonId, false);
@@ -696,10 +696,7 @@ public class MaterialButtonToggleGroup extends LinearLayout {
       return (LayoutParams) layoutParams;
     }
 
-    LinearLayout.LayoutParams newParams =
-        new LinearLayout.LayoutParams(layoutParams.width, layoutParams.height);
-
-    return newParams;
+    return new LayoutParams(layoutParams.width, layoutParams.height);
   }
 
   /**
@@ -795,7 +792,7 @@ public class MaterialButtonToggleGroup extends LinearLayout {
       return new CornerData(orig.topLeft, noCorner, orig.topRight, noCorner);
     }
 
-    /** Keep the left side of the corner original data */
+    /** Keep the bottom side of the corner original data */
     public static CornerData bottom(CornerData orig) {
       return new CornerData(noCorner, orig.bottomLeft, noCorner, orig.bottomRight);
     }

--- a/lib/javatests/com/google/android/material/button/MaterialButtonToggleGroupTest.java
+++ b/lib/javatests/com/google/android/material/button/MaterialButtonToggleGroupTest.java
@@ -35,12 +35,10 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-/**
- * Tests for {@link com.google.android.material.button.MaterialButtonToggleGroup}.
- */
+/** Tests for {@link com.google.android.material.button.MaterialButtonToggleGroup}. */
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 21)
-public class MaterialButtonToggleGroupUnitTest {
+public class MaterialButtonToggleGroupTest {
 
   private static final float CORNER_SIZE = 10f;
   private final Context context = ApplicationProvider.getApplicationContext();
@@ -48,18 +46,15 @@ public class MaterialButtonToggleGroupUnitTest {
   private MaterialButtonToggleGroup toggleGroup;
 
   @Before
-  public void themeApplicationContext() {
+  public void setup() {
+    // Set up app material theme
     context.setTheme(R.style.Theme_MaterialComponents_Light_NoActionBar_Bridge);
-  }
 
-  @Before
-  public void createToggleGroupWithButtons() {
+    // Set up test buttons in toggle group
     toggleGroup = new MaterialButtonToggleGroup(context);
-    float cornerSize = CORNER_SIZE;
-
     for (int i = 0; i < 3; ++i) {
       MaterialButton child = new MaterialButton(context);
-      child.setShapeAppearanceModel(child.getShapeAppearanceModel().withCornerSize(cornerSize));
+      child.setShapeAppearanceModel(child.getShapeAppearanceModel().withCornerSize(CORNER_SIZE));
       toggleGroup.addView(child, i);
       getInstrumentation().waitForIdleSync();
     }


### PR DESCRIPTION
What I did:
 - minor IDE warnings
 - Java doc typo
 - renamed `MaterialButtonToggleGroupUnitTest` to `MaterialButtonToggleGroupTest` to be consistent with other tests, and merged two `@Before` into one and added doc.

TESTED=builds and runs as expected & unit test passed