### PR TITLE
[CollapsingToolbarLayout] Use correct layout to calculate expanded bounds

### DIFF
--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -546,8 +546,6 @@ public final class CollapsingTextHelper {
             collapsedTextGravity,
             isRtl ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR);
 
-    float textLayoutHeight = textLayout != null ? textLayout.getHeight() : 0;
-
     switch (collapsedAbsGravity & Gravity.VERTICAL_GRAVITY_MASK) {
       case Gravity.BOTTOM:
         collapsedDrawY = collapsedBounds.bottom;
@@ -579,6 +577,8 @@ public final class CollapsingTextHelper {
     }
 
     calculateUsingTextSize(expandedTextSize);
+
+    float textLayoutHeight = textLayout != null ? textLayout.getHeight() : 0;
 
     float measuredWidth = textToDraw != null
         ? textPaint.measureText(textToDraw, 0, textToDraw.length()) : 0;


### PR DESCRIPTION
Fix an issue introduced in 83e4e47d2225cd281bef195d1baf035117cda4cd
which affected multiline collapsing toolbars
when the expanded size was much larger or smaller
than the collapsed size.
The stored `textLayoutHeight` is only used to
calculate the expanded bounds but is generated
after the call to `calculateUsingTextSize(collapsedTextSize)`
which updates `textLayout` to the collapsed size.
This change just moves it to after
`calculateUsingTextSize(expandedTextSize)` so
`textLayout` is using the expanded size.

Note this isn't very visible in the catalog app
because the text sizes are similar but you'll
notice after applying this that the bottom
margin now applies correctly. It's more noticeable
if you set the expanded text size to one of the
larger sizes.
