### PR TITLE
[Chip]Fix chip icon with different width and height

### DIFF
--- a/lib/java/com/google/android/material/chip/Chip.java
+++ b/lib/java/com/google/android/material/chip/Chip.java
@@ -2252,6 +2252,9 @@ public class Chip extends AppCompatCheckBox implements Delegate, Shapeable {
   /**
    * Sets if the chip's leading icon should use drawable size instead of chipIconSize.
    *
+   * <p>Note: To avoid icon shrink/stretch when using chipIcon and checkedIcon together,
+   * consider provide same size drawable for both.
+   *
    * @param useDrawableSize whether to use chip's leading icon drawable size.
    * @attr ref com.google.android.material.R.styleable#Chip_useChipIconDrawableSize
    */

--- a/lib/java/com/google/android/material/chip/Chip.java
+++ b/lib/java/com/google/android/material/chip/Chip.java
@@ -2265,7 +2265,7 @@ public class Chip extends AppCompatCheckBox implements Delegate, Shapeable {
   }
 
   /**
-   * Returns if chip's leading icon should use it's drawable size when measuring chip icon bounds.
+   * Return if chip's leading icon should use its drawable size when measuring chip icon bounds.
    *
    * @see #setUseChipIconDrawableSize(boolean)
    * @attr ref com.google.android.material.R.styleable#Chip_useChipIconDrawableSize

--- a/lib/java/com/google/android/material/chip/Chip.java
+++ b/lib/java/com/google/android/material/chip/Chip.java
@@ -2250,6 +2250,28 @@ public class Chip extends AppCompatCheckBox implements Delegate, Shapeable {
   }
 
   /**
+   * Sets if the chip's leading icon should use drawable size instead of chipIconSize.
+   *
+   * @param useDrawableSize whether to use chip's leading icon drawable size.
+   * @attr ref com.google.android.material.R.styleable#Chip_useChipIconDrawableSize
+   */
+  public void setUseChipIconDrawableSize(boolean useDrawableSize) {
+    if (chipDrawable != null) {
+      chipDrawable.setUseChipIconDrawableSize(useDrawableSize);
+    }
+  }
+
+  /**
+   * Returns if chip's leading icon should use it's drawable size when measuring chip icon bounds.
+   *
+   * @see #setUseChipIconDrawableSize(boolean)
+   * @attr ref com.google.android.material.R.styleable#Chip_useChipIconDrawableSize
+   */
+  public boolean isUseChipIconDrawableSize() {
+    return chipDrawable != null && chipDrawable.isUseChipIconDrawableSize();
+  }
+
+  /**
    * Returns whether this chip will expand its bounds (if needed) to meet the minimum touch target
    * size.
    *

--- a/lib/java/com/google/android/material/chip/ChipDrawable.java
+++ b/lib/java/com/google/android/material/chip/ChipDrawable.java
@@ -528,8 +528,8 @@ public class ChipDrawable extends MaterialShapeDrawable
   }
 
   /**
-   * Returns the chip's leading icon width.
-   * If chipIconUseDrawableSize is true return chipIconSize, otherwise, current icon drawable width.
+   * Return the chip's leading icon width.
+   * If useChipIconDrawableSize is false return chipIconSize, otherwise, current icon drawable width.
    */
   private float currentChipIconWidth() {
     Drawable iconDrawable = currentChecked ? checkedIcon : chipIcon;
@@ -540,8 +540,8 @@ public class ChipDrawable extends MaterialShapeDrawable
   }
 
   /**
-   * Returns the chip's leading icon height.
-   * If chipIconUseDrawableSize is true return chipIconSize, otherwise, current icon drawable height.
+   * Return the chip's leading icon height.
+   * If useChipIconDrawableSize is false return chipIconSize, otherwise, current icon drawable height.
    *
    * The drawable height should be smaller or equal than chipIconSize
    */
@@ -1695,7 +1695,7 @@ public class ChipDrawable extends MaterialShapeDrawable
   }
 
   /**
-   * Returns if chip's leading icon should use it's drawable size when measuring chip icon bounds.
+   * Return if chip's leading icon should use its drawable size when measuring chip icon bounds.
    *
    * @see #setUseChipIconDrawableSize(boolean)
    * @attr ref com.google.android.material.R.styleable#Chip_useChipIconDrawableSize

--- a/lib/java/com/google/android/material/chip/ChipDrawable.java
+++ b/lib/java/com/google/android/material/chip/ChipDrawable.java
@@ -183,6 +183,7 @@ public class ChipDrawable extends MaterialShapeDrawable
   @Nullable private ColorStateList chipIconTint;
   private float chipIconSize;
   private boolean hasChipIconTint;
+  private boolean chipIconUseDrawableSize;
 
   // Close icon
   private boolean closeIconVisible;
@@ -379,6 +380,7 @@ public class ChipDrawable extends MaterialShapeDrawable
         && attrs.getAttributeValue(NAMESPACE_APP, "chipIconVisible") == null) {
       setChipIconVisible(a.getBoolean(R.styleable.Chip_chipIconEnabled, false));
     }
+    setChipIconUseDrawableSize(a.getBoolean(R.styleable.Chip_chipIconUseDrawableSize, false));
     setChipIcon(MaterialResources.getDrawable(context, a, R.styleable.Chip_chipIcon));
     if (a.hasValue(R.styleable.Chip_chipIconTint)) {
       setChipIconTint(
@@ -527,11 +529,11 @@ public class ChipDrawable extends MaterialShapeDrawable
 
   /**
    * Returns the width of the chip using, chipIconSize, checkedIcon or chipIcon.
-   * If chipIconSize is set - not 0 - return it, otherwise, current icon drawable width.
+   * If chipIconUseDrawableSize is true return chipIconSize, otherwise, current icon drawable width.
    */
   private float currentChipIconWidth() {
     Drawable iconDrawable = currentChecked ? checkedIcon : chipIcon;
-    if (chipIconSize == 0 && iconDrawable != null) {
+    if (chipIconUseDrawableSize && iconDrawable != null) {
       return iconDrawable.getIntrinsicWidth();
     }
     return chipIconSize;
@@ -539,11 +541,11 @@ public class ChipDrawable extends MaterialShapeDrawable
 
   /**
    * Returns the height of the chip using, chipIconSize, checkedIcon or chipIcon.
-   * If chipIconSize is set - not 0 - return it, otherwise, current icon drawable height.
+   * If chipIconUseDrawableSize is true return chipIconSize, otherwise, current icon drawable height.
    */
   private float currentChipIconHeight() {
     Drawable iconDrawable = currentChecked ? checkedIcon : chipIcon;
-    if (chipIconSize == 0 && iconDrawable != null) {
+    if (chipIconUseDrawableSize && iconDrawable != null) {
       return iconDrawable.getIntrinsicHeight();
     }
     return chipIconSize;
@@ -1676,6 +1678,10 @@ public class ChipDrawable extends MaterialShapeDrawable
 
   public void setChipIconResource(@DrawableRes int id) {
     setChipIcon(AppCompatResources.getDrawable(context, id));
+  }
+
+  public void setChipIconUseDrawableSize(boolean useDrawableSize) {
+    chipIconUseDrawableSize = useDrawableSize;
   }
 
   public void setChipIcon(@Nullable Drawable chipIcon) {

--- a/lib/java/com/google/android/material/chip/ChipDrawable.java
+++ b/lib/java/com/google/android/material/chip/ChipDrawable.java
@@ -542,11 +542,13 @@ public class ChipDrawable extends MaterialShapeDrawable
   /**
    * Returns the height of the chip using, chipIconSize, checkedIcon or chipIcon.
    * If chipIconUseDrawableSize is true return chipIconSize, otherwise, current icon drawable height.
+   *
+   * The drawable height should be smaller or equal than chipIconSize
    */
   private float currentChipIconHeight() {
-    Drawable iconDrawable = currentChecked ? checkedIcon : chipIcon;
-    if (chipIconUseDrawableSize && iconDrawable != null) {
-      return iconDrawable.getIntrinsicHeight();
+    Drawable icon = currentChecked ? checkedIcon : chipIcon;
+    if (chipIconUseDrawableSize && icon != null && icon.getIntrinsicHeight() <= chipIconSize) {
+      return icon.getIntrinsicHeight();
     }
     return chipIconSize;
   }

--- a/lib/java/com/google/android/material/chip/ChipDrawable.java
+++ b/lib/java/com/google/android/material/chip/ChipDrawable.java
@@ -520,9 +520,33 @@ public class ChipDrawable extends MaterialShapeDrawable
   /** Returns the width of the chip icon plus padding, which only apply if the chip icon exists. */
   float calculateChipIconWidth() {
     if (showsChipIcon() || (showsCheckedIcon())) {
-      return iconStartPadding + chipIconSize + iconEndPadding;
+      return iconStartPadding + currentChipIconWidth() + iconEndPadding;
     }
     return 0f;
+  }
+
+  /**
+   * Returns the width of the chip using, chipIconSize, checkedIcon or chipIcon.
+   * If chipIconSize is set - not 0 - return it, otherwise, current icon drawable width.
+   */
+  private float currentChipIconWidth() {
+    Drawable iconDrawable = currentChecked ? checkedIcon : chipIcon;
+    if (chipIconSize == 0 && iconDrawable != null) {
+      return iconDrawable.getIntrinsicWidth();
+    }
+    return chipIconSize;
+  }
+
+  /**
+   * Returns the height of the chip using, chipIconSize, checkedIcon or chipIcon.
+   * If chipIconSize is set - not 0 - return it, otherwise, current icon drawable height.
+   */
+  private float currentChipIconHeight() {
+    Drawable iconDrawable = currentChecked ? checkedIcon : chipIcon;
+    if (chipIconSize == 0 && iconDrawable != null) {
+      return iconDrawable.getIntrinsicHeight();
+    }
+    return chipIconSize;
   }
 
   /**
@@ -779,17 +803,19 @@ public class ChipDrawable extends MaterialShapeDrawable
 
     if (showsChipIcon() || showsCheckedIcon()) {
       float offsetFromStart = chipStartPadding + iconStartPadding;
+      float chipWidth = currentChipIconWidth();
 
       if (DrawableCompat.getLayoutDirection(this) == ViewCompat.LAYOUT_DIRECTION_LTR) {
         outBounds.left = bounds.left + offsetFromStart;
-        outBounds.right = outBounds.left + chipIconSize;
+        outBounds.right = outBounds.left + chipWidth;
       } else {
         outBounds.right = bounds.right - offsetFromStart;
-        outBounds.left = outBounds.right - chipIconSize;
+        outBounds.left = outBounds.right - chipWidth;
       }
 
-      outBounds.top = bounds.exactCenterY() - chipIconSize / 2f;
-      outBounds.bottom = outBounds.top + chipIconSize;
+      float chipHeight = currentChipIconHeight();
+      outBounds.top = bounds.exactCenterY() - chipHeight / 2f;
+      outBounds.bottom = outBounds.top + chipHeight;
     }
   }
 

--- a/lib/java/com/google/android/material/chip/ChipDrawable.java
+++ b/lib/java/com/google/android/material/chip/ChipDrawable.java
@@ -183,7 +183,7 @@ public class ChipDrawable extends MaterialShapeDrawable
   @Nullable private ColorStateList chipIconTint;
   private float chipIconSize;
   private boolean hasChipIconTint;
-  private boolean chipIconUseDrawableSize;
+  private boolean useChipIconDrawableSize;
 
   // Close icon
   private boolean closeIconVisible;
@@ -380,7 +380,7 @@ public class ChipDrawable extends MaterialShapeDrawable
         && attrs.getAttributeValue(NAMESPACE_APP, "chipIconVisible") == null) {
       setChipIconVisible(a.getBoolean(R.styleable.Chip_chipIconEnabled, false));
     }
-    setChipIconUseDrawableSize(a.getBoolean(R.styleable.Chip_chipIconUseDrawableSize, false));
+    setUseChipIconDrawableSize(a.getBoolean(R.styleable.Chip_useChipIconDrawableSize, false));
     setChipIcon(MaterialResources.getDrawable(context, a, R.styleable.Chip_chipIcon));
     if (a.hasValue(R.styleable.Chip_chipIconTint)) {
       setChipIconTint(
@@ -533,7 +533,7 @@ public class ChipDrawable extends MaterialShapeDrawable
    */
   private float currentChipIconWidth() {
     Drawable iconDrawable = currentChecked ? checkedIcon : chipIcon;
-    if (chipIconUseDrawableSize && iconDrawable != null) {
+    if (useChipIconDrawableSize && iconDrawable != null) {
       return iconDrawable.getIntrinsicWidth();
     }
     return chipIconSize;
@@ -547,7 +547,7 @@ public class ChipDrawable extends MaterialShapeDrawable
    */
   private float currentChipIconHeight() {
     Drawable icon = currentChecked ? checkedIcon : chipIcon;
-    if (chipIconUseDrawableSize && icon != null && icon.getIntrinsicHeight() <= chipIconSize) {
+    if (useChipIconDrawableSize && icon != null && icon.getIntrinsicHeight() <= chipIconSize) {
       return icon.getIntrinsicHeight();
     }
     return chipIconSize;
@@ -1682,8 +1682,8 @@ public class ChipDrawable extends MaterialShapeDrawable
     setChipIcon(AppCompatResources.getDrawable(context, id));
   }
 
-  public void setChipIconUseDrawableSize(boolean useDrawableSize) {
-    chipIconUseDrawableSize = useDrawableSize;
+  public void setUseChipIconDrawableSize(boolean useDrawableSize) {
+    useChipIconDrawableSize = useDrawableSize;
   }
 
   public void setChipIcon(@Nullable Drawable chipIcon) {

--- a/lib/java/com/google/android/material/chip/ChipDrawable.java
+++ b/lib/java/com/google/android/material/chip/ChipDrawable.java
@@ -1690,6 +1690,8 @@ public class ChipDrawable extends MaterialShapeDrawable
    */
   public void setUseChipIconDrawableSize(boolean useDrawableSize) {
     useChipIconDrawableSize = useDrawableSize;
+    invalidateSelf();
+    onSizeChange();
   }
 
   /**

--- a/lib/java/com/google/android/material/chip/ChipDrawable.java
+++ b/lib/java/com/google/android/material/chip/ChipDrawable.java
@@ -542,7 +542,8 @@ public class ChipDrawable extends MaterialShapeDrawable
   /**
    * Returns the chip's leading icon height.
    * If chipIconUseDrawableSize is true return chipIconSize, otherwise, current icon drawable height.
-   * The drawable height should be smaller or equal than chipIconSize so it will keep aspect ratio
+   *
+   * The drawable height should be smaller or equal than chipIconSize
    */
   private float currentChipIconHeight() {
     Drawable icon = currentChecked ? checkedIcon : chipIcon;
@@ -1681,8 +1682,24 @@ public class ChipDrawable extends MaterialShapeDrawable
     setChipIcon(AppCompatResources.getDrawable(context, id));
   }
 
+  /**
+   * Sets if the chip's leading icon should use drawable size instead of chipIconSize.
+   *
+   * @param useDrawableSize whether to use chip's leading icon drawable size.
+   * @attr ref com.google.android.material.R.styleable#Chip_useChipIconDrawableSize
+   */
   public void setUseChipIconDrawableSize(boolean useDrawableSize) {
     useChipIconDrawableSize = useDrawableSize;
+  }
+
+  /**
+   * Returns if chip's leading icon should use it's drawable size when measuring chip icon bounds.
+   *
+   * @see #setUseChipIconDrawableSize(boolean)
+   * @attr ref com.google.android.material.R.styleable#Chip_useChipIconDrawableSize
+   */
+  public boolean isUseChipIconDrawableSize() {
+    return useChipIconDrawableSize;
   }
 
   public void setChipIcon(@Nullable Drawable chipIcon) {

--- a/lib/java/com/google/android/material/chip/ChipDrawable.java
+++ b/lib/java/com/google/android/material/chip/ChipDrawable.java
@@ -542,8 +542,7 @@ public class ChipDrawable extends MaterialShapeDrawable
   /**
    * Returns the chip's leading icon height.
    * If chipIconUseDrawableSize is true return chipIconSize, otherwise, current icon drawable height.
-   *
-   * The drawable height should be smaller or equal than chipIconSize
+   * The drawable height should be smaller or equal than chipIconSize so it will keep aspect ratio
    */
   private float currentChipIconHeight() {
     Drawable icon = currentChecked ? checkedIcon : chipIcon;

--- a/lib/java/com/google/android/material/chip/ChipDrawable.java
+++ b/lib/java/com/google/android/material/chip/ChipDrawable.java
@@ -528,7 +528,7 @@ public class ChipDrawable extends MaterialShapeDrawable
   }
 
   /**
-   * Returns the width of the chip using, chipIconSize, checkedIcon or chipIcon.
+   * Returns the chip's leading icon width.
    * If chipIconUseDrawableSize is true return chipIconSize, otherwise, current icon drawable width.
    */
   private float currentChipIconWidth() {
@@ -540,7 +540,7 @@ public class ChipDrawable extends MaterialShapeDrawable
   }
 
   /**
-   * Returns the height of the chip using, chipIconSize, checkedIcon or chipIcon.
+   * Returns the chip's leading icon height.
    * If chipIconUseDrawableSize is true return chipIconSize, otherwise, current icon drawable height.
    *
    * The drawable height should be smaller or equal than chipIconSize

--- a/lib/java/com/google/android/material/chip/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/chip/res/values/attrs.xml
@@ -67,7 +67,7 @@
     <attr name="chipIconTint" format="color"/>
     <!-- Size of the chip's icon and checked icon. -->
     <attr name="chipIconSize" format="dimension"/>
-    <!-- Whether to use chip's icon/checkedIcon drawable size or chipIconSize. -->
+    <!-- Whether to use chip's leading icon drawable size or chipIconSize. -->
     <attr name="useChipIconDrawableSize" format="boolean"/>
 
     <!-- Whether to show the close icon. -->

--- a/lib/java/com/google/android/material/chip/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/chip/res/values/attrs.xml
@@ -67,6 +67,8 @@
     <attr name="chipIconTint" format="color"/>
     <!-- Size of the chip's icon and checked icon. -->
     <attr name="chipIconSize" format="dimension"/>
+    <!-- Whether to use chip's icon drawable size or chipIconSize. -->
+    <attr name="chipIconUseDrawableSize" format="boolean"/>
 
     <!-- Whether to show the close icon. -->
     <attr name="closeIconVisible" format="boolean"/>

--- a/lib/java/com/google/android/material/chip/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/chip/res/values/attrs.xml
@@ -68,7 +68,7 @@
     <!-- Size of the chip's icon and checked icon. -->
     <attr name="chipIconSize" format="dimension"/>
     <!-- Whether to use chip's icon drawable size or chipIconSize. -->
-    <attr name="chipIconUseDrawableSize" format="boolean"/>
+    <attr name="useChipIconDrawableSize" format="boolean"/>
 
     <!-- Whether to show the close icon. -->
     <attr name="closeIconVisible" format="boolean"/>

--- a/lib/java/com/google/android/material/chip/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/chip/res/values/attrs.xml
@@ -67,7 +67,7 @@
     <attr name="chipIconTint" format="color"/>
     <!-- Size of the chip's icon and checked icon. -->
     <attr name="chipIconSize" format="dimension"/>
-    <!-- Whether to use chip's icon drawable size or chipIconSize. -->
+    <!-- Whether to use chip's icon/checkedIcon drawable size or chipIconSize. -->
     <attr name="useChipIconDrawableSize" format="boolean"/>
 
     <!-- Whether to show the close icon. -->


### PR DESCRIPTION
solves [#1241 ](https://github.com/material-components/material-components-android/issues/1241)

Now using `app:chipIconUseDrawableSize="true"` it will use the drawable size not the chipIconSize.

Working for chipIcon and checkedIcon.
