### PR TITLE
[SwitchMaterial] Add option to show switch button at the start of the…

### DIFF
--- a/catalog/java/io/material/catalog/switchmaterial/res/layout/cat_switch.xml
+++ b/catalog/java/io/material/catalog/switchmaterial/res/layout/cat_switch.xml
@@ -65,6 +65,18 @@
         android:checked="false"
         android:enabled="false"
         android:text="@string/cat_switch_disabled"/>
+    <TextView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:layout_columnSpan="2"
+      android:text="@string/cat_switch_gravity_guide"
+      android:textSize="@dimen/cat_switch_header_size"/>
+    <com.google.android.material.switchmaterial.SwitchMaterial
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:text="@string/cat_switch_gravity"
+      android:gravity="center_vertical|end"
+      app:switchGravity="start"/>
   </GridLayout>
   <ImageView
       android:layout_width="match_parent"

--- a/catalog/java/io/material/catalog/switchmaterial/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/switchmaterial/res/values/strings.xml
@@ -33,6 +33,10 @@
     description="The description of how switches look like when disabled. [CHAR LIMIT=NONE]">
     Switch elements that are disabled cannot be interacted with and will appear faded.
   </string>
+  <string name="cat_switch_gravity_guide"
+    description="The description of how switches look when setting switch gravity to start. [CHAR LIMIT=NONE]">
+    Switch elements that have gravity set to start.
+  </string>
   <string name="cat_switch_enabled"
     description="The label of enabled switches. [CHAR LIMIT=NONE]">
     Enabled
@@ -40,6 +44,10 @@
   <string name="cat_switch_disabled"
     description="The label of disabled switches. [CHAR LIMIT=NONE]">
     Disabled
+  </string>
+  <string name="cat_switch_gravity"
+    description="The label explaining the gravity of a switch. [CHAR LIMIT=NONE]">
+    Gravity
   </string>
   <string name="cat_switch_toggleable_description"
     description="The label explaining the function of a switch which toggles the state of enabling of the example switches. [CHAR LIMIT=NONE]">

--- a/lib/java/com/google/android/material/switchmaterial/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/switchmaterial/res/values/attrs.xml
@@ -21,5 +21,12 @@
       be ignored. This value should be set to false when using custom drawables
       that should not be tinted. This value is ignored if a buttonTint is set. -->
     <attr name="useMaterialThemeColors"/>
+    <!-- Specifies how the switch should be positioned on the X axis. -->
+    <attr name="switchGravity">
+      <!-- Push the switch to the start of the view. -->
+      <flag name="start" value="0x1"/>
+      <!-- Push the switch to the end of the view. This is the default value. -->
+      <flag name="end" value="0x2"/>
+    </attr>
   </declare-styleable>
 </resources>


### PR DESCRIPTION
closes #1239 

Add a new attribute called `switchGravity` with values `start` and `end`, where `end` is the default value that positions the switch button at the end of the view, and `start` positions the switch button at the start of the view.

In order to position the text to the end of the view when using `switchGravity` set to `start`, it's necessary to use `gravity` set to `center_vertical|end` in order to keep the text centred vertically and to the end of the view.