### PR TITLE
CI system hotfix (urgent)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   matrix:
     - EMULATOR_API=16
     - EMULATOR_API=19
-    - EMULATOR_API=24
+    - EMULATOR_API=23
 
 install:
   - export ANDROID_HOME=~/android-sdk-linux


### PR DESCRIPTION
closes #1297 

The small change proposed addresses the issue discussed in #1297 by changing the Android 24 VM to run Android API 23. By doing so, `sdkmanager` can continue with a valid system image and continue running.

Currently, there are no available `armeabi-v7a` system image that runs Android 24. I have tried using a different Android 24 system image, but that means recoding the CI script to support arm64 system images.

#1297 affects all CI runs currently, so it is best if this fix is merged in as soon as possible, so that the CI can work once again.

