### PR TITLE
[CollapsingToolbarLayout] Slight misalignment during transition in multiline mode

### DIFF
--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -713,7 +713,7 @@ public final class CollapsingTextHelper {
     // Collapsed text
     textPaint.setAlpha((int) (collapsedTextBlend * originalAlpha));
     canvas.drawText(
-        textToDrawCollapsed, 0, textToDrawCollapsed.length(), 0, -ascent / scale, textPaint);
+        textToDrawCollapsed, 0, textToDrawCollapsed.length(), 0, -ascent, textPaint);
     // Remove ellipsis for Cross-section animation
     String tmp = textToDrawCollapsed.toString().trim();
     if (tmp.endsWith(ELLIPSIS_NORMAL)) {
@@ -722,7 +722,7 @@ public final class CollapsingTextHelper {
     // Cross-section between both texts (should stay at original alpha)
     textPaint.setAlpha(originalAlpha);
     canvas.drawText(
-        tmp, 0, Math.min(textLayout.getLineEnd(0), tmp.length()), 0, -ascent / scale, textPaint);
+        tmp, 0, Math.min(textLayout.getLineEnd(0), tmp.length()), 0, -ascent, textPaint);
   }
 
   private boolean calculateIsRtl(@NonNull CharSequence text) {


### PR DESCRIPTION
Closes #1052

As explained in #1052 the alignment of the collapsing text was not correct. This became even more prominent if the textSize between expanded and collapsed became bigger.

## Before
![image](https://user-images.githubusercontent.com/790875/84746389-29e4f180-afb6-11ea-87f3-98dc374cc160.png)

## After
![image](https://user-images.githubusercontent.com/790875/84746426-36694a00-afb6-11ea-9b3d-968d3fc49874.png)
