### PR TITLE
[TextInputLayout] Fix: merge icon and view state when setting icon color

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -3840,11 +3840,24 @@ public class TextInputLayout extends LinearLayout {
     }
 
     int color =
-        colorStateList.getColorForState(this.getDrawableState(), colorStateList.getDefaultColor());
+        colorStateList.getColorForState(mergeIconState(iconView), colorStateList.getDefaultColor());
 
     icon = DrawableCompat.wrap(icon).mutate();
     DrawableCompat.setTintList(icon, ColorStateList.valueOf(color));
     iconView.setImageDrawable(icon);
+  }
+
+  private int[] mergeIconState(CheckableImageButton iconView) {
+    int[] textInputStates = this.getDrawableState();
+    int[] iconStates = iconView.getDrawableState();
+
+    int[] states = new int[textInputStates.length + iconStates.length];
+    int index = textInputStates.length;
+
+    System.arraycopy(textInputStates, 0, states, 0, textInputStates.length);
+    System.arraycopy(iconStates, 0, states, index, iconStates.length);
+
+    return states;
   }
 
   private void expandHint(boolean animate) {


### PR DESCRIPTION
closes #1235 

Side-effect of b17d042f

**Description:** neither `errorIconView`, `endIconView` and `startIconView` are using their states when updating their color.

**Expected behavior:** icons should be able to update their state if they are checked, focused, hovered, activated, etc.

**Source code:**
Create a color selector with state_checked:
```xml
<selector xmlns:android="http://schemas.android.com/apk/res/android">
  <item android:color="?attr/colorPrimary" android:state_checked="true"/>
  <item android:alpha="0.38" android:color="?attr/colorOnSurface" android:state_enabled="false"/>
  <item android:alpha="0.54" android:color="?attr/colorOnSurface"/>
</selector>
```

The icon does not change it's color when checked, as it currently only uses the TextInputLayout state in `updateIconColorOnState`.

**Android API version:** any (tested with 29 and 24)

**Material Library version:** 1.2.0-alpha06 (testes with master branch)

**Device:** any (tested with S10+ and Nexus 6)

**Solution:** merge icon state with view state when updating color.