### PR TITLE
[TextInputLayout] Reverse Show & Hide Password Icons

### DIFF
--- a/lib/java/com/google/android/material/textfield/res/drawable/design_password_eye.xml
+++ b/lib/java/com/google/android/material/textfield/res/drawable/design_password_eye.xml
@@ -21,22 +21,22 @@
 
     <item
         android:id="@+id/visible"
-        android:drawable="@drawable/design_ic_visibility"
+        android:drawable="@drawable/design_ic_visibility_off"
         android:state_checked="true"/>
 
     <item
         android:id="@+id/masked"
-        android:drawable="@drawable/design_ic_visibility_off"/>
+        android:drawable="@drawable/design_ic_visibility"/>
 
     <transition
         android:drawable="@drawable/avd_show_password"
-        android:fromId="@id/masked"
-        android:toId="@id/visible"/>
+        android:fromId="@id/visible"
+        android:toId="@id/masked"/>
 
     <transition
         android:drawable="@drawable/avd_hide_password"
-        android:fromId="@id/visible"
-        android:toId="@id/masked"/>
+        android:fromId="@id/masked"
+        android:toId="@id/visible"/>
 
 </animated-selector>
 


### PR DESCRIPTION
Fixes #1171 

There's a few ways this could be done, including re-naming image resources.

![Screenshot_20200420-183011_Material Components Catalog](https://user-images.githubusercontent.com/2594178/79805974-58877880-8335-11ea-9465-5c4b72a46452.jpg)
![Screenshot_20200420-183021_Material Components Catalog](https://user-images.githubusercontent.com/2594178/79805977-59200f00-8335-11ea-8acd-9c0210991cc0.jpg)
![Screenshot_20200420-183026_Material Components Catalog](https://user-images.githubusercontent.com/2594178/79805978-59200f00-8335-11ea-911c-e14df721249e.jpg)


### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
