### PR TITLE
[ExtendedFloatingActionButton] Added option to hide full button on collapse

### DIFF
--- a/lib/java/com/google/android/material/floatingactionbutton/ExtendedFloatingActionButton.java
+++ b/lib/java/com/google/android/material/floatingactionbutton/ExtendedFloatingActionButton.java
@@ -36,11 +36,11 @@ import android.util.AttributeSet;
 import android.util.Property;
 import android.view.Gravity;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.coordinatorlayout.widget.CoordinatorLayout.AttachedBehavior;
 import androidx.coordinatorlayout.widget.CoordinatorLayout.Behavior;
+//import androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams;
 import com.google.android.material.animation.MotionSpec;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
@@ -199,6 +199,23 @@ public class ExtendedFloatingActionButton extends MaterialButton implements Atta
             context, attrs, defStyleAttr, DEF_STYLE_RES, ShapeAppearanceModel.PILL
         ).build();
     setShapeAppearanceModel(shapeAppearanceModel);
+
+    //Patches corner case where the width does not fit to the text: http://bit.ly/35vSUJe
+    addOnExtendAnimationListener(new AnimatorListener() {
+
+      @Override
+      public void onAnimationEnd(Animator animation) {
+        LayoutParams newLayoutParams =  ExtendedFloatingActionButton.this.getLayoutParams();
+        newLayoutParams.width = LayoutParams.WRAP_CONTENT;
+        ExtendedFloatingActionButton.this.setLayoutParams(newLayoutParams);
+      }
+      @Override
+      public void onAnimationStart(Animator animation) {}
+      @Override
+      public void onAnimationCancel(Animator animation) {}
+      @Override
+      public void onAnimationRepeat(Animator animation) {}
+    });
   }
 
   @Override
@@ -215,6 +232,21 @@ public class ExtendedFloatingActionButton extends MaterialButton implements Atta
   @Override
   public Behavior<ExtendedFloatingActionButton> getBehavior() {
     return behavior;
+  }
+
+  /**
+   * Determines how the extended button is hidden when it needs to be collapsed
+   * @param isHide If true, none of the button will be visible when collapsed. If false, the button
+   * will "shrink" and hide button text but keep the icon.
+   *
+   * This option is "false" and perform a shrink by default.
+   */
+  public void setHideBehavior(boolean isHide) {
+
+    ExtendedFloatingActionButtonBehavior<ExtendedFloatingActionButton> extendedBehavior = (ExtendedFloatingActionButtonBehavior<ExtendedFloatingActionButton>) behavior;
+    extendedBehavior.setAutoHideEnabled(isHide);
+    extendedBehavior.setAutoShrinkEnabled(!isHide);
+
   }
 
 
@@ -764,7 +796,7 @@ public class ExtendedFloatingActionButton extends MaterialButton implements Atta
     }
 
     private static boolean isBottomSheet(@NonNull View view) {
-      final ViewGroup.LayoutParams lp = view.getLayoutParams();
+      final LayoutParams lp = view.getLayoutParams();
       if (lp instanceof CoordinatorLayout.LayoutParams) {
         return ((CoordinatorLayout.LayoutParams) lp).getBehavior() instanceof BottomSheetBehavior;
       }
@@ -1092,7 +1124,7 @@ public class ExtendedFloatingActionButton extends MaterialButton implements Atta
       super.onAnimationEnd();
       animState = ANIM_STATE_NONE;
       if (!isCancelled) {
-        setVisibility(GONE);
+        setVisibility(INVISIBLE);
       }
     }
   }


### PR DESCRIPTION
Until this commit, Extended FABs could only partially collapse and kept
the icon visible. Now, Extended FABs have an option to fully collapse,
similar to the collapse behavior of the FloatingActionButton

- [X] Identify the component the PR relates to in brackets in the title.
- [X] Link to GitHub issues it solves. closes #880
- [X] Sign the CLA bot. You can do this once the pull request is opened.