### PR TITLE
[Documentation] Fixed materialAlertDialogTitleTextStyle default value

### DIFF
--- a/docs/components/Dialog.md
+++ b/docs/components/Dialog.md
@@ -272,7 +272,7 @@ Default theme overlay attribute: `?attr/materialAlertDialogTheme`
 &nbsp;                    | **Theme attribute**                       | **Default value**
 ------------------------- | ----------------------------------------- | -----------------
 **Default style**         | `?attr/alertDialogStyle`                  | `@style/MaterialAlertDialog.MaterialComponents`
-**Title text style**      | `?attr/materialAlertDialogTitleTextStyle` | `@style/MaterialAlertDialog.MaterialComponents.Title.Icon`
+**Title text style**      | `?attr/materialAlertDialogTitleTextStyle` | `@style/MaterialAlertDialog.MaterialComponents.Title.Text`
 **Supporting text style** | `?attr/materialAlertDialogBodyTextStyle`  | `@style/MaterialAlertDialog.MaterialComponents.Body.Text`
 
 See full list of


### PR DESCRIPTION
The default value of materialAlertDialogTitleTextStyle is not `@style/MaterialAlertDialog.MaterialComponents.Title.Icon` but `@style/MaterialAlertDialog.MaterialComponents.Title.Text` according to the source code [here](https://github.com/material-components/material-components-android/blob/daa3a0406902be6aa16b2cc7fec18f7fd6134371/lib/java/com/google/android/material/dialog/res/values/themes.xml#L73)

```
    <item name="materialAlertDialogTitleTextStyle">@style/MaterialAlertDialog.MaterialComponents.Title.Text</item>
```