### PR TITLE
[TextInputLayout] Remove perform click in DropdownMenuEndIconDelegate

### DIFF
--- a/lib/java/com/google/android/material/textfield/DropdownMenuEndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/DropdownMenuEndIconDelegate.java
@@ -349,7 +349,6 @@ class DropdownMenuEndIconDelegate extends EndIconDelegate {
                 dropdownPopupDirty = false;
               }
               showHideDropdown(editText);
-              v.performClick();
             }
             return false;
           }


### PR DESCRIPTION
### Fix double sound on click of DropDownMenu
#### [TextInputLayout] DropDownMenuEndIconDelegate

By removing the performClick from the EditText's OnClickListener. There won't be any click performed as it is already happening when you click it yourself. Android takes care of the click sound and the performClick call caused it to happen the second time.

closes #1080 

