### PR TITLE
[TextInputLayout] set endIconView as active when TextInputEditText gain focus

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputEditText.java
+++ b/lib/java/com/google/android/material/textfield/TextInputEditText.java
@@ -223,4 +223,13 @@ public class TextInputEditText extends AppCompatEditText {
       return "";
     }
   }
+
+  @Override
+  protected void onFocusChanged(boolean focused, int direction, Rect previouslyFocusedRect) {
+    super.onFocusChanged(focused, direction, previouslyFocusedRect);
+    TextInputLayout textInputLayout = getTextInputLayout();
+    if (textInputLayout != null) {
+      textInputLayout.setEndIconActivated(focused);
+    }
+  }
 }

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -3840,11 +3840,24 @@ public class TextInputLayout extends LinearLayout {
     }
 
     int color =
-        colorStateList.getColorForState(this.getDrawableState(), colorStateList.getDefaultColor());
+        colorStateList.getColorForState(mergeIconState(iconView), colorStateList.getDefaultColor());
 
     icon = DrawableCompat.wrap(icon).mutate();
     DrawableCompat.setTintList(icon, ColorStateList.valueOf(color));
     iconView.setImageDrawable(icon);
+  }
+
+  private int[] mergeIconState(CheckableImageButton iconView) {
+    int[] textInputStates = this.getDrawableState();
+    int[] iconStates = iconView.getDrawableState();
+
+    int[] states = new int[textInputStates.length + iconStates.length];
+    int index = textInputStates.length;
+
+    System.arraycopy(textInputStates, 0, states, 0, textInputStates.length);
+    System.arraycopy(iconStates, 0, states, index, iconStates.length);
+
+    return states;
   }
 
   private void expandHint(boolean animate) {


### PR DESCRIPTION
closes #879 

This feature allows the endIconView to be set as activated when TextInputEditText gains focus.

The feature is blocked by #1235 (186c8f0786b57c406694501389ba31c91bc128e2)