### PR TITLE
[TextInputLayout] Do not overlay the layout hint and the edit hint

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -1301,7 +1301,7 @@ public class TextInputLayout extends LinearLayout {
 
   private void updateLabelState(boolean animate, boolean force) {
     final boolean isEnabled = isEnabled();
-    final boolean hasText = editText != null && !TextUtils.isEmpty(editText.getText());
+    final boolean hasText = editText != null && (!TextUtils.isEmpty(editText.getText()) || !TextUtils.isEmpty(editText.getHint()));
     final boolean hasFocus = editText != null && editText.hasFocus();
     final boolean errorShouldBeShown = indicatorViewController.errorShouldBeShown();
 


### PR DESCRIPTION
Everybody wants to have a label for a edit text box. But some people
also want to have some default gray value shown when the box doesn't
have anything put in there. This used to be called the "hint". But now,
the "hint" is actually used as a label. Sort of:

If the hint is set on the TextInputEditText, it operates like a normal
hint, being visible when there's no text inside. If a hint is set on the
TextInputLayout, however, it operates like a label, unless the
TextInputEditText has no text, in which case, it operates like a hint.
The result is that one winds up with two hints, one on top of the other
in an illegible mess:

![image](https://user-images.githubusercontent.com/10643/77832716-b097da00-70fd-11ea-809e-3c6928c66b62.png)

I'm currently hacking around this by subclassing TextInputEditText with
this horror:

```kt
    @Override
    override fun getText(): Editable? {
        val text = super.getText()
        if (!text.isNullOrEmpty())
            return text
        /* We want this expression in TextInputLayout.java to be true if there's a hint set:
         *        final boolean hasText = editText != null && !TextUtils.isEmpty(editText.getText());
         * But for everyone else it should return the real value, so we check the caller.
         */
        if (!hint.isNullOrEmpty() && Thread.currentThread().stackTrace[3].className == TextInputLayout::class.qualifiedName)
            return SpannableStringBuilder(hint)
        return text
    }
```

It doesn't get worse than that. This commit fixes the issue by avoiding
the expanded hint in the case that the enclosing EditText already has a
hint. It works:

![image](https://user-images.githubusercontent.com/10643/77832735-c86f5e00-70fd-11ea-8cdd-3b1b9eb86c5b.png)
