### PR TITLE
[Slider] Add missing functionality from SeekBar regarding touch events and value changes

### DIFF
--- a/catalog/java/io/material/catalog/slider/SliderContinuousDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderContinuousDemoFragment.java
@@ -16,17 +16,20 @@
 
 package io.material.catalog.slider;
 
-import io.material.catalog.R;
-
 import android.os.Bundle;
-import androidx.annotation.IdRes;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.SwitchCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
+import androidx.annotation.IdRes;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SwitchCompat;
+
 import com.google.android.material.slider.Slider;
+import com.google.android.material.snackbar.Snackbar;
+
+import io.material.catalog.R;
 import io.material.catalog.feature.DemoFragment;
 
 /**
@@ -57,6 +60,19 @@ public class SliderContinuousDemoFragment extends DemoFragment {
     final Slider slider = view.findViewById(sliderId);
     slider.setOnChangeListener(
         (slider1, value, fromUser) -> sliderValue.setText(String.format(valueFormat, value)));
+    slider.setOnSliderTouchListener(new Slider.OnSliderTouchListener() {
+      @Override
+      public void onStartTrackingTouch(Slider slider) {
+        Snackbar.make(slider, getText(R.string.cat_slider_start_touch_description),
+            Snackbar.LENGTH_SHORT).show();
+      }
+
+      @Override
+      public void onStopTrackingTouch(Slider slider) {
+        Snackbar.make(slider, getText(R.string.cat_slider_stop_touch_description),
+            Snackbar.LENGTH_SHORT).show();
+      }
+    });
     slider.setValue(slider.getValueFrom());
     SwitchCompat switchButton = view.findViewById(switchId);
     switchButton.setOnCheckedChangeListener(

--- a/catalog/java/io/material/catalog/slider/SliderContinuousDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderContinuousDemoFragment.java
@@ -56,7 +56,7 @@ public class SliderContinuousDemoFragment extends DemoFragment {
     final TextView sliderValue = view.findViewById(valueId);
     final Slider slider = view.findViewById(sliderId);
     slider.setOnChangeListener(
-        (slider1, value) -> sliderValue.setText(String.format(valueFormat, value)));
+        (slider1, value, fromUser) -> sliderValue.setText(String.format(valueFormat, value)));
     slider.setValue(slider.getValueFrom());
     SwitchCompat switchButton = view.findViewById(switchId);
     switchButton.setOnCheckedChangeListener(

--- a/catalog/java/io/material/catalog/slider/SliderContinuousDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderContinuousDemoFragment.java
@@ -57,7 +57,7 @@ public class SliderContinuousDemoFragment extends DemoFragment {
       final String valueFormat) {
     final TextView sliderValue = view.findViewById(valueId);
     final Slider slider = view.findViewById(sliderId);
-    slider.setOnChangeListener(
+    slider.addOnChangeListener(
         (slider1, value, fromUser) -> sliderValue.setText(String.format(valueFormat, value)));
     slider.setValue(slider.getValueFrom());
     SwitchCompat switchButton = view.findViewById(switchId);

--- a/catalog/java/io/material/catalog/slider/SliderContinuousDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderContinuousDemoFragment.java
@@ -27,7 +27,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SwitchCompat;
 
 import com.google.android.material.slider.Slider;
-import com.google.android.material.snackbar.Snackbar;
 
 import io.material.catalog.R;
 import io.material.catalog.feature.DemoFragment;
@@ -60,19 +59,6 @@ public class SliderContinuousDemoFragment extends DemoFragment {
     final Slider slider = view.findViewById(sliderId);
     slider.setOnChangeListener(
         (slider1, value, fromUser) -> sliderValue.setText(String.format(valueFormat, value)));
-    slider.setOnSliderTouchListener(new Slider.OnSliderTouchListener() {
-      @Override
-      public void onStartTrackingTouch(Slider slider) {
-        Snackbar.make(slider, getText(R.string.cat_slider_start_touch_description),
-            Snackbar.LENGTH_SHORT).show();
-      }
-
-      @Override
-      public void onStopTrackingTouch(Slider slider) {
-        Snackbar.make(slider, getText(R.string.cat_slider_stop_touch_description),
-            Snackbar.LENGTH_SHORT).show();
-      }
-    });
     slider.setValue(slider.getValueFrom());
     SwitchCompat switchButton = view.findViewById(switchId);
     switchButton.setOnCheckedChangeListener(

--- a/catalog/java/io/material/catalog/slider/SliderDiscreteDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderDiscreteDemoFragment.java
@@ -26,7 +26,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import com.google.android.material.slider.Slider;
-import com.google.android.material.snackbar.Snackbar;
 
 import io.material.catalog.feature.DemoFragment;
 
@@ -56,19 +55,6 @@ public class SliderDiscreteDemoFragment extends DemoFragment {
       View view, @IdRes int switchId, @IdRes int sliderId, Slider.LabelFormatter labelFormatter) {
     final Slider slider = view.findViewById(sliderId);
     slider.setLabelFormatter(labelFormatter);
-    slider.setOnSliderTouchListener(new Slider.OnSliderTouchListener() {
-      @Override
-      public void onStartTrackingTouch(Slider slider) {
-        Snackbar.make(slider, getText(R.string.cat_slider_start_touch_description),
-            Snackbar.LENGTH_SHORT).show();
-      }
-
-      @Override
-      public void onStopTrackingTouch(Slider slider) {
-        Snackbar.make(slider, getText(R.string.cat_slider_stop_touch_description),
-            Snackbar.LENGTH_SHORT).show();
-      }
-    });
     SwitchCompat switchButton = view.findViewById(switchId);
     switchButton.setOnCheckedChangeListener(
         (buttonView, isChecked) -> slider.setEnabled(isChecked));

--- a/catalog/java/io/material/catalog/slider/SliderDiscreteDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderDiscreteDemoFragment.java
@@ -26,6 +26,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import com.google.android.material.slider.Slider;
+import com.google.android.material.snackbar.Snackbar;
+
 import io.material.catalog.feature.DemoFragment;
 
 /**
@@ -54,6 +56,19 @@ public class SliderDiscreteDemoFragment extends DemoFragment {
       View view, @IdRes int switchId, @IdRes int sliderId, Slider.LabelFormatter labelFormatter) {
     final Slider slider = view.findViewById(sliderId);
     slider.setLabelFormatter(labelFormatter);
+    slider.setOnSliderTouchListener(new Slider.OnSliderTouchListener() {
+      @Override
+      public void onStartTrackingTouch(Slider slider) {
+        Snackbar.make(slider, getText(R.string.cat_slider_start_touch_description),
+            Snackbar.LENGTH_SHORT).show();
+      }
+
+      @Override
+      public void onStopTrackingTouch(Slider slider) {
+        Snackbar.make(slider, getText(R.string.cat_slider_stop_touch_description),
+            Snackbar.LENGTH_SHORT).show();
+      }
+    });
     SwitchCompat switchButton = view.findViewById(switchId);
     switchButton.setOnCheckedChangeListener(
         (buttonView, isChecked) -> slider.setEnabled(isChecked));

--- a/catalog/java/io/material/catalog/slider/SliderMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderMainDemoFragment.java
@@ -25,6 +25,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import com.google.android.material.slider.Slider;
+import com.google.android.material.snackbar.Snackbar;
+
 import io.material.catalog.feature.DemoFragment;
 
 /** A fragment that displays the main Slider demo for the Catalog app. */
@@ -37,6 +39,19 @@ public class SliderMainDemoFragment extends DemoFragment {
         layoutInflater.inflate(R.layout.cat_slider_fragment, viewGroup, false /* attachToRoot */);
 
     Slider slider = view.findViewById(R.id.slider);
+    slider.setOnSliderTouchListener(new Slider.OnSliderTouchListener() {
+      @Override
+      public void onStartTrackingTouch(Slider slider) {
+        Snackbar.make(slider, getText(R.string.cat_slider_start_touch_description),
+            Snackbar.LENGTH_SHORT).show();
+      }
+
+      @Override
+      public void onStopTrackingTouch(Slider slider) {
+        Snackbar.make(slider, getText(R.string.cat_slider_stop_touch_description),
+            Snackbar.LENGTH_SHORT).show();
+      }
+    });
     Button button = view.findViewById(R.id.button);
 
     button.setOnClickListener(v -> slider.setValue(slider.getValueTo()));

--- a/catalog/java/io/material/catalog/slider/SliderMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderMainDemoFragment.java
@@ -42,13 +42,13 @@ public class SliderMainDemoFragment extends DemoFragment {
     slider.setOnSliderTouchListener(new Slider.OnSliderTouchListener() {
       @Override
       public void onStartTrackingTouch(Slider slider) {
-        Snackbar.make(slider, getText(R.string.cat_slider_start_touch_description),
+        Snackbar.make(slider, R.string.cat_slider_start_touch_description,
             Snackbar.LENGTH_SHORT).show();
       }
 
       @Override
       public void onStopTrackingTouch(Slider slider) {
-        Snackbar.make(slider, getText(R.string.cat_slider_stop_touch_description),
+        Snackbar.make(slider, R.string.cat_slider_stop_touch_description,
             Snackbar.LENGTH_SHORT).show();
       }
     });

--- a/catalog/java/io/material/catalog/slider/SliderMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderMainDemoFragment.java
@@ -39,7 +39,7 @@ public class SliderMainDemoFragment extends DemoFragment {
         layoutInflater.inflate(R.layout.cat_slider_fragment, viewGroup, false /* attachToRoot */);
 
     Slider slider = view.findViewById(R.id.slider);
-    slider.setOnSliderTouchListener(new Slider.OnSliderTouchListener() {
+    slider.addOnSlideTouchListener(new Slider.OnSliderTouchListener() {
       @Override
       public void onStartTrackingTouch(Slider slider) {
         Snackbar.make(slider, R.string.cat_slider_start_touch_description,

--- a/catalog/java/io/material/catalog/slider/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/slider/res/values/strings.xml
@@ -33,4 +33,7 @@
   <string name="cat_slider_title_3" description="The title for a demonstration slider">Negative numbers!</string>
   <string name="cat_slider_title_4" description="The title for a demonstration slider">With a label formatter</string>
   <string name="cat_slider_title_5" description="The title for a demonstration slider">I can has decimal numbers?</string>
+  <string name="cat_slider_start_touch_description" description="Indicates the slider is now being touched">Slider started being touched</string>
+  <string name="cat_slider_stop_touch_description" description="Indicates the slider stopped being touched">Slider stopped being touched</string>
+
 </resources>

--- a/lib/java/com/google/android/material/slider/Slider.java
+++ b/lib/java/com/google/android/material/slider/Slider.java
@@ -845,10 +845,10 @@ public class Slider extends View {
         ensureLabel();
         updateLabelPosition();
         invalidate();
+        onStartTrackingTouch();
         if (hasOnChangeListener()) {
           listener.onValueChange(this, getValue(), true);
         }
-        onStartTrackingTouch();
         break;
       case MotionEvent.ACTION_MOVE:
         thumbPosition = position;

--- a/lib/java/com/google/android/material/slider/Slider.java
+++ b/lib/java/com/google/android/material/slider/Slider.java
@@ -184,6 +184,7 @@ public class Slider extends View {
   private int haloRadius;
   private int labelPadding;
   private OnChangeListener listener;
+  private OnSliderTouchListener touchListener;
   private LabelFormatter formatter;
   private boolean thumbIsPressed = false;
   private float valueFrom;
@@ -207,6 +208,16 @@ public class Slider extends View {
   /** Interface definition for a callback invoked when a slider's value is changed. */
   public interface OnChangeListener {
     void onValueChange(Slider slider, float value, boolean fromUser);
+  }
+
+  /**
+   * Interface definition for callbacks invoked when a slider's touch event
+   * is being started/stopped.
+   */
+  public interface OnSliderTouchListener {
+    void onStartTrackingTouch(Slider slider);
+
+    void onStopTrackingTouch(Slider slider);
   }
 
   /**
@@ -566,6 +577,15 @@ public class Slider extends View {
   }
 
   /**
+   * Registers a callback to be invoked when the slider touch event is being started or stopped
+   *
+   * @param listener The callback to run when the slider starts or stops being touched
+   */
+  public void setOnSliderTouchListener(@Nullable OnSliderTouchListener listener) {
+    this.touchListener = listener;
+  }
+
+  /**
    * Returns {@code true} if the slider has a {@link LabelFormatter} attached, {@code false}
    * otherwise.
    */
@@ -828,6 +848,7 @@ public class Slider extends View {
         if (hasOnChangeListener()) {
           listener.onValueChange(this, getValue(), true);
         }
+        onStartTrackingTouch();
         break;
       case MotionEvent.ACTION_MOVE:
         thumbPosition = position;
@@ -846,8 +867,11 @@ public class Slider extends View {
         thumbPosition = position;
         snapThumbPosition();
         ViewUtils.getContentViewOverlay(this).remove(label);
+        onStopTrackingTouch();
         invalidate();
         break;
+      case MotionEvent.ACTION_CANCEL:
+        onStopTrackingTouch();
       default:
         // Nothing to do in this case.
     }
@@ -901,6 +925,18 @@ public class Slider extends View {
     activeTrackPaint.setStrokeWidth(trackHeight);
     inactiveTicksPaint.setStrokeWidth(trackHeight / 2.0f);
     activeTicksPaint.setStrokeWidth(trackHeight / 2.0f);
+  }
+
+  private void onStartTrackingTouch(){
+    if(touchListener != null){
+      touchListener.onStartTrackingTouch(this);
+    }
+  }
+
+  private void onStopTrackingTouch(){
+    if(touchListener != null){
+      touchListener.onStopTrackingTouch(this);
+    }
   }
 
   @Override

--- a/lib/java/com/google/android/material/slider/Slider.java
+++ b/lib/java/com/google/android/material/slider/Slider.java
@@ -206,7 +206,7 @@ public class Slider extends View {
 
   /** Interface definition for a callback invoked when a slider's value is changed. */
   public interface OnChangeListener {
-    void onValueChange(Slider slider, float value);
+    void onValueChange(Slider slider, float value, boolean fromUser);
   }
 
   /**
@@ -497,7 +497,7 @@ public class Slider extends View {
     if (isValueValid(value)) {
       thumbPosition = (value - valueFrom) / (valueTo - valueFrom);
       if (hasOnChangeListener()) {
-        listener.onValueChange(this, getValue());
+        listener.onValueChange(this, getValue(), false);
       }
       invalidate();
     }
@@ -826,7 +826,7 @@ public class Slider extends View {
         updateLabelPosition();
         invalidate();
         if (hasOnChangeListener()) {
-          listener.onValueChange(this, getValue());
+          listener.onValueChange(this, getValue(), true);
         }
         break;
       case MotionEvent.ACTION_MOVE:
@@ -837,7 +837,7 @@ public class Slider extends View {
         updateLabelPosition();
         invalidate();
         if (hasOnChangeListener()) {
-          listener.onValueChange(this, getValue());
+          listener.onValueChange(this, getValue(), true);
         }
         break;
       case MotionEvent.ACTION_UP:
@@ -956,7 +956,7 @@ public class Slider extends View {
       requestFocus();
     }
     if (hasOnChangeListener()) {
-      listener.onValueChange(this, getValue());
+      listener.onValueChange(this, getValue(), false);
     }
   }
 


### PR DESCRIPTION
Fixes #771 and #803 

### Value changes

There's no way to know currently if the value is being changed due to a user triggered event.

To fix this, OnChangeListener was changed from:

```java
public interface OnChangeListener {
   void onValueChange(Slider slider, float value);
}
```

to:

```java
public interface OnChangeListener {
   void onValueChange(Slider slider, float value, boolean fromUser);
}
```

### Touch event tracking

There's currently no way to determine when the user is touching or releasing the Slider.
A new OnSliderTouchListener was added instead of adding the methods to OnChangeListener to track the touch events:

```java
public interface OnSliderTouchListener {
  void onStartTrackingTouch(Slider slider);

  void onStopTrackingTouch(Slider slider);
}
```
