### PR TITLE
[Slider] Keyboard navigation fix, part 2

### DIFF
--- a/lib/javatests/com/google/android/material/slider/RtlTestUtils.java
+++ b/lib/javatests/com/google/android/material/slider/RtlTestUtils.java
@@ -1,0 +1,55 @@
+package com.google.android.material.slider;
+
+import static android.os.Build.VERSION.SDK_INT;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.RuntimeEnvironment.application;
+
+import android.app.Application;
+import android.content.pm.ApplicationInfo;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.util.DisplayMetrics;
+import androidx.test.core.app.ApplicationProvider;
+import java.util.Locale;
+
+public final class RtlTestUtils {
+
+  public static void checkAppSupportsRtl() {
+    Application application = ApplicationProvider.getApplicationContext();
+    ApplicationInfo info = application.getApplicationInfo();
+    boolean supportsRtl = (info.flags & ApplicationInfo.FLAG_SUPPORTS_RTL) != 0;
+    assertTrue("android:supportsRtl must be true.", supportsRtl);
+    assertTrue("targetSdkVersion must be >= 17.", info.targetSdkVersion >= 17);
+  }
+
+  public static void checkPlatformSupportsRtl() {
+    assertTrue("SDK_INT must be >= 17.", SDK_INT >= 17);
+  }
+
+  public static void applyRtlPseudoLocale() {
+    setLocale(new Locale("ar", "XB"));
+  }
+
+  /**
+   * @see org.robolectric.RuntimeEnvironment#setQualifiers(String)
+   */
+  @SuppressWarnings("deprecation")
+  private static void setLocale(Locale locale) {
+    Configuration configuration = new Configuration(Resources.getSystem().getConfiguration());
+    DisplayMetrics displayMetrics = new DisplayMetrics();
+    displayMetrics.setTo(Resources.getSystem().getDisplayMetrics());
+
+    configuration.setLocale(locale);
+
+    Resources systemResources = Resources.getSystem();
+    systemResources.updateConfiguration(configuration, displayMetrics);
+
+    if (application != null) {
+      application.getResources().updateConfiguration(configuration, displayMetrics);
+    }
+  }
+
+  private RtlTestUtils() {
+    throw new AssertionError();
+  }
+}

--- a/lib/javatests/com/google/android/material/slider/SliderKeyTestCommon.java
+++ b/lib/javatests/com/google/android/material/slider/SliderKeyTestCommon.java
@@ -16,32 +16,35 @@
 
 package com.google.android.material.slider;
 
-import com.google.android.material.R;
-
 import static com.google.android.material.slider.SliderHelper.clickDpadCenter;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
-import androidx.appcompat.app.AppCompatActivity;
 import android.view.KeyEvent;
 import android.view.View;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.customview.widget.ExploreByTouchHelper;
 import androidx.test.core.app.ApplicationProvider;
+import com.google.android.material.R;
 import com.google.android.material.slider.KeyUtils.KeyEventBuilder;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 
-/** Tests for key handling of {@link Slider} */
-@RunWith(RobolectricTestRunner.class)
-public class SliderKeyTest {
+/**
+ * Tests for key handling of {@link Slider} both in left-to-right and right-to-left layouts.
+ */
+public abstract class SliderKeyTestCommon {
+
   private static final float SLIDER_VALUE_FROM = 0f;
   private static final float SLIDER_VALUE_TO = 100f;
 
-  private Slider slider;
-  Float[] values = new Float[] {1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f};
+  protected Slider slider;
+  private Float[] values = new Float[]{1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f};
+
+  protected int countTestValues() {
+    return values.length;
+  }
 
   @Before
   public void createSlider() {
@@ -77,21 +80,7 @@ public class SliderKeyTest {
   public void testThumbFocus_focusBackward_focusesLastThumb() {
     slider.requestFocus(View.FOCUS_BACKWARD);
 
-    assertThat(slider.getFocusedThumbIndex()).isEqualTo(values.length - 1);
-  }
-
-  @Test
-  public void testThumbFocus_focusLeft_focusesLastThumb() {
-    slider.requestFocus(View.FOCUS_LEFT);
-
-    assertThat(slider.getFocusedThumbIndex()).isEqualTo(values.length - 1);
-  }
-
-  @Test
-  public void testThumbFocus_focusRight_focusesFirstThumb() {
-    slider.requestFocus(View.FOCUS_RIGHT);
-
-    assertThat(slider.getFocusedThumbIndex()).isEqualTo(0);
+    assertThat(slider.getFocusedThumbIndex()).isEqualTo(countTestValues() - 1);
   }
 
   @Test
@@ -133,17 +122,7 @@ public class SliderKeyTest {
     KeyEventBuilder tab = new KeyEventBuilder(KeyEvent.KEYCODE_TAB);
     KeyEventBuilder shiftTab = new KeyEventBuilder(KeyEvent.KEYCODE_TAB, KeyEvent.META_SHIFT_ON);
 
-    sendKeyEventLeftAndRight(tab, shiftTab);
-  }
-
-  @Test
-  public void testMoveThumbFocus_dPad_correctThumbHasFocus() {
-    slider.requestFocus();
-
-    KeyEventBuilder right = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_RIGHT);
-    KeyEventBuilder left = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_LEFT);
-
-    sendKeyEventLeftAndRight(right, left);
+    sendKeyEventThereAndBack(tab, shiftTab);
   }
 
   @Test
@@ -153,7 +132,18 @@ public class SliderKeyTest {
     KeyEventBuilder plus = new KeyEventBuilder(KeyEvent.KEYCODE_PLUS);
     KeyEventBuilder minus = new KeyEventBuilder(KeyEvent.KEYCODE_MINUS);
 
-    sendKeyEventLeftAndRight(plus, minus);
+    sendKeyEventThereAndBack(plus, minus);
+  }
+
+  @Test
+  public void testMoveThumbFocus_equalsMinus_correctThumbHasFocus() {
+    slider.requestFocus();
+
+    // Numpad Plus == Shift + Equals, at least in AVD.
+    KeyEventBuilder equals = new KeyEventBuilder(KeyEvent.KEYCODE_EQUALS);
+    KeyEventBuilder minus = new KeyEventBuilder(KeyEvent.KEYCODE_MINUS);
+
+    sendKeyEventThereAndBack(equals, minus);
   }
 
   @Test
@@ -167,12 +157,12 @@ public class SliderKeyTest {
     assertThat(slider.getActiveThumbIndex()).isEqualTo(2);
   }
 
-  private void activateFocusedThumb(Slider s) {
-    int focusedThumbIndex = s.getFocusedThumbIndex();
+  protected void activateFocusedThumb() {
+    int focusedThumbIndex = slider.getFocusedThumbIndex();
     if (focusedThumbIndex != -1) {
       // Clicking D-Pad in Slider isn't idempotent. Only do it here if we're changing focused thumb.
-      if (focusedThumbIndex != s.getActiveThumbIndex()) {
-        clickDpadCenter(s);
+      if (focusedThumbIndex != slider.getActiveThumbIndex()) {
+        clickDpadCenter(slider);
       }
     }
   }
@@ -183,45 +173,11 @@ public class SliderKeyTest {
 
     slider.setFocusedThumbIndex(2);
 
-    activateFocusedThumb(slider);
+    activateFocusedThumb();
 
     clickDpadCenter(slider);
 
     assertThat(slider.getActiveThumbIndex()).isEqualTo(-1);
-  }
-
-  @Test
-  public void testActivateThirdThumb_moveRight_movesThirdThumbRight() {
-    slider.requestFocus();
-
-    slider.setFocusedThumbIndex(2);
-
-    activateFocusedThumb(slider);
-
-    KeyEventBuilder right = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_RIGHT);
-    for (int i = 0; i < 20; i++) {
-      right.dispatchEvent(slider);
-    }
-
-    assertThat(slider.getValues()).contains(23.0f);
-    assertThat(slider.getValues()).doesNotContain(3.0f);
-  }
-
-  @Test
-  public void testActivateThirdThumb_moveLeft_movesThirdThumbLeft() {
-    slider.requestFocus();
-
-    slider.setFocusedThumbIndex(2);
-
-    activateFocusedThumb(slider);
-
-    KeyEventBuilder left = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_LEFT);
-    for (int i = 0; i < 3; i++) {
-      left.dispatchEvent(slider);
-    }
-
-    assertThat(slider.getValues()).contains(0.0f);
-    assertThat(slider.getValues()).doesNotContain(3.0f);
   }
 
   @Test
@@ -240,7 +196,7 @@ public class SliderKeyTest {
   public void testActivateDefaultThumb_clickUpDPad_unhandled() {
     slider.requestFocus();
 
-    activateFocusedThumb(slider);
+    activateFocusedThumb();
 
     KeyEventBuilder up = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_UP);
     boolean handledDown = slider.dispatchKeyEvent(up.buildDown());
@@ -266,7 +222,7 @@ public class SliderKeyTest {
   public void testActivateDefaultThumb_clickDownDPad_unhandled() {
     slider.requestFocus();
 
-    activateFocusedThumb(slider);
+    activateFocusedThumb();
 
     KeyEventBuilder down = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_DOWN);
     boolean handledDown = slider.dispatchKeyEvent(down.buildDown());
@@ -297,7 +253,7 @@ public class SliderKeyTest {
 
     slider.setFocusedThumbIndex(0);
 
-    activateFocusedThumb(slider);
+    activateFocusedThumb();
 
     KeyEventBuilder tab = new KeyEventBuilder(KeyEvent.KEYCODE_TAB);
     tab.meta = KeyEvent.META_SHIFT_ON;
@@ -312,7 +268,7 @@ public class SliderKeyTest {
   public void testFocusLastThumb_tab_unhandled() {
     slider.requestFocus();
 
-    slider.setFocusedThumbIndex(values.length - 1);
+    slider.setFocusedThumbIndex(countTestValues() - 1);
 
     KeyEventBuilder tab = new KeyEventBuilder(KeyEvent.KEYCODE_TAB);
     boolean handledDown = slider.dispatchKeyEvent(tab.buildDown());
@@ -326,9 +282,9 @@ public class SliderKeyTest {
   public void testActivateLastThumb_tab_unhandled() {
     slider.requestFocus();
 
-    slider.setFocusedThumbIndex(values.length - 1);
+    slider.setFocusedThumbIndex(countTestValues() - 1);
 
-    activateFocusedThumb(slider);
+    activateFocusedThumb();
 
     KeyEventBuilder tab = new KeyEventBuilder(KeyEvent.KEYCODE_TAB);
     boolean handledDown = slider.dispatchKeyEvent(tab.buildDown());
@@ -338,14 +294,14 @@ public class SliderKeyTest {
     assertThat(handledUp).isFalse();
   }
 
-  private void sendKeyEventLeftAndRight(KeyEventBuilder right, KeyEventBuilder left) {
-    for (int i = 1; i < values.length; i++) {
-      right.dispatchEvent(slider);
+  protected void sendKeyEventThereAndBack(KeyEventBuilder there, KeyEventBuilder back) {
+    for (int i = 1; i < countTestValues(); i++) {
+      there.dispatchEvent(slider);
       assertWithMessage("moving right").that(slider.getFocusedThumbIndex()).isEqualTo(i);
     }
 
-    for (int i = values.length - 1; i > 0; i--) {
-      left.dispatchEvent(slider);
+    for (int i = countTestValues() - 1; i > 0; i--) {
+      back.dispatchEvent(slider);
       assertWithMessage("moving left").that(slider.getFocusedThumbIndex()).isEqualTo(i - 1);
     }
   }

--- a/lib/javatests/com/google/android/material/slider/SliderKeyTestLtr.java
+++ b/lib/javatests/com/google/android/material/slider/SliderKeyTestLtr.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.material.slider;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.view.KeyEvent;
+import android.view.View;
+import com.google.android.material.slider.KeyUtils.KeyEventBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Tests for key handling of {@link Slider} in left-to-right layout.
+ */
+@RunWith(RobolectricTestRunner.class)
+public final class SliderKeyTestLtr extends SliderKeyTestCommon {
+
+  @Test
+  public void testThumbFocus_focusLeft_focusesLastThumb() {
+    slider.requestFocus(View.FOCUS_LEFT);
+
+    assertThat(slider.getFocusedThumbIndex()).isEqualTo(countTestValues() - 1);
+  }
+
+  @Test
+  public void testThumbFocus_focusRight_focusesFirstThumb() {
+    slider.requestFocus(View.FOCUS_RIGHT);
+
+    assertThat(slider.getFocusedThumbIndex()).isEqualTo(0);
+  }
+
+  @Test
+  public void testMoveThumbFocus_dPad_correctThumbHasFocus() {
+    slider.requestFocus();
+
+    KeyEventBuilder right = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_RIGHT);
+    KeyEventBuilder left = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_LEFT);
+
+    sendKeyEventThereAndBack(right, left);
+  }
+
+  @Test
+  public void testActivateThirdThumb_moveRight_movesThirdThumbRight() {
+    slider.requestFocus();
+
+    slider.setFocusedThumbIndex(2);
+
+    activateFocusedThumb();
+
+    KeyEventBuilder right = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_RIGHT);
+    for (int i = 0; i < 20; i++) {
+      right.dispatchEvent(slider);
+    }
+
+    assertThat(slider.getValues()).contains(23.0f);
+    assertThat(slider.getValues()).doesNotContain(3.0f);
+  }
+
+  @Test
+  public void testActivateThirdThumb_moveLeft_movesThirdThumbLeft() {
+    slider.requestFocus();
+
+    slider.setFocusedThumbIndex(2);
+
+    activateFocusedThumb();
+
+    KeyEventBuilder left = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_LEFT);
+    for (int i = 0; i < 3; i++) {
+      left.dispatchEvent(slider);
+    }
+
+    assertThat(slider.getValues()).contains(0.0f);
+    assertThat(slider.getValues()).doesNotContain(3.0f);
+  }
+}

--- a/lib/javatests/com/google/android/material/slider/SliderKeyTestRtl.java
+++ b/lib/javatests/com/google/android/material/slider/SliderKeyTestRtl.java
@@ -1,0 +1,100 @@
+package com.google.android.material.slider;
+
+import static com.google.android.material.slider.RtlTestUtils.checkAppSupportsRtl;
+import static com.google.android.material.slider.RtlTestUtils.checkPlatformSupportsRtl;
+import static com.google.android.material.slider.RtlTestUtils.applyRtlPseudoLocale;
+import static com.google.common.truth.Truth.assertThat;
+
+import android.view.KeyEvent;
+import android.view.View;
+import com.google.android.material.slider.KeyUtils.KeyEventBuilder;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Tests for key handling of {@link Slider} in right-to-left layout.
+ */
+@RunWith(RobolectricTestRunner.class)
+public final class SliderKeyTestRtl extends SliderKeyTestCommon {
+
+  @Before
+  public void checkRtl() {
+    checkPlatformSupportsRtl();
+    checkAppSupportsRtl();
+  }
+
+  @Override
+  public void createSlider() {
+    applyRtlPseudoLocale();
+    super.createSlider();
+  }
+
+  @Ignore("Fix RTL support for Robolectric tests.")
+  @Test
+  public void testThumbFocus_focusLeft_focusesFirstThumb() {
+    slider.requestFocus(View.FOCUS_LEFT);
+
+    assertThat(slider.getFocusedThumbIndex()).isEqualTo(0);
+  }
+
+  @Ignore("Fix RTL support for Robolectric tests.")
+  @Test
+  public void testThumbFocus_focusRight_focusesLastThumb() {
+    slider.requestFocus(View.FOCUS_RIGHT);
+
+    assertThat(slider.getFocusedThumbIndex()).isEqualTo(countTestValues() - 1);
+  }
+
+  @Ignore("Fix RTL support for Robolectric tests.")
+  @Test
+  public void testMoveThumbFocus_dPad_correctThumbHasFocus() {
+    slider.requestFocus();
+
+    KeyEventBuilder left = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_LEFT);
+    KeyEventBuilder right = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_RIGHT);
+
+    // We start at far right in RTL so go left first, then go back right.
+    sendKeyEventThereAndBack(left, right);
+  }
+
+  @Ignore("Fix RTL support for Robolectric tests.")
+  @Test
+  public void testActivateThirdThumb_moveRight_movesThirdThumbRight() {
+    slider.requestFocus();
+
+    slider.setFocusedThumbIndex(2);
+
+    activateFocusedThumb();
+
+    KeyEventBuilder right = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_RIGHT);
+    for (int i = 0; i < 3; i++) {
+      right.dispatchEvent(slider);
+    }
+
+    // Moving right decrements in RTL.
+    assertThat(slider.getValues()).contains(0.0f);
+    assertThat(slider.getValues()).doesNotContain(3.0f);
+  }
+
+  @Ignore("Fix RTL support for Robolectric tests.")
+  @Test
+  public void testActivateThirdThumb_moveLeft_movesThirdThumbLeft() {
+    slider.requestFocus();
+
+    slider.setFocusedThumbIndex(2);
+
+    activateFocusedThumb();
+
+    KeyEventBuilder left = new KeyEventBuilder(KeyEvent.KEYCODE_DPAD_LEFT);
+    for (int i = 0; i < 20; i++) {
+      left.dispatchEvent(slider);
+    }
+
+    // Moving left increments in RTL.
+    assertThat(slider.getValues()).contains(23.0f);
+    assertThat(slider.getValues()).doesNotContain(3.0f);
+  }
+}


### PR DESCRIPTION
Closes #1381.

Does anybody know how to test RTL in Robolectric?

It runs with `targetSdkVersion` 14 (it's unset so it takes it from `minSdkVersion`) and the only fix is having `targetSdkVersion` 17+ in build.gradle (RTL is API 17+ only) so Robolectric picks it up. Then I tried setting `@Config(qualifiers="+ldrtl)`. Then I tried setting default locale to `ar_XB` and updating system configuration with it (mimic `RuntimeEnvironment.setQualifiers(...)`). Then I tried manually setting RTL on the slider. None of this worked.