### PR TITLE
[TextField] Added EnclosedBox style to TextField

### DIFF
--- a/catalog/java/io/material/catalog/textfield/TextFieldEnclosedDemoFragment.java
+++ b/catalog/java/io/material/catalog/textfield/TextFieldEnclosedDemoFragment.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.material.catalog.textfield;
+
+import androidx.annotation.LayoutRes;
+
+import io.material.catalog.R;
+
+/** A fragment that displays the filled text field demos with controls for the Catalog app. */
+public class TextFieldEnclosedDemoFragment extends TextFieldControllableDemoFragment {
+
+  @Override
+  @LayoutRes
+  public int getTextFieldContent() {
+    return R.layout.cat_textfield_enclosed_content;
+  }
+}

--- a/catalog/java/io/material/catalog/textfield/TextFieldEnclosedIconsDemoFragment.java
+++ b/catalog/java/io/material/catalog/textfield/TextFieldEnclosedIconsDemoFragment.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.material.catalog.textfield;
+
+import androidx.annotation.LayoutRes;
+
+import io.material.catalog.R;
+
+/**
+ * A fragment that displays the filled text field demos with start and end icons and controls for
+ * the Catalog app.
+ */
+public class TextFieldEnclosedIconsDemoFragment extends TextFieldFilledDemoFragment {
+
+  @Override
+  @LayoutRes
+  public int getTextFieldContent() {
+    return R.layout.cat_textfield_enclosed_icons_content;
+  }
+}

--- a/catalog/java/io/material/catalog/textfield/TextFieldExposedDropdownMenuDemoFragment.java
+++ b/catalog/java/io/material/catalog/textfield/TextFieldExposedDropdownMenuDemoFragment.java
@@ -73,6 +73,14 @@ public class TextFieldExposedDropdownMenuDemoFragment extends TextFieldControlla
         view.findViewById(R.id.outlined_exposed_dropdown_editable);
     editTextOutlinedEditableExposedDropdown.setAdapter(adapter);
 
+    AutoCompleteTextView editTextEnclosedExposedDropdown =
+        view.findViewById(R.id.enclosed_exposed_dropdown);
+    editTextEnclosedExposedDropdown.setAdapter(adapter);
+
+    AutoCompleteTextView editTextEnclosedEditableExposedDropdown =
+        view.findViewById(R.id.enclosed_exposed_dropdown_editable);
+    editTextEnclosedEditableExposedDropdown.setAdapter(adapter);
+
     // Initialize button for toggling the leading icon's visibility.
     Button toggleLeadingIconButton = view.findViewById(R.id.button_toggle_leading_icon);
     toggleLeadingIconButton.setVisibility(View.VISIBLE);

--- a/catalog/java/io/material/catalog/textfield/TextFieldFragment.java
+++ b/catalog/java/io/material/catalog/textfield/TextFieldFragment.java
@@ -71,6 +71,13 @@ public class TextFieldFragment extends DemoLandingFragment {
           }
         });
     additionalDemos.add(
+        new Demo(R.string.cat_textfield_enclosed_demo_title) {
+          @Override
+          public Fragment createFragment() {
+            return new TextFieldEnclosedDemoFragment();
+          }
+        });
+    additionalDemos.add(
         new Demo(R.string.cat_textfield_exposed_dropdown_menu_demo_title) {
           @Override
           public Fragment createFragment() {
@@ -89,6 +96,13 @@ public class TextFieldFragment extends DemoLandingFragment {
           @Override
           public Fragment createFragment() {
             return new TextFieldOutlinedIconsDemoFragment();
+          }
+        });
+    additionalDemos.add(
+        new Demo(R.string.cat_textfield_enclosed_icons_demo_title) {
+          @Override
+          public Fragment createFragment() {
+            return new TextFieldEnclosedIconsDemoFragment();
           }
         });
     additionalDemos.add(

--- a/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_content.xml
+++ b/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_content.xml
@@ -78,4 +78,33 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"/>
     </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+    style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:hint="@string/cat_textfield_label"
+    app:helperText="@string/cat_textfield_enclosed_helper_text"
+    app:helperTextEnabled="true"
+    app:placeholderText="@string/cat_textfield_placeholder_text">
+    <com.google.android.material.textfield.TextInputEditText
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+    style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox.Dense"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:hint="@string/cat_textfield_label"
+    app:helperText="@string/cat_textfield_enclosed_dense_helper_text"
+    app:helperTextEnabled="true"
+    app:placeholderText="@string/cat_textfield_placeholder_text">
+    <com.google.android.material.textfield.TextInputEditText
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
   </LinearLayout>

--- a/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_enclosed_content.xml
+++ b/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_enclosed_content.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+  <com.google.android.material.textfield.TextInputLayout
+    style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+    android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="4dp"
+      android:hint="@string/cat_textfield_label"
+      app:counterEnabled="true"
+      app:counterMaxLength="10"
+      app:errorEnabled="true"
+      app:helperText="@string/cat_textfield_enclosed_helper_text"
+      app:helperTextEnabled="true"
+      app:placeholderText="@string/cat_textfield_placeholder_text">
+    <com.google.android.material.textfield.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+      style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox.Dense"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="4dp"
+      android:hint="@string/cat_textfield_label"
+      app:counterEnabled="true"
+      app:counterMaxLength="10"
+      app:errorEnabled="true"
+      app:helperText="@string/cat_textfield_enclosed_dense_helper_text"
+      app:helperTextEnabled="true"
+      app:placeholderText="@string/cat_textfield_placeholder_text">
+    <com.google.android.material.textfield.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_enclosed_icons_content.xml
+++ b/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_enclosed_icons_content.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2019 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+  <com.google.android.material.textfield.TextInputLayout
+      style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox.Dense"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="4dp"
+      android:hint="@string/cat_textfield_password"
+      app:endIconMode="password_toggle"
+      app:errorEnabled="true"
+      app:helperText="@string/cat_textfield_enclosed_dense_password_helper_text"
+      app:helperTextEnabled="true"
+      app:placeholderText="@string/cat_textfield_placeholder_text">
+    <com.google.android.material.textfield.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textPassword"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+      style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="4dp"
+      android:hint="@string/cat_textfield_label"
+      app:endIconMode="clear_text"
+      app:errorEnabled="true"
+      app:helperText="@string/cat_textfield_enclosed_clear_button_helper_text"
+      app:helperTextEnabled="true"
+      app:placeholderText="@string/cat_textfield_placeholder_text">
+    <com.google.android.material.textfield.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+      style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="4dp"
+      android:hint="@string/cat_textfield_label"
+      app:endIconContentDescription="@string/cat_textfield_custom_end_icon_content_description"
+      app:endIconDrawable="@drawable/ic_accelerator_24px"
+      app:endIconMode="custom"
+      app:errorEnabled="true"
+      app:helperText="@string/cat_textfield_enclosed_custom_end_icon_helper_text"
+      app:helperTextEnabled="true"
+      app:placeholderText="@string/cat_textfield_placeholder_text">
+    <com.google.android.material.textfield.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+      style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="4dp"
+      android:hint="@string/cat_textfield_label"
+      app:counterEnabled="true"
+      app:counterMaxLength="10"
+      app:errorEnabled="true"
+      app:helperText="@string/cat_textfield_enclosed_start_icon_helper_text"
+      app:helperTextEnabled="true"
+      app:startIconContentDescription="@string/cat_textfield_custom_start_icon_content_description"
+      app:startIconDrawable="@drawable/ic_search_24px"
+      app:placeholderText="@string/cat_textfield_placeholder_text">
+    <com.google.android.material.textfield.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+      style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="4dp"
+      android:hint="@string/cat_textfield_label"
+      app:counterEnabled="true"
+      app:counterMaxLength="10"
+      app:endIconContentDescription="@string/cat_textfield_custom_end_icon_content_description"
+      app:endIconDrawable="@drawable/ic_accelerator_24px"
+      app:endIconMode="custom"
+      app:errorEnabled="true"
+      app:helperText="@string/cat_textfield_enclosed_start_end_icons_helper_text"
+      app:helperTextEnabled="true"
+      app:startIconContentDescription="@string/cat_textfield_custom_start_icon_content_description"
+      app:startIconDrawable="@drawable/ic_search_24px"
+      app:placeholderText="@string/cat_textfield_placeholder_text">
+    <com.google.android.material.textfield.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_exposed_dropdown_menu_content.xml
+++ b/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_exposed_dropdown_menu_content.xml
@@ -87,4 +87,36 @@
         android:layout_height="wrap_content"/>
   </com.google.android.material.textfield.TextInputLayout>
 
+  <com.google.android.material.textfield.TextInputLayout
+    style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox.ExposedDropdownMenu"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:hint="@string/cat_textfield_label"
+    app:errorEnabled="true"
+    app:helperText="@string/cat_textfield_enclosed_exposed_dropdown_helper_text"
+    app:helperTextEnabled="true">
+    <AutoCompleteTextView
+      android:id="@+id/enclosed_exposed_dropdown"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:inputType="none"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+
+  <com.google.android.material.textfield.TextInputLayout
+    style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox.ExposedDropdownMenu"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:hint="@string/cat_textfield_label"
+    app:errorEnabled="true"
+    app:helperText="@string/cat_textfield_enclosed_editable_exposed_dropdown_helper_text"
+    app:helperTextEnabled="true">
+    <AutoCompleteTextView
+      android:id="@+id/enclosed_exposed_dropdown_editable"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
 </LinearLayout>

--- a/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_prefix_suffix_content.xml
+++ b/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_prefix_suffix_content.xml
@@ -162,4 +162,74 @@
         android:inputType="numberDecimal"/>
   </com.google.android.material.textfield.TextInputLayout>
 
+  <com.google.android.material.textfield.TextInputLayout
+    style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:hint="@string/cat_textfield_label"
+    app:errorEnabled="true"
+    app:helperText="@string/cat_textfield_enclosed_prefix_helper_text"
+    app:helperTextEnabled="true"
+    app:prefixText="@string/cat_textfield_prefix">
+    <com.google.android.material.textfield.TextInputEditText
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:inputType="numberDecimal"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+    style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:hint="@string/cat_textfield_label"
+    app:errorEnabled="true"
+    app:helperText="@string/cat_textfield_enclosed_suffix_helper_text"
+    app:helperTextEnabled="true"
+    app:suffixText="@string/cat_textfield_suffix">
+    <com.google.android.material.textfield.TextInputEditText
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_gravity="end"
+      android:textAlignment="textEnd"
+      android:inputType="numberDecimal"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+    style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:hint="@string/cat_textfield_label"
+    app:errorEnabled="true"
+    app:helperText="@string/cat_textfield_enclosed_prefix_icon_helper_text"
+    app:helperTextEnabled="true"
+    app:startIconDrawable="@drawable/ic_search_24px"
+    app:prefixText="@string/cat_textfield_prefix">
+    <com.google.android.material.textfield.TextInputEditText
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:inputType="numberDecimal"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
+  <com.google.android.material.textfield.TextInputLayout
+    style="@style/Widget.MaterialComponents.TextInputLayout.EnclosedBox"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:hint="@string/cat_textfield_label"
+    app:errorEnabled="true"
+    app:helperText="@string/cat_textfield_enclosed_suffix_icon_helper_text"
+    app:helperTextEnabled="true"
+    app:endIconMode="clear_text"
+    app:suffixText="@string/cat_textfield_suffix">
+    <com.google.android.material.textfield.TextInputEditText
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_gravity="end"
+      android:textAlignment="textEnd"
+      android:inputType="numberDecimal"/>
+  </com.google.android.material.textfield.TextInputLayout>
+
 </LinearLayout>

--- a/catalog/java/io/material/catalog/textfield/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/textfield/res/values/strings.xml
@@ -66,6 +66,22 @@
   <string name="cat_textfield_filled_suffix_helper_text" translatable="false">Filled text field with suffix</string>
   <string name="cat_textfield_filled_suffix_icon_helper_text" translatable="false">Filled text field with suffix and icon</string>
 
+  <string name="cat_textfield_enclosed_helper_text">Enclosed text field</string>
+  <string name="cat_textfield_enclosed_dense_helper_text">Dense enclosed text field</string>
+  <string name="cat_textfield_enclosed_demo_title">Enclosed Text Field Demo</string>
+  <string name="cat_textfield_enclosed_icons_demo_title">Enclosed Icons Text Field Demo</string>
+  <string name="cat_textfield_enclosed_exposed_dropdown_helper_text">Enclosed exposed dropdown menu</string>
+  <string name="cat_textfield_enclosed_editable_exposed_dropdown_helper_text">Enclosed editable exposed dropdown menu</string>
+  <string name="cat_textfield_enclosed_dense_password_helper_text">Dense enclosed password text field</string>
+  <string name="cat_textfield_enclosed_clear_button_helper_text">Enclosed clear button text field</string>
+  <string name="cat_textfield_enclosed_custom_end_icon_helper_text">Enclosed custom end icon text field</string>
+  <string name="cat_textfield_enclosed_start_icon_helper_text">Enclosed start icon text field</string>
+  <string name="cat_textfield_enclosed_start_end_icons_helper_text">Enclosed start and end icons text field</string>
+  <string name="cat_textfield_enclosed_prefix_icon_helper_text">Enclosed text field with prefix and icon</string>
+  <string name="cat_textfield_enclosed_suffix_icon_helper_text">Enclosed text field with suffix and icon</string>
+  <string name="cat_textfield_enclosed_suffix_helper_text">Enclosed text field with suffix</string>
+  <string name="cat_textfield_enclosed_prefix_helper_text">Enclosed text field with prefix</string>
+
   <string name="cat_textfield_customize_section_title" translatable="false">Customize text fields</string>
   <string name="cat_textfield_customize_section_description" translatable="false">
     Enter values below to customize the text fields above. Press \"done\" to update each field.

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -242,13 +242,14 @@ public class TextInputLayout extends LinearLayout {
    * Values for box background mode. There is either a filled background, an outline background, or
    * no background.
    */
-  @IntDef({BOX_BACKGROUND_NONE, BOX_BACKGROUND_FILLED, BOX_BACKGROUND_OUTLINE})
+  @IntDef({BOX_BACKGROUND_NONE, BOX_BACKGROUND_FILLED, BOX_BACKGROUND_OUTLINE, BOX_BACKGROUND_ENCLOSED})
   @Retention(RetentionPolicy.SOURCE)
   public @interface BoxBackgroundMode {}
 
   public static final int BOX_BACKGROUND_NONE = 0;
   public static final int BOX_BACKGROUND_FILLED = 1;
   public static final int BOX_BACKGROUND_OUTLINE = 2;
+  public static final int BOX_BACKGROUND_ENCLOSED = 3;
 
   private final Rect tmpRect = new Rect();
   private final Rect tmpBoundsRect = new Rect();
@@ -837,7 +838,9 @@ public class TextInputLayout extends LinearLayout {
 
   @NonNull
   MaterialShapeDrawable getBoxBackground() {
-    if (boxBackgroundMode == BOX_BACKGROUND_FILLED || boxBackgroundMode == BOX_BACKGROUND_OUTLINE) {
+    if (boxBackgroundMode == BOX_BACKGROUND_FILLED
+        || boxBackgroundMode == BOX_BACKGROUND_OUTLINE
+        || boxBackgroundMode == BOX_BACKGROUND_ENCLOSED) {
       return boxBackground;
     }
     throw new IllegalStateException();
@@ -846,8 +849,8 @@ public class TextInputLayout extends LinearLayout {
   /**
    * Set the box background mode (filled, outline, or none).
    *
-   * <p>May be one of {@link #BOX_BACKGROUND_NONE}, {@link #BOX_BACKGROUND_FILLED}, or {@link
-   * #BOX_BACKGROUND_OUTLINE}.
+   * <p>May be one of {@link #BOX_BACKGROUND_NONE}, {@link #BOX_BACKGROUND_FILLED}, {@link
+   * #BOX_BACKGROUND_OUTLINE}, or {@link #BOX_BACKGROUND_ENCLOSED}.
    *
    * <p>Note: This method defines TextInputLayout's internal behavior (for example, it allows the
    * hint to be displayed inline with the stroke in a cutout), but doesn't set all attributes that
@@ -871,8 +874,8 @@ public class TextInputLayout extends LinearLayout {
   /**
    * Get the box background mode (filled, outline, or none).
    *
-   * <p>May be one of {@link #BOX_BACKGROUND_NONE}, {@link #BOX_BACKGROUND_FILLED}, or {@link
-   * #BOX_BACKGROUND_OUTLINE}.
+   * <p>May be one of {@link #BOX_BACKGROUND_NONE}, {@link #BOX_BACKGROUND_FILLED}, {@link
+   * #BOX_BACKGROUND_OUTLINE}, or {@link #BOX_BACKGROUND_ENCLOSED}.
    */
   @BoxBackgroundMode
   public int getBoxBackgroundMode() {
@@ -900,6 +903,10 @@ public class TextInputLayout extends LinearLayout {
         } else {
           boxBackground = new MaterialShapeDrawable(shapeAppearanceModel);
         }
+        boxUnderline = null;
+        break;
+      case BOX_BACKGROUND_ENCLOSED:
+        boxBackground = new MaterialShapeDrawable(shapeAppearanceModel);
         boxUnderline = null;
         break;
       case BOX_BACKGROUND_NONE:
@@ -1079,9 +1086,9 @@ public class TextInputLayout extends LinearLayout {
   /**
    * Set the resource used for the filled box's background color.
    *
-   * <p>Note: The background color is only supported for filled boxes. When used with box variants
-   * other than {@link BoxBackgroundMode#BOX_BACKGROUND_FILLED}, the box background color may not
-   * work as intended.
+   * <p>Note: The background color is only supported for filled or enclosed boxes. When used with
+   * box variants other than {@link BoxBackgroundMode#BOX_BACKGROUND_FILLED} or {@link
+   * BoxBackgroundMode#BOX_BACKGROUND_ENCLOSED}, the box background color may not work as intended.
    *
    * @param boxBackgroundColorId the resource to use for the box's background color
    */
@@ -1090,14 +1097,14 @@ public class TextInputLayout extends LinearLayout {
   }
 
   /**
-   * Sets the filled box's default background color. Calling this method will make the background
-   * color not be stateful, if it was before.
+   * Sets the filled or enclosed box's default background color. Calling this method will make
+   * the background color not be stateful, if it was before.
    *
-   * <p>Note: The background color is only supported for filled boxes. When used with box variants
-   * other than {@link BoxBackgroundMode#BOX_BACKGROUND_FILLED}, the box background color may not
-   * work as intended.
+   * <p>Note: The background color is only supported for filled or enclosed boxes. When used with
+   * box variants other than {@link BoxBackgroundMode#BOX_BACKGROUND_FILLED} or {@link
+   * BoxBackgroundMode#BOX_BACKGROUND_ENCLOSED}, the box background color may not work as intended.
    *
-   * @param boxBackgroundColor the color to use for the filled box's background
+   * @param boxBackgroundColor the color to use for the filled or enclosed box's background
    * @see #getBoxBackgroundColor()
    */
   public void setBoxBackgroundColor(@ColorInt int boxBackgroundColor) {
@@ -1113,9 +1120,9 @@ public class TextInputLayout extends LinearLayout {
   /**
    * Sets the box's background color state list.
    *
-   * <p>Note: The background color is only supported for filled boxes. When used with box variants
-   * other than {@link BoxBackgroundMode#BOX_BACKGROUND_FILLED}, the box background color may not
-   * work as intended.
+   * <p>Note: The background color is only supported for filled or enclosed boxes. When used with
+   * box variants other than {@link BoxBackgroundMode#BOX_BACKGROUND_FILLED} or {@link
+   * BoxBackgroundMode#BOX_BACKGROUND_ENCLOSED}, the box background color may not work as intended.
    *
    * @param boxBackgroundColorStateList the color state list to use for the box's background color
    */
@@ -1378,7 +1385,8 @@ public class TextInputLayout extends LinearLayout {
   private void updateInputLayoutMargins() {
     // Create/update the LayoutParams so that we can add enough top margin
     // to the EditText to make room for the label.
-    if (boxBackgroundMode != BOX_BACKGROUND_FILLED) {
+    if (boxBackgroundMode != BOX_BACKGROUND_FILLED
+        && boxBackgroundMode != BOX_BACKGROUND_ENCLOSED) {
       final LayoutParams lp = (LayoutParams) inputFrame.getLayoutParams();
       final int newTopMargin = calculateLabelMarginTop();
 
@@ -2433,6 +2441,7 @@ public class TextInputLayout extends LinearLayout {
       case BOX_BACKGROUND_OUTLINE:
         return (int) (collapsingTextHelper.getCollapsedTextHeight() / 2);
       case BOX_BACKGROUND_FILLED:
+      case BOX_BACKGROUND_ENCLOSED:
       case BOX_BACKGROUND_NONE:
         return (int) collapsingTextHelper.getCollapsedTextHeight();
       default:
@@ -2456,6 +2465,7 @@ public class TextInputLayout extends LinearLayout {
         bounds.right = rect.right - editText.getPaddingRight();
         return bounds;
       case BOX_BACKGROUND_FILLED:
+      case BOX_BACKGROUND_ENCLOSED:
         bounds.left = getLabelLeftBoundAlightWithPrefix(rect.left, isRtl);
         bounds.top = rect.top + boxCollapsedPaddingTopPx;
         bounds.right = getLabelRightBoundAlignedWithSuffix(rect.right, isRtl);
@@ -2524,7 +2534,8 @@ public class TextInputLayout extends LinearLayout {
   }
 
   private boolean isSingleLineFilledTextField() {
-    return boxBackgroundMode == BOX_BACKGROUND_FILLED
+    return (boxBackgroundMode == BOX_BACKGROUND_FILLED
+        || boxBackgroundMode == BOX_BACKGROUND_ENCLOSED)
         && (VERSION.SDK_INT < 16 || editText.getMinLines() <= 1);
   }
 
@@ -2536,7 +2547,8 @@ public class TextInputLayout extends LinearLayout {
    */
   private int calculateBoxBackgroundColor() {
     int backgroundColor = boxBackgroundColor;
-    if (boxBackgroundMode == BOX_BACKGROUND_FILLED) {
+    if (boxBackgroundMode == BOX_BACKGROUND_FILLED
+        || boxBackgroundMode == BOX_BACKGROUND_ENCLOSED) {
       int surfaceLayerColor = MaterialColors.getColor(this, R.attr.colorSurface, Color.TRANSPARENT);
       backgroundColor = MaterialColors.layer(surfaceLayerColor, boxBackgroundColor);
     }
@@ -2577,7 +2589,9 @@ public class TextInputLayout extends LinearLayout {
   }
 
   private boolean canDrawOutlineStroke() {
-    return boxBackgroundMode == BOX_BACKGROUND_OUTLINE && canDrawStroke();
+    return (boxBackgroundMode == BOX_BACKGROUND_OUTLINE
+        || boxBackgroundMode == BOX_BACKGROUND_ENCLOSED)
+        && canDrawStroke();
   }
 
   private boolean canDrawStroke() {
@@ -3937,7 +3951,8 @@ public class TextInputLayout extends LinearLayout {
     }
 
     // Update the text box's background color based on the current state.
-    if (boxBackgroundMode == BOX_BACKGROUND_FILLED) {
+    if (boxBackgroundMode == BOX_BACKGROUND_FILLED
+        || boxBackgroundMode == BOX_BACKGROUND_ENCLOSED) {
       if (!isEnabled()) {
         boxBackgroundColor = disabledFilledBackgroundColor;
       } else if (isHovered && !hasFocus) {

--- a/lib/java/com/google/android/material/textfield/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/attrs.xml
@@ -192,6 +192,8 @@
       <enum name="filled" value="1"/>
       <!-- Outline box mode for the text input box. -->
       <enum name="outline" value="2"/>
+      <!-- Enclosed box mode for the text input box. -->
+      <enum name="enclosed" value="3"/>
     </attr>
     <!-- Value to use for the EditText's collapsed top padding in box mode. -->
     <attr name="boxCollapsedPaddingTop" format="dimension"/>

--- a/lib/java/com/google/android/material/textfield/res/values/styles.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/styles.xml
@@ -116,6 +116,25 @@
     <item name="boxCollapsedPaddingTop">8dp</item>
   </style>
 
+  <style name="Widget.MaterialComponents.TextInputLayout.EnclosedBox" parent="Base.Widget.MaterialComponents.TextInputLayout">
+    <item name="materialThemeOverlay">
+      @style/ThemeOverlay.MaterialComponents.TextInputEditText.EnclosedBox
+    </item>
+    <item name="boxBackgroundMode">enclosed</item>
+    <item name="boxBackgroundColor">@color/mtrl_filled_background_color</item>
+    <item name="endIconTint">@color/mtrl_filled_icon_tint</item>
+    <item name="startIconTint">@color/mtrl_filled_icon_tint</item>
+    <item name="boxCollapsedPaddingTop">12dp</item>
+    <item name="boxStrokeColor">@color/mtrl_outlined_stroke_color</item>
+  </style>
+
+  <style name="Widget.MaterialComponents.TextInputLayout.EnclosedBox.Dense">
+    <item name="materialThemeOverlay">
+      @style/ThemeOverlay.MaterialComponents.TextInputEditText.EnclosedBox.Dense
+    </item>
+    <item name="boxCollapsedPaddingTop">8dp</item>
+  </style>
+
   <style name="Widget.MaterialComponents.TextInputLayout.OutlinedBox" parent="Base.Widget.MaterialComponents.TextInputLayout">
     <item name="materialThemeOverlay">
       @style/ThemeOverlay.MaterialComponents.TextInputEditText.OutlinedBox
@@ -140,6 +159,21 @@
   <style name="Widget.MaterialComponents.TextInputLayout.FilledBox.Dense.ExposedDropdownMenu">
     <item name="materialThemeOverlay">
       @style/ThemeOverlay.MaterialComponents.AutoCompleteTextView.FilledBox.Dense
+    </item>
+    <item name="endIconMode">dropdown_menu</item>
+  </style>
+
+  <!-- Styles to be used for the exposed dropdown menu. -->
+  <style name="Widget.MaterialComponents.TextInputLayout.EnclosedBox.ExposedDropdownMenu">
+    <item name="materialThemeOverlay">
+      @style/ThemeOverlay.MaterialComponents.AutoCompleteTextView.EnclosedBox
+    </item>
+    <item name="endIconMode">dropdown_menu</item>
+  </style>
+
+  <style name="Widget.MaterialComponents.TextInputLayout.EnclosedBox.Dense.ExposedDropdownMenu">
+    <item name="materialThemeOverlay">
+      @style/ThemeOverlay.MaterialComponents.AutoCompleteTextView.EnclosedBox.Dense
     </item>
     <item name="endIconMode">dropdown_menu</item>
   </style>
@@ -188,6 +222,16 @@
     <item name="android:paddingBottom">8dp</item>
   </style>
 
+  <style name="Widget.MaterialComponents.TextInputEditText.EnclosedBox" parent="Base.Widget.MaterialComponents.TextInputEditText">
+    <item name="android:paddingTop">28dp</item>
+    <item name="android:paddingBottom">12dp</item>
+  </style>
+
+  <style name="Widget.MaterialComponents.TextInputEditText.EnclosedBox.Dense">
+    <item name="android:paddingTop">24dp</item>
+    <item name="android:paddingBottom">8dp</item>
+  </style>
+
   <style name="Widget.MaterialComponents.TextInputEditText.OutlinedBox" parent="Base.Widget.MaterialComponents.TextInputEditText"/>
 
   <style name="Widget.MaterialComponents.TextInputEditText.OutlinedBox.Dense">
@@ -222,6 +266,17 @@
     <item name="android:paddingBottom">8dp</item>
   </style>
 
+  <!-- Styles for the AutocompleteTextView to be used if an ExposedDropdownMenu style is being used. -->
+  <style name="Widget.MaterialComponents.AutoCompleteTextView.EnclosedBox" parent="Base.Widget.MaterialComponents.AutoCompleteTextView">
+    <item name="android:paddingTop">28dp</item>
+    <item name="android:paddingBottom">12dp</item>
+  </style>
+
+  <style name="Widget.MaterialComponents.AutoCompleteTextView.EnclosedBox.Dense">
+    <item name="android:paddingTop">24dp</item>
+    <item name="android:paddingBottom">8dp</item>
+  </style>
+
   <style name="Widget.MaterialComponents.AutoCompleteTextView.OutlinedBox" parent="Base.Widget.MaterialComponents.AutoCompleteTextView"/>
 
   <style name="Widget.MaterialComponents.AutoCompleteTextView.OutlinedBox.Dense">
@@ -245,6 +300,15 @@
 
   <style name="ThemeOverlay.MaterialComponents.TextInputEditText.FilledBox.Dense">
     <item name="editTextStyle">@style/Widget.MaterialComponents.TextInputEditText.FilledBox.Dense
+    </item>
+  </style>
+
+  <style name="ThemeOverlay.MaterialComponents.TextInputEditText.EnclosedBox">
+    <item name="editTextStyle">@style/Widget.MaterialComponents.TextInputEditText.EnclosedBox</item>
+  </style>
+
+  <style name="ThemeOverlay.MaterialComponents.TextInputEditText.EnclosedBox.Dense">
+    <item name="editTextStyle">@style/Widget.MaterialComponents.TextInputEditText.EnclosedBox.Dense
     </item>
   </style>
 
@@ -272,6 +336,18 @@
   <style name="ThemeOverlay.MaterialComponents.AutoCompleteTextView.FilledBox.Dense">
     <item name="autoCompleteTextViewStyle">
       @style/Widget.MaterialComponents.AutoCompleteTextView.FilledBox.Dense
+    </item>
+  </style>
+
+  <style name="ThemeOverlay.MaterialComponents.AutoCompleteTextView.EnclosedBox">
+    <item name="autoCompleteTextViewStyle">
+      @style/Widget.MaterialComponents.AutoCompleteTextView.EnclosedBox
+    </item>
+  </style>
+
+  <style name="ThemeOverlay.MaterialComponents.AutoCompleteTextView.EnclosedBox.Dense">
+    <item name="autoCompleteTextViewStyle">
+      @style/Widget.MaterialComponents.AutoCompleteTextView.EnclosedBox.Dense
     </item>
   </style>
 


### PR DESCRIPTION
### [TextField] Added EnclosedBox style to TextField

EnclosedBox style have fill and layout like FilledBox but instead of underline it have border like OutlinedBox. That looked somewhat like [this dribble shot.](https://dribbble.com/shots/3429471-Floating-label-input-field)

![Dribble Shot - Floating label input field](https://cdn.dribbble.com/users/211428/screenshots/3429471/apr-12-2017_14-47-54.gif)

I've seen this style in places but couldn't achieve with this library. It felt like it should be here. So I've tried to fit it here.

I've also updated catalog to showcase examples of this style.