### PR TITLE
[ProgressIndicator] Add new minHideDelay property

### DIFF
--- a/catalog/java/io/material/catalog/progressindicator/ProgressIndicatorIndeterminateDemoFragment.java
+++ b/catalog/java/io/material/catalog/progressindicator/ProgressIndicatorIndeterminateDemoFragment.java
@@ -121,6 +121,7 @@ public class ProgressIndicatorIndeterminateDemoFragment extends DemoFragment {
           for (ProgressIndicator progressIndicator : indicatorList) {
             resetProgressIndicator(progressIndicator);
             progressIndicator.show();
+            progressIndicator.hide();
           }
         });
     hideButton.setOnClickListener(

--- a/catalog/java/io/material/catalog/progressindicator/res/layout/cat_progress_indicator_indeterminate_indicators.xml
+++ b/catalog/java/io/material/catalog/progressindicator/res/layout/cat_progress_indicator_indeterminate_indicators.xml
@@ -27,6 +27,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="center"
+      app:minHideDelay="1000"
       style="@style/Widget.MaterialComponents.ProgressIndicator.Linear.Indeterminate"
       app:indicatorColor="?attr/colorPrimary"/>
 
@@ -38,6 +39,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="center"
+      app:minHideDelay="7000"
       style="@style/Widget.MaterialComponents.ProgressIndicator.Linear.Indeterminate"
       app:indicatorColor="?attr/colorPrimary"
       app:inverse="true"
@@ -52,6 +54,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="center"
+      app:minHideDelay="0"
       style="@style/Widget.MaterialComponents.ProgressIndicator.Linear.Indeterminate"
       app:indicatorColors="@array/cat_custom_progress_colors"
       app:linearSeamless="false"
@@ -65,6 +68,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="center"
+      app:minHideDelay="-1"
       style="@style/Widget.MaterialComponents.ProgressIndicator.Linear.Indeterminate"
       app:indicatorColors="@array/cat_custom_progress_colors"
       app:growMode="outgoing"/>
@@ -103,6 +107,7 @@
       <com.google.android.material.progressindicator.ProgressIndicator
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          app:minHideDelay="200"
           style="@style/Widget.MaterialComponents.ProgressIndicator.Circular.Indeterminate"
           app:indicatorColor="?attr/colorPrimary"
           app:inverse="true"

--- a/lib/java/com/google/android/material/progressindicator/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/progressindicator/res-public/values/public.xml
@@ -28,6 +28,7 @@
   <public name="circularRadius" type="attr" />
   <public name="circularInset" type="attr" />
   <public name="linearSeamless" type="attr" />
+  <public name="minHideDelay" type="attr" />
 
   <public name="Widget.MaterialComponents.ProgressIndicator.Linear.Determinate" type="style" />
   <public name="Widget.MaterialComponents.ProgressIndicator.Linear.Indeterminate" type="style" />

--- a/lib/java/com/google/android/material/progressindicator/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/progressindicator/res/values/attrs.xml
@@ -102,6 +102,15 @@
       indicator.
     -->
     <attr name="linearSeamless" format="boolean"/>
+
+    <!--
+      The delay the progress indicator will wait before hiding once show() is
+      called in milliseconds. Max value capped at 1 second (1000 ms).
+      If not set the progress indicator will dismiss as soon as possible once
+      hide() is called.
+    -->
+    <attr name="minHideDelay" format="integer" />
+
   </declare-styleable>
 
   <!-- Style to use for ProgressIndicators in this theme. -->


### PR DESCRIPTION
I've tried to stay compliant as much as possible with the original [ContentLoadingProgressBar](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-master-dev:core/core/src/main/java/androidx/core/widget/ContentLoadingProgressBar.java;l=33?q=ContentLoadingProgressBar&ss=androidx%2Fplatform%2Fframeworks%2Fsupport) and the improved version from Christophe Beyls [here](https://gist.github.com/cbeyls/133164625e06b16520c1).

Considerations:
- I've not added a way to set this value from code. I don't see real value on doing this because I can't imagine people changing this value at runtime but if we want to unlock this extra step we should be more careful with some checks and callback reset. (Imagine if someone changes the delay value while the hide callback is scheduled).
- The original ContentLoadingProgressBar had a minimum show delay which prevented the progress to appear at all if show and hide were called below a certain threshold. I didn't implement this part because the new material animations are great and I think it's always worth showing them.
- I've added 2 commits, the second commit is just to simplify the feature testing, it must be removed before the merge if this PR is ok. If this is not OK just ask and I will remove it ASAP.
- I've used `SystemClock.uptimeMillis` because it is monotonic. This clock stops when the device goes to deep sleep but for this specific case, I thought it's enough to not worth the use of `SystemClock.elapsedRealTime` which does not. Check [SystemClock](https://developer.android.com/reference/android/os/SystemClock) docs for more info.
- If this part is testable I could add some tests, is there some code which I can take inspiration from? If we stick with the parameter to be set from XML only we are forced to test with XML view inflation. 
I've checked `ProgressIndicatorConfigTest` but probably is not the right place for this.

Follow up work of #1391 from #1382
