### PR TITLE
[TabLayout] Selected indicator paint can be null

### DIFF
--- a/lib/java/com/google/android/material/tabs/TabLayout.java
+++ b/lib/java/com/google/android/material/tabs/TabLayout.java
@@ -2822,7 +2822,7 @@ public class TabLayout extends HorizontalScrollView {
 
   class SlidingTabIndicator extends LinearLayout {
     private int selectedIndicatorHeight;
-    @NonNull private final Paint selectedIndicatorPaint;
+    private Paint selectedIndicatorPaint;
     @NonNull private final GradientDrawable defaultSelectionIndicator;
 
     int selectedPosition = -1;
@@ -2840,11 +2840,19 @@ public class TabLayout extends HorizontalScrollView {
     SlidingTabIndicator(Context context) {
       super(context);
       setWillNotDraw(false);
-      selectedIndicatorPaint = new Paint();
       defaultSelectionIndicator = new GradientDrawable();
     }
 
     void setSelectedIndicatorColor(int color) {
+      if (color == 0) {
+        selectedIndicatorPaint = null;
+        return;
+      }
+
+      if (selectedIndicatorPaint == null) {
+        selectedIndicatorPaint = new Paint();
+      }
+
       if (selectedIndicatorPaint.getColor() != color) {
         selectedIndicatorPaint.setColor(color);
         ViewCompat.postInvalidateOnAnimation(this);


### PR DESCRIPTION
Selected indicator paint can be null to allow using drawable color in TabLayout.

closes #1481 

- [x] Identify the component the PR relates to in brackets in the title.
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

When you set `app:tabIndicatorColor="@null"` it will clear the indicator color and it will not influence drawable anymore.