### PR TITLE
[TabLayout] added smooth scroll functionality in TabLayoutMediator

### DIFF
--- a/lib/java/com/google/android/material/tabs/TabLayoutMediator.java
+++ b/lib/java/com/google/android/material/tabs/TabLayoutMediator.java
@@ -83,6 +83,14 @@ public final class TabLayoutMediator {
       @NonNull TabLayout tabLayout,
       @NonNull ViewPager2 viewPager,
       boolean autoRefresh,
+      @NonNull TabConfigurationStrategy tabConfigurationStrategy) {
+    this(tabLayout, viewPager, autoRefresh, true, tabConfigurationStrategy);
+  }
+
+  public TabLayoutMediator(
+      @NonNull TabLayout tabLayout,
+      @NonNull ViewPager2 viewPager,
+      boolean autoRefresh,
       boolean smoothScroll,
       @NonNull TabConfigurationStrategy tabConfigurationStrategy) {
     this.tabLayout = tabLayout;
@@ -241,9 +249,9 @@ public final class TabLayoutMediator {
    */
   private static class ViewPagerOnTabSelectedListener implements TabLayout.OnTabSelectedListener {
     private final ViewPager2 viewPager;
-    private final Boolean smoothScroll;
+    private final boolean smoothScroll;
 
-    ViewPagerOnTabSelectedListener(ViewPager2 viewPager, Boolean smoothScroll) {
+    ViewPagerOnTabSelectedListener(ViewPager2 viewPager, boolean smoothScroll) {
       this.viewPager = viewPager;
       this.smoothScroll = smoothScroll;
     }

--- a/lib/java/com/google/android/material/tabs/TabLayoutMediator.java
+++ b/lib/java/com/google/android/material/tabs/TabLayoutMediator.java
@@ -47,6 +47,7 @@ public final class TabLayoutMediator {
   @NonNull private final TabLayout tabLayout;
   @NonNull private final ViewPager2 viewPager;
   private final boolean autoRefresh;
+  private final boolean smoothScroll;
   private final TabConfigurationStrategy tabConfigurationStrategy;
   @Nullable private RecyclerView.Adapter<?> adapter;
   private boolean attached;
@@ -75,17 +76,19 @@ public final class TabLayoutMediator {
       @NonNull TabLayout tabLayout,
       @NonNull ViewPager2 viewPager,
       @NonNull TabConfigurationStrategy tabConfigurationStrategy) {
-    this(tabLayout, viewPager, true, tabConfigurationStrategy);
+    this(tabLayout, viewPager, true, true, tabConfigurationStrategy);
   }
 
   public TabLayoutMediator(
       @NonNull TabLayout tabLayout,
       @NonNull ViewPager2 viewPager,
       boolean autoRefresh,
+      boolean smoothScroll,
       @NonNull TabConfigurationStrategy tabConfigurationStrategy) {
     this.tabLayout = tabLayout;
     this.viewPager = viewPager;
     this.autoRefresh = autoRefresh;
+    this.smoothScroll = smoothScroll;
     this.tabConfigurationStrategy = tabConfigurationStrategy;
   }
 
@@ -113,7 +116,7 @@ public final class TabLayoutMediator {
     viewPager.registerOnPageChangeCallback(onPageChangeCallback);
 
     // Now we'll add a tab selected listener to set ViewPager's current item
-    onTabSelectedListener = new ViewPagerOnTabSelectedListener(viewPager);
+    onTabSelectedListener = new ViewPagerOnTabSelectedListener(viewPager, smoothScroll);
     tabLayout.addOnTabSelectedListener(onTabSelectedListener);
 
     // Now we'll populate ourselves from the pager adapter, adding an observer if
@@ -238,14 +241,16 @@ public final class TabLayoutMediator {
    */
   private static class ViewPagerOnTabSelectedListener implements TabLayout.OnTabSelectedListener {
     private final ViewPager2 viewPager;
+    private final Boolean smoothScroll;
 
-    ViewPagerOnTabSelectedListener(ViewPager2 viewPager) {
+    ViewPagerOnTabSelectedListener(ViewPager2 viewPager, Boolean smoothScroll) {
       this.viewPager = viewPager;
+      this.smoothScroll = smoothScroll;
     }
 
     @Override
     public void onTabSelected(@NonNull TabLayout.Tab tab) {
-      viewPager.setCurrentItem(tab.getPosition(), true);
+      viewPager.setCurrentItem(tab.getPosition(), smoothScroll);
     }
 
     @Override


### PR DESCRIPTION
Added the functionality to manage smooth scroll value `(true/false)` in TabLayoutMediator. 
Usecase: I am having ViewPager2 with `isUserInputEnabled=false` and I want the flexibility of changing smooth scroll to `false` when ViewPager2 current page is being set.

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
