### PR TITLE
[BottomSheet] Added missing defensive checks to viewDragHelper calls

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -506,11 +506,13 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
       velocityTracker = VelocityTracker.obtain();
     }
     velocityTracker.addMovement(event);
-    // The ViewDragHelper tries to capture only the top-most View. We have to explicitly tell it
-    // to capture the bottom sheet in case it is not captured and the touch slop is passed.
-    if (action == MotionEvent.ACTION_MOVE && !ignoreEvents) {
-      if (Math.abs(initialY - event.getY()) > viewDragHelper.getTouchSlop()) {
-        viewDragHelper.captureChildView(child, event.getPointerId(event.getActionIndex()));
+    if (viewDragHelper != null) {
+      // The ViewDragHelper tries to capture only the top-most View. We have to explicitly tell it
+      // to capture the bottom sheet in case it is not captured and the touch slop is passed.
+      if (action == MotionEvent.ACTION_MOVE && !ignoreEvents) {
+        if (Math.abs(initialY - event.getY()) > viewDragHelper.getTouchSlop()) {
+          viewDragHelper.captureChildView(child, event.getPointerId(event.getActionIndex()));
+        }
       }
     }
     return !ignoreEvents;
@@ -1277,10 +1279,12 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
   }
 
   void startSettlingAnimation(View child, int state, int top, boolean settleFromViewDragHelper) {
-    boolean startedSettling =
-        settleFromViewDragHelper
-            ? viewDragHelper.settleCapturedViewAt(child.getLeft(), top)
-            : viewDragHelper.smoothSlideViewTo(child, child.getLeft(), top);
+    boolean startedSettling = false;
+    if (viewDragHelper != null) {
+      startedSettling = settleFromViewDragHelper
+          ? viewDragHelper.settleCapturedViewAt(child.getLeft(), top)
+          : viewDragHelper.smoothSlideViewTo(child, child.getLeft(), top);
+    }
     if (startedSettling) {
       setStateInternal(STATE_SETTLING);
       // STATE_SETTLING won't animate the material shape, so do that here with the target state.


### PR DESCRIPTION
Added missing defensive checks where we used `viewDragHelper` as proposed [here](https://issuetracker.google.com/issues/156400385#comment3)

We have a defensive check for null everywhere in the code, but there were 2 places without them.

With my limited understanding in `startSettlingAnimation` method, I supposed the default value for the variable `startedSettling` should be false, let me know if this is not the case.

The fix can't be tested because is a "hard to reproduce" crash and I was not able to reproduce it manually, I just think we should be safe now.

Closes #1295 