### PR TITLE
[MaterialDatePicker] Moves selection header to bottom

### DIFF
--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_selection_text.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_selection_text.xml
@@ -21,7 +21,7 @@
   style="?attr/materialCalendarHeaderSelection"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:layout_gravity="top|start"
+  android:layout_gravity="bottom|start"
   android:gravity="start|bottom"
   app:firstBaselineToTopHeight="@dimen/mtrl_calendar_selection_text_baseline_to_top"
   app:lineHeight="@dimen/mtrl_calendar_header_selection_line_height"


### PR DESCRIPTION
This moves the selection header to the bottom of its parent. Fixes the overlap between the title of the dialog and the selection header.
