### PR TITLE
[CollapsingToolbarLayout] Fix CollapsingToolbar multiline position

### DIFF
--- a/catalog/java/io/material/catalog/application/theme/res/values/styles.xml
+++ b/catalog/java/io/material/catalog/application/theme/res/values/styles.xml
@@ -48,5 +48,10 @@
     <item name="android:textColorPrimary">?attr/colorOnPrimarySurface</item>
     <item name="colorControlNormal">?attr/colorOnPrimarySurface</item>
   </style>
-  
+
+  <style name="ThemeOverlay.Catalog.PopupMenu" parent="">
+    <item name="android:textColorPrimary">?attr/colorOnSurface</item>
+    <item name="colorControlNormal">?attr/colorOnSurface</item>
+  </style>
+
 </resources>

--- a/catalog/java/io/material/catalog/menu/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/menu/res/values/strings.xml
@@ -42,4 +42,8 @@
     <item>Item 3</item>
     <item>Item 4</item>
   </string-array>
+
+  <string name="menu_multiline_1">Max lines 1</string>
+  <string name="menu_multiline_2">Max lines 2</string>
+  <string name="menu_multiline_3">Max lines 3</string>
 </resources>

--- a/catalog/java/io/material/catalog/topappbar/TopAppBarCollapsingMultilineDemoFragment.java
+++ b/catalog/java/io/material/catalog/topappbar/TopAppBarCollapsingMultilineDemoFragment.java
@@ -19,16 +19,30 @@ package io.material.catalog.topappbar;
 import io.material.catalog.R;
 
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import androidx.annotation.Nullable;
+
+import com.google.android.material.appbar.CollapsingToolbarLayout;
+
 import io.material.catalog.feature.DemoFragment;
 
 /** A fragment that displays a collapsing Top App Bar demo for the Catalog app. */
 public class TopAppBarCollapsingMultilineDemoFragment extends DemoFragment {
+
+  @Override
+  public void onCreate(@Nullable Bundle bundle) {
+    super.onCreate(bundle);
+    setHasOptionsMenu(true);
+  }
 
   @Override
   public View onCreateDemoView(
@@ -42,6 +56,48 @@ public class TopAppBarCollapsingMultilineDemoFragment extends DemoFragment {
     activity.setSupportActionBar(toolbar);
 
     return view;
+  }
+
+  @Override
+  public void onCreateOptionsMenu(Menu menu, MenuInflater menuInflater) {
+    menuInflater.inflate(R.menu.cat_topappbar_menu_maxlines, menu);
+
+    super.onCreateOptionsMenu(menu, menuInflater);
+  }
+
+  @Override
+  public void onPrepareOptionsMenu(@NonNull Menu menu) {
+    super.onPrepareOptionsMenu(menu);
+
+    CollapsingToolbarLayout collapsingToolbarLayout = requireView().findViewById(R.id.collapsingtoolbarlayout);
+    switch (collapsingToolbarLayout.getMaxLines()) {
+      case 1:
+        menu.findItem(R.id.maxLines1).setChecked(true);
+        break;
+      case 2:
+        menu.findItem(R.id.maxLines2).setChecked(true);
+        break;
+      case 3:
+        menu.findItem(R.id.maxLines3).setChecked(true);
+        break;
+    }
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    CollapsingToolbarLayout collapsingToolbarLayout = requireView().findViewById(R.id.collapsingtoolbarlayout);
+    switch (item.getItemId()) {
+      case R.id.maxLines1:
+        collapsingToolbarLayout.setMaxLines(1);
+        return true;
+      case R.id.maxLines2:
+        collapsingToolbarLayout.setMaxLines(2);
+        return true;
+      case R.id.maxLines3:
+        collapsingToolbarLayout.setMaxLines(3);
+        return true;
+    }
+    return super.onOptionsItemSelected(item);
   }
 
   @Override

--- a/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_multiline_fragment.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/layout/cat_topappbar_collapsing_multiline_fragment.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   Copyright 2020 The Android Open Source Project
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -11,8 +10,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/coordinator"
@@ -47,6 +45,7 @@
         android:layout_height="?attr/actionBarSize"
         android:elevation="0dp"
         app:layout_collapseMode="pin"
+        app:popupTheme="@style/ThemeOverlay.Catalog.PopupMenu"
         app:title="@string/cat_topappbar_collapsing_multiline_demo_toolbar_title"
         tools:ignore="UnusedAttribute" />
     </com.google.android.material.appbar.CollapsingToolbarLayout>

--- a/catalog/java/io/material/catalog/topappbar/res/menu/cat_topappbar_menu_maxlines.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/menu/cat_topappbar_menu_maxlines.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+  <group android:checkableBehavior="single">
+    <item
+      android:id="@+id/maxLines1"
+      android:title="@string/menu_multiline_1" />
+    <item
+      android:id="@+id/maxLines2"
+      android:title="@string/menu_multiline_2" />
+    <item
+      android:id="@+id/maxLines3"
+      android:title="@string/menu_multiline_3" />
+  </group>
+</menu>

--- a/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
+++ b/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
@@ -482,7 +482,7 @@ public class CollapsingToolbarLayout extends FrameLayout {
         collapsingTextHelper.setCollapsedBounds(
             tmpRect.left + (isRtl ? toolbar.getTitleMarginEnd() : toolbar.getTitleMarginStart()),
             tmpRect.top + maxOffset + toolbar.getTitleMarginTop(),
-            tmpRect.right + (isRtl ? toolbar.getTitleMarginStart() : toolbar.getTitleMarginEnd()),
+            tmpRect.right - (isRtl ? toolbar.getTitleMarginStart() : toolbar.getTitleMarginEnd()),
             tmpRect.bottom + maxOffset - toolbar.getTitleMarginBottom());
 
         // Update the expanded bounds


### PR DESCRIPTION
closes https://github.com/material-components/material-components-android/issues/1201 and https://github.com/material-components/material-components-android/issues/1458

- [x] Identify the component the PR relates to in brackets in the title.
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

This fixes position of multiline text in expanded state (best visible if bottom margin is set to 0 as in https://github.com/material-components/material-components-android/issues/1458) as well as some jump when transitioning to collapsed state.