### PR TITLE
[TextInputLayout] Add hintAlwaysFloat attribute to TextInputLayout

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -214,6 +214,7 @@ public class TextInputLayout extends LinearLayout {
   @NonNull private final TextView suffixTextView;
 
   private boolean hintEnabled;
+  private boolean hintAlwaysFloat;
   private CharSequence hint;
 
   /**
@@ -468,6 +469,7 @@ public class TextInputLayout extends LinearLayout {
             R.styleable.TextInputLayout_hintTextAppearance);
 
     hintEnabled = a.getBoolean(R.styleable.TextInputLayout_hintEnabled, true);
+    hintAlwaysFloat = a.getBoolean(R.styleable.TextInputLayout_hintAlwaysFloat, false);
     setHint(a.getText(R.styleable.TextInputLayout_android_hint));
     hintAnimationEnabled = a.getBoolean(R.styleable.TextInputLayout_hintAnimationEnabled, true);
 
@@ -1328,9 +1330,9 @@ public class TextInputLayout extends LinearLayout {
       collapsingTextHelper.setCollapsedTextColor(focusedTextColor);
     } // If none of these states apply, leave the expanded and collapsed colors as they are.
 
-    if (hasText || (isEnabled() && (hasFocus || errorShouldBeShown))) {
+    if (hasText || (isEnabled() && (hasFocus || errorShouldBeShown || hintAlwaysFloat))) {
       // We should be showing the label so do so if it isn't already
-      if (force || hintExpanded) {
+      if (force || hintAlwaysFloat || hintExpanded) {
         collapseHint(animate);
       }
     } else {

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -1330,9 +1330,9 @@ public class TextInputLayout extends LinearLayout {
       collapsingTextHelper.setCollapsedTextColor(focusedTextColor);
     } // If none of these states apply, leave the expanded and collapsed colors as they are.
 
-    if (hasText || (isEnabled() && (hasFocus || errorShouldBeShown || hintAlwaysFloat))) {
+    if (hasText || hintAlwaysFloat || (isEnabled() && (hasFocus || errorShouldBeShown))) {
       // We should be showing the label so do so if it isn't already
-      if (force || hintAlwaysFloat || hintExpanded) {
+      if (force || hintExpanded) {
         collapseHint(animate);
       }
     } else {

--- a/lib/java/com/google/android/material/textfield/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/attrs.xml
@@ -30,6 +30,8 @@
 
     <!-- Whether the layout's floating label functionality is enabled. -->
     <attr name="hintEnabled" format="boolean"/>
+    <!-- Whether the layout's floating label will always float. -->
+    <attr name="hintAlwaysFloat" format="boolean"/>
     <!-- Whether to animate hint state changes. -->
     <attr name="hintAnimationEnabled" format="boolean"/>
     <!-- TextAppearance of the hint in the collapsed floating label. -->


### PR DESCRIPTION
This adds attribute for keeping TextInputLayouts hint in collapsed state.
Refences issue #810 