### PR TITLE
[TabLayoutMediator] Prevent crash `autoRefresh` disabled mediator

### DIFF
--- a/lib/java/com/google/android/material/tabs/TabLayoutMediator.java
+++ b/lib/java/com/google/android/material/tabs/TabLayoutMediator.java
@@ -136,12 +136,12 @@ public final class TabLayoutMediator {
    * called before {@link #attach()} when a ViewPager2's adapter is changed.
    */
   public void detach() {
-    if (adapter != null) {
+    if (autoRefresh && adapter != null) {
       adapter.unregisterAdapterDataObserver(pagerAdapterObserver);
+      pagerAdapterObserver = null;
     }
     tabLayout.removeOnTabSelectedListener(onTabSelectedListener);
     viewPager.unregisterOnPageChangeCallback(onPageChangeCallback);
-    pagerAdapterObserver = null;
     onTabSelectedListener = null;
     onPageChangeCallback = null;
     adapter = null;


### PR DESCRIPTION
The `TabLayoutMediator` constructed with `autoRefresh = false` is crashed when calling `detach`. Because `pagerAdapterObserver` remained `null` on `attach` and then on `detach` `adapter.unregisterAdapterDataObserver(pagerAdapterObserver)` throws `IllegalArgumentException`.

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [ ] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
