### PR TITLE
[attrs.xml] Specify boolean format to some attributes

### DIFF
--- a/lib/java/com/google/android/material/button/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/button/res/values/attrs.xml
@@ -85,11 +85,11 @@
     <!-- Whether only a single button in this group is allowed to be checked at any time. By
          default, this is false and multiple buttons in this group are allowed to be checked at
          once. -->
-    <attr name="singleSelection"/>
+    <attr name="singleSelection" format="boolean"/>
 
     <!-- Whether we prevent all child buttons from being deselected.
          It's false by default. -->
-    <attr name="selectionRequired"/>
+    <attr name="selectionRequired" format="boolean"/>
     <!-- The id of the child button that should be checked by default within this button group. -->
     <attr name="checkedButton" format="reference"/>
   </declare-styleable>

--- a/lib/java/com/google/android/material/checkbox/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/checkbox/res/values/attrs.xml
@@ -20,7 +20,7 @@
       Material Theme colors. When set to false, Material Theme colors will
       be ignored. This value should be set to false when using custom drawables
       that should not be tinted. This value is ignored if a buttonTint is set. -->
-    <attr name="useMaterialThemeColors"/>
+    <attr name="useMaterialThemeColors" format="boolean"/>
     <!-- Tint for the checkbox. -->
     <attr name="buttonTint"/>
   </declare-styleable>

--- a/lib/java/com/google/android/material/chip/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/chip/res/values/attrs.xml
@@ -149,10 +149,10 @@
 
     <!-- Whether only a single chip in this group is allowed to be checked at any time. By default,
          this is false and multiple chips in this group are allowed to be checked at once. -->
-    <attr name="singleSelection"/>
+    <attr name="singleSelection" format="boolean"/>
     <!-- Whether we prevent all child chips from being deselected.
          It's false by default. -->
-    <attr name="selectionRequired"/>
+    <attr name="selectionRequired" format="boolean"/>
     <!-- The id of the child chip that should be checked by default within this chip group. -->
     <attr name="checkedChip" format="reference"/>
 

--- a/lib/java/com/google/android/material/radiobutton/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/radiobutton/res/values/attrs.xml
@@ -20,6 +20,6 @@
       Material Theme colors. When set to false, Material Theme colors will
       be ignored. This value should be set to false when using custom drawables
       that should not be tinted. This value is ignored if a buttonTint is set. -->
-    <attr name="useMaterialThemeColors"/>
+    <attr name="useMaterialThemeColors" format="boolean"/>
   </declare-styleable>
 </resources>

--- a/lib/java/com/google/android/material/switchmaterial/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/switchmaterial/res/values/attrs.xml
@@ -20,6 +20,6 @@
       Material Theme colors. When set to false, Material Theme colors will
       be ignored. This value should be set to false when using custom drawables
       that should not be tinted. This value is ignored if a buttonTint is set. -->
-    <attr name="useMaterialThemeColors"/>
+    <attr name="useMaterialThemeColors" format="boolean"/>
   </declare-styleable>
 </resources>


### PR DESCRIPTION
As far as I know, by specifying format to custom attribute, Android Studio will give us better suggestions. However, I found out that some attribute formats are not being specified, so I added some to them. 

There's quite a lot of unspecified attribute formats, but I am not sure if I should put those formats to them. 

> Attributes like: `shapeAppearance`, `itemIconSize`, `itemIconTint`, `itemTextColor` are not specified.