### PR TITLE
[Shrine] Updated deprecated volley dependency

### DIFF
--- a/demos/java/io/material/demo/shrine/products/build.gradle
+++ b/demos/java/io/material/demo/shrine/products/build.gradle
@@ -5,7 +5,7 @@ dependencies {
   api compatibility("cardview")
   api compatibility("recyclerview")
 
-  api 'com.android.volley:volley:1.0.0'
+  api 'com.android.volley:volley:1.1.0'
   api 'com.google.code.gson:gson:2.2.4'
   api project(':lib')
 


### PR DESCRIPTION
closes #871 

The older 1.0.0 version of Volley has issues running on Android P(API 29) devices, whereas later versions (most recently 1.1.0) include support for API 29 devices. The app initially crashed because of the old dependency, as changing it fixes the issue.
