### PR TITLE
[BottomSheetBehavior] Resolving `behavior_expandedOffset` as a `dimen`

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -299,7 +299,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
     setSaveFlags(a.getInt(R.styleable.BottomSheetBehavior_Layout_behavior_saveFlags, SAVE_NONE));
     setHalfExpandedRatio(
         a.getFloat(R.styleable.BottomSheetBehavior_Layout_behavior_halfExpandedRatio, 0.5f));
-    setExpandedOffset(a.getInt(R.styleable.BottomSheetBehavior_Layout_behavior_expandedOffset, 0));
+    setExpandedOffset(a.getDimensionPixelOffset(R.styleable.BottomSheetBehavior_Layout_behavior_expandedOffset, 0));
     a.recycle();
     ViewConfiguration configuration = ViewConfiguration.get(context);
     maximumVelocity = configuration.getScaledMaximumFlingVelocity();
@@ -1161,7 +1161,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
     return velocityTracker.getYVelocity(activePointerId);
   }
 
-  private int getExpandedOffset() {
+  public int getExpandedOffset() {
     return fitToContents ? fitToContentsOffset : expandedOffset;
   }
 

--- a/lib/java/com/google/android/material/bottomsheet/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/bottomsheet/res/values/attrs.xml
@@ -40,7 +40,7 @@
     <attr name="behavior_halfExpandedRatio" format="reference|float"/>
     <!-- The top offset of the BottomSheet in the expanded-state when fitsToContent is false.
          The default value is 0, which results in the sheet matching the parent's top. -->
-    <attr name="behavior_expandedOffset" format="reference|integer"/>
+    <attr name="behavior_expandedOffset" format="reference|dimension"/>
     <!-- Shape appearance style reference for BottomSheet. Attribute declaration is in the shape
          package. -->
      <attr name="shapeAppearance"/>


### PR DESCRIPTION
Closes #835.

This PR changes the solution of `BottomSheetBehavior`'s `behavior_expandedOffset` attribute to `getDimensionPixelOffset` and also exposes the getter for `expandedOffset`, as it may be required for coordinations on with other `Behavior`s
