### PR TITLE
[Bottomsheet] draw under navbar

### DIFF
--- a/catalog/java/io/material/catalog/bottomsheet/BottomSheetMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/bottomsheet/BottomSheetMainDemoFragment.java
@@ -124,7 +124,7 @@ public class BottomSheetMainDemoFragment extends DemoFragment {
     expansionSwitch.setOnCheckedChangeListener(
         (buttonView, isChecked) -> {
           LayoutParams lp = bottomSheetInternal.getLayoutParams();
-          lp.height = isChecked ? 400 : getBottomSheetDialogDefaultHeight();
+          lp.height = isChecked ? 400 : LayoutParams.WRAP_CONTENT;
           bottomSheetInternal.setLayoutParams(lp);
 
           lp = bottomSheetPersistent.getLayoutParams();

--- a/catalog/java/io/material/catalog/bottomsheet/BottomSheetMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/bottomsheet/BottomSheetMainDemoFragment.java
@@ -37,6 +37,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCa
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.switchmaterial.SwitchMaterial;
 import io.material.catalog.feature.DemoFragment;
+import io.material.catalog.windowpreferences.WindowPreferencesManager;
 
 /** A fragment that displays the main BottomSheet demo for the Catalog app. */
 public class BottomSheetMainDemoFragment extends DemoFragment {
@@ -46,8 +47,11 @@ public class BottomSheetMainDemoFragment extends DemoFragment {
       LayoutInflater layoutInflater, @Nullable ViewGroup viewGroup, @Nullable Bundle bundle) {
     View view = layoutInflater.inflate(getDemoContent(), viewGroup, false /* attachToRoot */);
 
+    WindowPreferencesManager windowPreferencesManager = new WindowPreferencesManager(requireContext());
+
     // Set up BottomSheetDialog
     BottomSheetDialog bottomSheetDialog = new BottomSheetDialog(getContext());
+    windowPreferencesManager.applyEdgeToEdgePreference(bottomSheetDialog.getWindow());
     bottomSheetDialog.setContentView(R.layout.cat_bottomsheet_content);
     // Opt in to perform swipe to dismiss animation when dismissing bottom sheet dialog.
     bottomSheetDialog.setDismissWithAnimation(true);

--- a/lib/java/com/google/android/material/bottomsheet/res/layout/design_bottom_sheet_dialog.xml
+++ b/lib/java/com/google/android/material/bottomsheet/res/layout/design_bottom_sheet_dialog.xml
@@ -20,8 +20,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
 
   <androidx.coordinatorlayout.widget.CoordinatorLayout
       android:id="@+id/coordinator"
@@ -43,6 +42,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal|top"
+        android:fitsSystemWindows="true"
         app:layout_behavior="@string/bottom_sheet_behavior"/>
 
   </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
This PR fixes:
- lib: drawing bottomsheet content under navbar;
- catalog: reseting layout height in catalog demo app;
- catalog: dynamic setting of light navbar for bottomsheet; if it would be done declaratively, it's ok.

Note: the demo uses statically defined 400px peek height, which is not much convenient.

<details>
<summary>Preview</summary>

<table>
<tr>
<td>

![device-2020-01-08-114710](https://user-images.githubusercontent.com/284263/71974969-2aad7680-3213-11ea-9e41-3c95522eb111.png)

</td>
<td>

![device-2020-01-08-125430](https://user-images.githubusercontent.com/284263/71976248-2171d900-3216-11ea-800d-66033909a58a.png)


</td>
</tr>
</table>

</details>