### PR TITLE
[MaterialDatePicker] Don't clip the background when there's a selected range of dates

### DIFF
--- a/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
@@ -46,6 +46,8 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.GridView;
+import android.widget.LinearLayout;
+
 import com.google.android.material.button.MaterialButton;
 import java.util.Calendar;
 
@@ -163,6 +165,11 @@ public final class MaterialCalendar<S> extends PickerFragment<S> {
     daysHeader.setEnabled(false);
 
     recyclerView = root.findViewById(R.id.mtrl_calendar_months);
+    if (MaterialDatePicker.isFullscreen(themedContext)) {
+      daysHeader.setLayoutParams(new LinearLayout.LayoutParams(
+          MaterialDatePicker.getPaddedPickerWidth(themedContext),
+          LinearLayout.LayoutParams.MATCH_PARENT));
+    }
 
     SmoothCalendarLayoutManager layoutManager =
         new SmoothCalendarLayoutManager(getContext(), orientation, false) {

--- a/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
@@ -187,11 +187,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     View root = layoutInflater.inflate(layout, viewGroup);
     Context context = root.getContext();
 
-    if (fullscreen) {
-      View frame = root.findViewById(R.id.mtrl_calendar_frame);
-      frame.setLayoutParams(
-          new LayoutParams(getPaddedPickerWidth(context), LayoutParams.WRAP_CONTENT));
-    } else {
+    if (!fullscreen) {
       View pane = root.findViewById(R.id.mtrl_calendar_main_pane);
       View frame = root.findViewById(R.id.mtrl_calendar_frame);
       pane.setLayoutParams(
@@ -402,7 +398,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     return navigationHeight + daysOfWeekHeight + calendarHeight + calendarPadding;
   }
 
-  private static int getPaddedPickerWidth(@NonNull Context context) {
+  static int getPaddedPickerWidth(@NonNull Context context) {
     Resources resources = context.getResources();
     int padding = resources.getDimensionPixelOffset(R.dimen.mtrl_calendar_content_padding);
     int daysInWeek = Month.today().daysInWeek;

--- a/lib/java/com/google/android/material/datepicker/MonthsPagerAdapter.java
+++ b/lib/java/com/google/android/material/datepicker/MonthsPagerAdapter.java
@@ -15,20 +15,22 @@
  */
 package com.google.android.material.datepicker;
 
-import com.google.android.material.R;
-
 import android.content.Context;
-import androidx.annotation.NonNull;
-import androidx.core.view.ViewCompat;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.recyclerview.widget.RecyclerView.LayoutParams;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.view.ViewCompat;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerView.LayoutParams;
+
+import com.google.android.material.R;
 import com.google.android.material.datepicker.MaterialCalendar.OnDayClickListener;
 
 /**
@@ -69,7 +71,20 @@ class MonthsPagerAdapter extends RecyclerView.Adapter<MonthsPagerAdapter.ViewHol
     setHasStableIds(true);
   }
 
-  public static class ViewHolder extends RecyclerView.ViewHolder {
+  @Override
+  public void onViewAttachedToWindow(@NonNull ViewHolder holder) {
+    super.onViewAttachedToWindow(holder);
+    holder.onAttachedToWindow();
+  }
+
+  @Override
+  public void onViewDetachedFromWindow(@NonNull ViewHolder holder) {
+    super.onViewDetachedFromWindow(holder);
+    holder.onDetachedFromWindow();
+  }
+
+  public static class ViewHolder extends RecyclerView.ViewHolder
+      implements ViewTreeObserver.OnPreDrawListener {
 
     final TextView monthTitle;
     final MaterialCalendarGridView monthGrid;
@@ -83,6 +98,29 @@ class MonthsPagerAdapter extends RecyclerView.Adapter<MonthsPagerAdapter.ViewHol
         monthTitle.setVisibility(View.GONE);
       }
     }
+
+    void onAttachedToWindow() {
+      if (MaterialDatePicker.isFullscreen(itemView.getContext()) && itemView.getWidth() == 0) {
+        itemView.getViewTreeObserver().addOnPreDrawListener(this);
+      }
+    }
+
+    void onDetachedFromWindow() {
+      itemView.getViewTreeObserver().removeOnPreDrawListener(this);
+    }
+
+    @Override
+    public boolean onPreDraw() {
+      if (itemView.getWidth() != 0) {
+        final int paddedWidth = MaterialDatePicker.getPaddedPickerWidth(itemView.getContext());
+        final int padding = (itemView.getWidth() - paddedWidth) / 2;
+        monthTitle.setPadding(padding, 0, 0, 0);
+        monthGrid.setPadding(padding, 0, padding, 0);
+        itemView.getViewTreeObserver().removeOnPreDrawListener(this);
+      }
+      return false;
+    }
+
   }
 
   @NonNull

--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_fullscreen.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_fullscreen.xml
@@ -27,10 +27,6 @@
   <FrameLayout
       android:id="@+id/mtrl_calendar_frame"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:paddingStart="@dimen/mtrl_calendar_content_padding"
-      android:paddingEnd="@dimen/mtrl_calendar_content_padding"
-      android:paddingLeft="@dimen/mtrl_calendar_content_padding"
-      android:paddingRight="@dimen/mtrl_calendar_content_padding"/>
+      android:layout_height="wrap_content"/>
 
 </LinearLayout>


### PR DESCRIPTION
Partially addresses #762 


| Before | After |
| ------------- | ------------- |
| ![clipped](https://user-images.githubusercontent.com/10662096/70868165-be25bb80-1f75-11ea-9838-13a708b78e79.png)  | ![unclipped](https://user-images.githubusercontent.com/10662096/70868168-c5e56000-1f75-11ea-9ebe-f02a216bf3fa.png)  |

I'm not sure if this should be done for tablets or landscape mode, but according to the spec, the layout should look like this:

![image](https://user-images.githubusercontent.com/10662096/70868210-3be9c700-1f76-11ea-945a-330dd24b409e.png)
