### PR TITLE
[ExtendedFloatingActionButton] Allowed for width to adapt to text size after expand animation

### DIFF
--- a/lib/java/com/google/android/material/floatingactionbutton/BaseMotionStrategy.java
+++ b/lib/java/com/google/android/material/floatingactionbutton/BaseMotionStrategy.java
@@ -25,6 +25,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.Preconditions;
 import android.view.View;
+import android.view.ViewGroup;
+
 import com.google.android.material.animation.AnimatorSetCompat;
 import com.google.android.material.animation.MotionSpec;
 import java.util.ArrayList;
@@ -99,6 +101,9 @@ abstract class BaseMotionStrategy implements MotionStrategy {
   @Override
   @CallSuper
   public void onAnimationEnd() {
+    ViewGroup.LayoutParams newLayoutParams =  fab.getLayoutParams();
+    newLayoutParams.width = ViewGroup.LayoutParams.WRAP_CONTENT;
+    fab.setLayoutParams(newLayoutParams);
     tracker.clear();
   }
 


### PR DESCRIPTION
closes #858 

After the button has been expanded, the width is statically defined, meaning it stays at a single value. If the text is changed, the width will no longer grow and shrink with the size of the text, instead creating whitespace and cutting out words. To fix it, the width is set
to WRAP_CONTENT after the animation happens, which allows the width
to change with the text.
