### PR TITLE
Use conditional keep rule for MaterialComponentsViewInflater

### DIFF
--- a/lib/java/com/google/android/material/theme/MaterialComponentsViewInflater.java
+++ b/lib/java/com/google/android/material/theme/MaterialComponentsViewInflater.java
@@ -21,7 +21,6 @@ import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 import android.content.Context;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
-import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
@@ -42,7 +41,6 @@ import com.google.android.material.textview.MaterialTextView;
  * An extension of {@link AppCompatViewInflater} that replaces some framework widgets with Material
  * Components ones at inflation time, provided a Material Components theme is in use.
  */
-@Keep // Make proguard keep this class as it's accessed reflectively by AppCompat
 public class MaterialComponentsViewInflater extends AppCompatViewInflater {
 
   // Cached background resource ID used for workaround to not inflate MaterialButton in

--- a/lib/proguard-inflater.pro
+++ b/lib/proguard-inflater.pro
@@ -12,5 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# MaterialComponentsViewInflater inflates Material Components rather than their AppCompat counterparts.
--keep class com.google.android.material.theme.MaterialComponentsViewInflater { *; }
+# AppCompatViewInflater reads the viewInflaterClass theme attribute which then reflectively
+# instantiates MaterialComponentsViewInflater using the no-argument constructor. We only need to
+# keep this constructor and the class name if AppCompatViewInflater is also being kept.
+-if class androidx.appcompat.app.AppCompatViewInflater
+-keep class com.google.android.material.theme.MaterialComponentsViewInflater {
+    <init>();
+}


### PR DESCRIPTION
This allows it to be removed when `AppCompatViewInflater` is also unused, along with their many transitive class dependencies.

Closes #818