### PR TITLE
[ProgressIndicator] Fix for non dismissable progress indicator

### DIFF
--- a/lib/java/com/google/android/material/progressindicator/DrawableWithAnimatedVisibilityChange.java
+++ b/lib/java/com/google/android/material/progressindicator/DrawableWithAnimatedVisibilityChange.java
@@ -206,11 +206,6 @@ abstract class DrawableWithAnimatedVisibilityChange extends Drawable implements 
     boolean shouldAnimate =
         animationDesired && progressIndicator.getGrowMode() != ProgressIndicator.GROW_MODE_NONE;
 
-    // We don't want to change visibility while show/hide animation is running.
-    if (showAnimator.isRunning() || hideAnimator.isRunning()) {
-      return false;
-    }
-
     // Cancels any running animations.
     showAnimator.cancel();
     hideAnimator.cancel();


### PR DESCRIPTION
This should fix the problem with `ProgressIndicator` , that prevent them to dismiss if `hide()` is called too quickly.

We need to evaluate the animation state every time, so I removed the check which stops logic when animations are running.

This was reproducible on catalog app fast clicking "Show" and "Hide" in the "Indeterminate Progress Indicator Demo" page.
With the fix applied, the progress indicator are dismissed correctly.

Let me know if this is ok for you.

Closes #1382