### PR TITLE
[FloatingActionButton] Add reference format to attributes

### DIFF
--- a/lib/java/com/google/android/material/floatingactionbutton/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/floatingactionbutton/res/values/attrs.xml
@@ -86,8 +86,8 @@
   </declare-styleable>
 
   <!-- Style to use for FloatingActionButtons in this theme. -->
-  <attr name="floatingActionButtonStyle"/>
+  <attr name="floatingActionButtonStyle" format="reference"/>
 
   <!-- Style to use for ExtendedFloatingActionButtons in this theme. -->
-  <attr name="extendedFloatingActionButtonStyle"/>
+  <attr name="extendedFloatingActionButtonStyle" format="reference"/>
 </resources>


### PR DESCRIPTION
Add `reference` format to `floatingActionButtonStyle` and `extendedFloatingActionButtonStyle` so Android Studio knows what to suggest.