### PR TITLE
[Divider] Added a full-bleed divider UI component

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -48,6 +48,7 @@ def srcDirs = [
   'com/google/android/material/color',
   'com/google/android/material/datepicker',
   'com/google/android/material/dialog',
+  'com/google/android/material/divider',
   'com/google/android/material/drawable',
   'com/google/android/material/elevation',
   'com/google/android/material/expandable',

--- a/lib/java/com/google/android/material/divider/MaterialDivider.java
+++ b/lib/java/com/google/android/material/divider/MaterialDivider.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.material.divider;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewGroup.LayoutParams;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.Dimension;
+import androidx.annotation.Px;
+
+import com.google.android.material.R;
+import com.google.android.material.internal.ThemeEnforcement;
+import com.google.android.material.internal.ViewUtils;
+
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
+import static com.google.android.material.theme.overlay.MaterialThemeOverlay.wrap;
+
+public class MaterialDivider extends View {
+
+
+  public MaterialDivider(Context context) {
+    this(context, null);
+  }
+
+  public MaterialDivider(Context context, AttributeSet attrs) {
+    this(context, attrs, R.attr.dividerStyle);
+  }
+
+  boolean isRtlEnabled;
+
+  AttributeSet initialAttrs;
+  int initialDefStyleAttr;
+
+  private static final int DEF_STYLE_RES = R.style.Widget_MaterialComponents_Divider;
+
+  public MaterialDivider(Context context, AttributeSet attrs, int defStyleAttr) {
+
+    super(wrap(context, attrs, defStyleAttr, DEF_STYLE_RES), attrs, defStyleAttr);
+    initialAttrs = attrs;
+    initialDefStyleAttr = defStyleAttr;
+    isRtlEnabled = ViewUtils.isLayoutRtl(this);
+
+    float alpha = attrs.getAttributeFloatValue("http://schemas.android.com/apk/res/android", "alpha", -1);
+    int color = attrs.getAttributeIntValue(android.R.attr.background, -1);
+
+    final TypedArray dividerStyleAttrs = getDividerStyleAttrs();
+    if (alpha == -1) {
+      alpha = dividerStyleAttrs.getFloat(ATTR_ALPHA, -1);
+    }
+    if (color == -1) {
+      color = dividerStyleAttrs.getColor(ATTR_COLOR, -1);
+    }
+
+    setAlpha(alpha);
+    setColor(color);
+  }
+
+  int[] ATTRS = {R.attr.dividerAlpha, R.attr.dividerColor, R.attr.dividerInset, R.attr.dividerSize};
+  private static final int ATTR_ALPHA = 0;
+  private static final int ATTR_COLOR = 1;
+  private static final int ATTR_INSET = 2;
+  private static final int ATTR_SIZE = 3;
+
+  private TypedArray getDividerStyleAttrs() {
+    TypedValue dividerStyle = new TypedValue();
+    getContext().getTheme().resolveAttribute(R.attr.dividerStyle, dividerStyle, true);
+    return getContext().obtainStyledAttributes(dividerStyle.resourceId, ATTRS);
+  }
+
+  //Runs when this view's layoutParams are available
+  @Override
+  protected void onAttachedToWindow() {
+
+    super.onAttachedToWindow();
+    initializeOrientation();
+    TypedArray dividerStyleAttrs = getDividerStyleAttrs();
+    TypedArray styledAttributes =
+        ThemeEnforcement.obtainStyledAttributes(getContext(), initialAttrs, R.styleable.MaterialDivider, initialDefStyleAttr, DEF_STYLE_RES);
+    LayoutParams layoutParams = getLayoutParams();
+
+    if (orientation != INVALID) {
+      int size = orientation == VERTICAL ? layoutParams.height : layoutParams.width;
+      if (size == WRAP_CONTENT) {
+        size = (int) dividerStyleAttrs.getDimension(ATTR_SIZE, -1);
+        setSize(size);
+      }
+    }
+
+    if (orientation == VERTICAL) {
+      int inset = (int) styledAttributes.getDimension(R.styleable.MaterialDivider_inset, -1);
+      if (inset == -1) {
+        inset = (int) dividerStyleAttrs.getDimension(ATTR_INSET, -1);
+      }
+      setInset(inset);
+    }
+
+    dividerStyleAttrs.recycle();
+    styledAttributes.recycle();
+  }
+
+  private static final int INVALID = -1;
+  private static final int HORIZONTAL = 0;
+  private static final int VERTICAL = 1;
+  private int orientation;
+
+  private void initializeOrientation() {
+    LayoutParams layoutParams = getLayoutParams();
+    if (layoutParams.width == MATCH_PARENT && layoutParams.height == MATCH_PARENT) {
+      orientation = INVALID;
+    } else if (layoutParams.width == MATCH_PARENT) {
+      orientation = VERTICAL;
+    } else if (layoutParams.height == MATCH_PARENT) {
+      orientation = HORIZONTAL;
+    }
+  }
+
+  @Dimension
+  int size = 0;
+
+  public @Dimension int getSize() {
+    return size;
+  }
+
+  public void setSize(@Dimension int size) {
+    this.size = size;
+    LayoutParams layoutParams = getLayoutParams();
+
+    if (orientation == INVALID) {
+      throw new UnsupportedOperationException("Material dividers only support resizing for horizontal and vertical dividers. Either android.R.attr#layout_width or android.R.attr#layout_height needs to be set to MATCH_PARENT");
+    } else if (orientation == VERTICAL) {
+      layoutParams.height = size;
+    } else {
+      layoutParams.width = size;
+    }
+
+    setLayoutParams(layoutParams);
+    requestLayout();
+  }
+
+  @ColorInt int color = 0;
+
+  public @ColorInt int getColor() {
+    return color;
+  }
+
+  public void setColor(@ColorInt int color) {
+    this.color = color;
+    setBackgroundColor(color);
+  }
+
+  @Dimension int inset = 0;
+
+  public @Dimension int getInset() {
+    return inset;
+  }
+
+
+  public void setInset(@Dimension final int inset) {
+
+    this.inset = inset;
+    if (orientation != VERTICAL) {
+      throw new UnsupportedOperationException("Material dividers only supports insetting for vertical dividers. Please set android.R.attr#layout_width to MATCH_PARENT to define a vertical divider");
+    }
+
+    int insetLeft = isRtlEnabled ? 0 : inset;
+    int insetRight = isRtlEnabled ? inset : 0;
+
+    ViewGroup.MarginLayoutParams marginLayoutParams = (ViewGroup.MarginLayoutParams) getLayoutParams();
+    marginLayoutParams.setMargins(insetLeft, 0, insetRight, 0);
+    setLayoutParams(marginLayoutParams);
+    requestLayout();
+  }
+}

--- a/lib/java/com/google/android/material/divider/MaterialDividerItemDecoration.java
+++ b/lib/java/com/google/android/material/divider/MaterialDividerItemDecoration.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.material.divider;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.InsetDrawable;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.RectShape;
+import android.util.TypedValue;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.Dimension;
+import androidx.recyclerview.widget.DividerItemDecoration;
+
+import com.google.android.material.R;
+
+public class MaterialDividerItemDecoration extends DividerItemDecoration {
+
+  int orientation;
+  boolean isRtlEnabled;
+
+  ShapeDrawable dividerDrawable;
+
+  private static final int ATTR_ALPHA = 0;
+  private static final int ATTR_COLOR = 1;
+  private static final int ATTR_INSET = 2;
+  private static final int ATTR_SIZE = 3;
+  private static final int[] attrs = new int[]{
+      R.attr.dividerAlpha,
+      R.attr.dividerColor,
+      R.attr.dividerInset,
+      R.attr.dividerSize
+  };
+
+  public MaterialDividerItemDecoration(Context context, int orientation) {
+    super(context, orientation);
+
+    this.orientation = orientation;
+    isRtlEnabled = context.getResources().getBoolean(R.bool.is_rtl_enabled);
+
+    TypedValue dividerStyle = new TypedValue();
+    context.getTheme().resolveAttribute(R.attr.dividerStyle, dividerStyle, true);
+
+    TypedArray dividerStyleAttrs = context.getTheme().obtainStyledAttributes(dividerStyle.resourceId, attrs);
+    float alpha = dividerStyleAttrs.getFloat(ATTR_ALPHA, -1);
+    int color = dividerStyleAttrs.getColor(ATTR_COLOR, -1);
+    int inset = (int) dividerStyleAttrs.getDimension(ATTR_INSET, -1);
+    int size = (int) dividerStyleAttrs.getDimension(ATTR_SIZE, -1);
+    dividerStyleAttrs.recycle();
+
+    dividerDrawable = new ShapeDrawable(new RectShape());
+    setAlpha(alpha);
+    setColor(color);
+    setSize(size);
+
+    //Insetting is not supported for horizontal dividers, so we ignore it for them rather than throwing an error
+    if (orientation == VERTICAL) {
+      setInset(inset);
+    }
+  }
+
+  int size = 0;
+
+  public int getSize() {
+    return size;
+  }
+
+  public void setSize(int size) {
+    this.size = size;
+    if (orientation == VERTICAL) {
+      dividerDrawable.setIntrinsicHeight(size);
+    } else {
+      dividerDrawable.setIntrinsicWidth(size);
+    }
+    dividerDrawable.invalidateSelf();
+  }
+
+  float alpha = 0;
+
+  public float getAlpha() {
+    return alpha;
+  }
+
+  public void setAlpha(float alpha) {
+    this.alpha = alpha;
+    dividerDrawable.getPaint().setAlpha((int) (alpha * 255));
+    dividerDrawable.invalidateSelf();
+  }
+
+  @ColorInt
+  int color = 0;
+
+  public @ColorInt
+  int getColor() {
+    return color;
+  }
+
+  public void setColor(@ColorInt int color) {
+    this.color = color;
+    dividerDrawable.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
+    dividerDrawable.invalidateSelf();
+  }
+
+  @Dimension
+  int inset = 0;
+
+  public @Dimension
+  int getInset() {
+    return inset;
+  }
+
+  public void setInset(@Dimension int inset) {
+
+    if (orientation == HORIZONTAL) {
+      throw new UnsupportedOperationException("Material divider does not support insetting for horizontal dividers");
+    }
+
+    this.inset = inset;
+    int insetLeft = isRtlEnabled ? 0 : inset;
+    int insetRight = isRtlEnabled ? inset : 0;
+
+    InsetDrawable insetDrawable = new InsetDrawable(dividerDrawable, insetLeft, 0, insetRight, 0);
+    setDrawable(insetDrawable);
+  }
+}

--- a/lib/java/com/google/android/material/divider/build.gradle
+++ b/lib/java/com/google/android/material/divider/build.gradle
@@ -1,0 +1,38 @@
+apply plugin: 'com.android.library'
+apply plugin: 'com.github.dcendents.android-maven'
+
+archivesBaseName = getArchivesBaseName(project.name)
+version = rootProject.ext.mdcLibraryVersion
+
+dependencies {
+  implementation compatibility("annotation")
+  implementation compatibility("appcompat")
+  implementation compatibility("core")
+
+  implementation project(fromPath("lib/java/com/google/android/material/color"))
+  implementation project(fromPath("lib/java/com/google/android/material/internal"))
+  implementation project(fromPath("lib/java/com/google/android/material/resources"))
+}
+
+android {
+  sourceSets {
+    main.manifest.srcFile 'AndroidManifest.xml'
+    main.java.srcDir '.'
+    main.java.excludes = [
+      '**/build/**',
+    ]
+    main.res.srcDirs = [
+      'res',
+      'res-public'
+    ]
+    main.assets.srcDir 'assets'
+  }
+}
+
+uploadArchives {
+  repositories {
+    mavenDeployer {
+      repository(url: rootProject.ext.mavenRepoUrl)
+    }
+  }
+}

--- a/lib/java/com/google/android/material/divider/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/divider/res-public/values/public.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2020 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+  <public name="dividerStyle" type="attr"/>
+  <public name="dividerAlpha" type="attr"/>
+  <public name="dividerSize" type="attr"/>
+  <public name="dividerColor" type="attr"/>
+  <public name="dividerInset" type="attr"/>
+  <public name="Widget.MaterialComponents.Divider" type="style"/>
+
+  <public name="inset" type="attr"/>
+</resources>

--- a/lib/java/com/google/android/material/divider/res/values-ldrtl/bools.xml
+++ b/lib/java/com/google/android/material/divider/res/values-ldrtl/bools.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2020 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+  <bool name="is_rtl_enabled">true</bool>
+</resources>

--- a/lib/java/com/google/android/material/divider/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/divider/res/values/attrs.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2020 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+
+  <!-- Style to use for Dividers in this theme, usually to be used as a view. -->
+  <attr name="dividerStyle" format="reference" />
+  <attr name="dividerAlpha" format="float" />
+  <attr name="dividerSize" format="dimension"/>
+  <attr name="dividerColor" format="color"/>
+  <attr name="dividerInset" format="dimension"/>
+</resources>

--- a/lib/java/com/google/android/material/divider/res/values/bools.xml
+++ b/lib/java/com/google/android/material/divider/res/values/bools.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2020 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+  <bool name="is_rtl_enabled">false</bool>
+</resources>

--- a/lib/java/com/google/android/material/divider/res/values/dimens.xml
+++ b/lib/java/com/google/android/material/divider/res/values/dimens.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2020 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+  <!-- The standard height of a divider that is recommended in the Material spec -->
+  <dimen name="mtrl_divider_size">@dimen/material_divider_default</dimen>
+  <dimen name="material_divider_default">1dp</dimen>
+  <dimen name="mtrl_divider_inset">0dp</dimen>
+
+  <!-- The standard color transparency of a divider that is recommended in the Material spec -->
+  <item name="mtrl_divider_transparency" format="float" type="dimen">0.1</item>
+</resources>

--- a/lib/java/com/google/android/material/divider/res/values/styles.xml
+++ b/lib/java/com/google/android/material/divider/res/values/styles.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2020 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+  <!-- Style for dividers that adjust a view to become a standard divider
+     Use dividers to group and separate items. -->
+  <declare-styleable name="MaterialDivider">
+    <attr name="inset" format="dimension"/>
+  </declare-styleable>
+
+  <style name="Widget.MaterialComponents.Divider" parent="">
+
+    <item name="enforceMaterialTheme">true</item>
+
+    <item name="dividerAlpha">@dimen/mtrl_divider_transparency</item>
+    <item name="dividerColor">?attr/colorOnSurface</item>
+    <item name="dividerInset">@dimen/mtrl_divider_inset</item>
+    <item name="dividerSize">@dimen/material_divider_default</item>
+
+  </style>
+</resources>

--- a/lib/java/com/google/android/material/theme/res/values/themes_base_bridge.xml
+++ b/lib/java/com/google/android/material/theme/res/values/themes_base_bridge.xml
@@ -58,6 +58,7 @@
     <item name="chipStyle">@style/Widget.MaterialComponents.Chip.Action</item>
     <item name="chipGroupStyle">@style/Widget.MaterialComponents.ChipGroup</item>
     <item name="chipStandaloneStyle">@style/Widget.MaterialComponents.Chip.Entry</item>
+    <item name="dividerStyle">@style/Widget.MaterialComponents.Divider</item>
     <item name="extendedFloatingActionButtonStyle">@style/Widget.MaterialComponents.ExtendedFloatingActionButton.Icon</item>
     <item name="floatingActionButtonStyle">@style/Widget.MaterialComponents.FloatingActionButton</item>
     <item name="materialButtonStyle">@style/Widget.MaterialComponents.Button</item>
@@ -131,6 +132,7 @@
     <item name="chipStyle">@style/Widget.MaterialComponents.Chip.Action</item>
     <item name="chipGroupStyle">@style/Widget.MaterialComponents.ChipGroup</item>
     <item name="chipStandaloneStyle">@style/Widget.MaterialComponents.Chip.Entry</item>
+    <item name="dividerStyle">@style/Widget.MaterialComponents.Divider</item>
     <item name="extendedFloatingActionButtonStyle">@style/Widget.MaterialComponents.ExtendedFloatingActionButton.Icon</item>
     <item name="floatingActionButtonStyle">@style/Widget.MaterialComponents.FloatingActionButton</item>
     <item name="materialButtonStyle">@style/Widget.MaterialComponents.Button</item>


### PR DESCRIPTION
> Created a full-bleed divider that follows the Material spec and has its
> color supplied by a Material theme.
> 
> Though this is the "base implementation" of a Material Divider, already
> includes most of the needed features:
> 
> * Proper divider height (based on the Material Spec)
> * Proper color transparency (based on the Material Spec)
> * Adaptable coloring from a Material theme
> * Dark theme support (from Material Theming)
> * Customizable attributes; the height, color and width can be changed

When creating Material lists, I found that it helped to split up its needed parts into "subcomponents." However, I later realized that these "subcomponents" could also individually be used internally and externally by developers. For the repository, a divider component makes sense. Infact, MDC-Android even includes small divider implementations!

Back in #78, dividers were mainly shrugged off as being _simple to implement_. However, with the introduction of dark mode and much confusion around implementing dividers ([stackoverflow](https://stackoverflow.com/questions/5049852/android-drawing-separator-divider-line-in-layout) 
 has 20+ answers and [this helpful divider guide](https://medium.com/@szholdiyarov/how-to-add-divider-to-list-and-recycler-views-858344450401) has multiple pages) the need for developer guidance on dividers is growing. 

In addition, I think working on a smaller component will help establish an open-source workflow, since the process of adding new-components through PRs has never been discussed before.

In the base implementation of dividers, I added support for a traditional full-bleed divider. I had the divider extend View and be configured to let developers add it through XML. Everything is documented, and all necessary attributes are annotated.

I think by adding dividers, Material Components Android will be more compelling solution for UIs.

In future contributions, I plan on improving this component and making it production ready:
* In the next contribution, I am going to add inset divider support to this component. The divider will only display a line up to a certain View or distance.
* Public and private API documentation, to make understanding the component easier.
* A catalog app example of using Material dividers
* UI tests to allow Dividers to be production ready

If any of these features should be added into this PR, I am happy to add them in 👍 

@dsn5ft @leticiarossi  
