### PR TITLE
[Shape] Allowed ShapeableImageView to dynamically update

### DIFF
--- a/lib/java/com/google/android/material/imageview/ShapeableImageView.java
+++ b/lib/java/com/google/android/material/imageview/ShapeableImageView.java
@@ -159,7 +159,12 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @Override
   public void setShapeAppearanceModel(@NonNull ShapeAppearanceModel shapeAppearanceModel) {
     this.shapeAppearanceModel = shapeAppearanceModel;
-    requestLayout();
+    updateShapeAppearanceModel();
+  }
+
+  private void updateShapeAppearanceModel(){
+    this.onSizeChanged(getWidth(), getHeight(), getWidth(), getHeight());
+    invalidate();
   }
 
   @NonNull


### PR DESCRIPTION
closes #1327 

>After the ShapeAppearanceModel is changed, ShapeableImageView will now automatically redraw itself to use the latest ShapeAppearanceModel when drawing edges and corners.

When updating the ShapeAppearanceModel of a ShapeableImageView, the View sometimes does not update with the latest changes. This issue is an unconsidered corner case, however ShapeableImageView should be able to support updates in any part of the View rendering lifecycle.