### PR TITLE
[BottomSheetDialog] Removed existing content during each setContentView

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetDialog.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetDialog.java
@@ -204,6 +204,7 @@ public class BottomSheetDialog extends AppCompatDialog {
     }
 
     FrameLayout bottomSheet = (FrameLayout) container.findViewById(R.id.design_bottom_sheet);
+    bottomSheet.removeAllViews();
     if (params == null) {
       bottomSheet.addView(view);
     } else {


### PR DESCRIPTION
closes #869

Previously, calling setContentView added the parameter view to the layout which would create overlap between it and previously added views. Removing previous views before the new one is added prevents this issue.

setContentView is meant to *set* the view, not add it to others.
