### PR TITLE
[MaterialDatePicker] Single/Range Selectors Allows Positive Button Interaction For Invalid State

### DIFF
--- a/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
+++ b/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
@@ -207,31 +207,27 @@ public class RangeDateSelector implements DateSelector<Pair<Long, Long>> {
 
           @Override
           void onValidDate(@Nullable Long day) {
-            proposedTextStart = day;
+            selectedStartItem = day;
             updateIfValidTextProposal(startTextInput, endTextInput, listener);
           }
 
           @Override
           void onInvalidDate() {
-            updateIfValidTextProposal(startTextInput, endTextInput, listener);
-
             selectedStartItem = null;
-            listener.onSelectionChanged(getSelection());
+            updateIfValidTextProposal(startTextInput, endTextInput, listener);
           }
         });
 
     endEditText.addTextChangedListener(
         new DateFormatTextWatcher(formatHint, format, endTextInput, constraints) {
           void onValidDate(@Nullable Long day) {
-            proposedTextEnd = day;
+            selectedEndItem = day;
             updateIfValidTextProposal(startTextInput, endTextInput, listener);
           }
 
           void onInvalidDate() {
-            updateIfValidTextProposal(startTextInput, endTextInput, listener);
-
             selectedEndItem = null;
-            listener.onSelectionChanged(getSelection());
+            updateIfValidTextProposal(startTextInput, endTextInput, listener);
           }
         });
 
@@ -248,17 +244,13 @@ public class RangeDateSelector implements DateSelector<Pair<Long, Long>> {
       @NonNull TextInputLayout startTextInput,
       @NonNull TextInputLayout endTextInput,
       @NonNull OnSelectionChangedListener<Pair<Long, Long>> listener) {
-    if (proposedTextStart == null || proposedTextEnd == null) {
+    if (selectedStartItem == null || selectedEndItem == null) {
       clearInvalidRange(startTextInput, endTextInput);
-      return;
-    }
-    if (isValidRange(proposedTextStart, proposedTextEnd)) {
-      selectedStartItem = proposedTextStart;
-      selectedEndItem = proposedTextEnd;
-      listener.onSelectionChanged(getSelection());
-    } else {
+    } else if (!isValidRange(selectedStartItem, selectedEndItem)) {
       setInvalidRange(startTextInput, endTextInput);
     }
+
+    listener.onSelectionChanged(getSelection());
   }
 
   private void clearInvalidRange(@NonNull TextInputLayout start, @NonNull TextInputLayout end) {

--- a/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
+++ b/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
@@ -213,7 +213,6 @@ public class RangeDateSelector implements DateSelector<Pair<Long, Long>> {
 
           @Override
           void onInvalidDate() {
-            proposedTextStart = null;
             updateIfValidTextProposal(startTextInput, endTextInput, listener);
 
             selectedStartItem = null;
@@ -229,7 +228,6 @@ public class RangeDateSelector implements DateSelector<Pair<Long, Long>> {
           }
 
           void onInvalidDate() {
-            proposedTextEnd = null;
             updateIfValidTextProposal(startTextInput, endTextInput, listener);
 
             selectedEndItem = null;

--- a/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
+++ b/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
@@ -215,6 +215,9 @@ public class RangeDateSelector implements DateSelector<Pair<Long, Long>> {
           void onInvalidDate() {
             proposedTextStart = null;
             updateIfValidTextProposal(startTextInput, endTextInput, listener);
+
+            selectedStartItem = null;
+            listener.onSelectionChanged(getSelection());
           }
         });
 
@@ -228,6 +231,9 @@ public class RangeDateSelector implements DateSelector<Pair<Long, Long>> {
           void onInvalidDate() {
             proposedTextEnd = null;
             updateIfValidTextProposal(startTextInput, endTextInput, listener);
+
+            selectedEndItem = null;
+            listener.onSelectionChanged(getSelection());
           }
         });
 

--- a/lib/java/com/google/android/material/datepicker/SingleDateSelector.java
+++ b/lib/java/com/google/android/material/datepicker/SingleDateSelector.java
@@ -126,6 +126,12 @@ public class SingleDateSelector implements DateSelector<Long> {
             }
             listener.onSelectionChanged(getSelection());
           }
+
+          @Override
+          void onInvalidDate() {
+            clearSelection();
+            listener.onSelectionChanged(getSelection());
+          }
         });
 
     ViewUtils.requestFocusAndShowKeyboard(dateEditText);


### PR DESCRIPTION
- [x] Identify the component the PR relates to in brackets in the title.
- [x] Link to GitHub issues it solves. closes #1270 
- [x] Sign the CLA bot. You can do this once the pull request is opened.

### Expected behavior:
The Positive Button CTA should be disabled, if the Date Text Input(s) is/are invalid.

![textInputInvalidCorrect](https://user-images.githubusercontent.com/1795695/80924508-fe33e200-8d4e-11ea-89f9-c2c12fca0a88.png)

### Current Behavior: 
The Positive Button CTA is always enabled, even if the Date Text Input(s) is/are invalid.

![textInputInvalidIncorrect](https://user-images.githubusercontent.com/1795695/80924565-4bb04f00-8d4f-11ea-97b2-54c20ec6b74c.png)