### PR TITLE
[BottomNavigationView] add label mode unselected

### DIFF
--- a/catalog/java/io/material/catalog/bottomnav/BottomNavigationLabelVisibilityDemoFragment.java
+++ b/catalog/java/io/material/catalog/bottomnav/BottomNavigationLabelVisibilityDemoFragment.java
@@ -66,6 +66,9 @@ public class BottomNavigationLabelVisibilityDemoFragment extends BottomNavigatio
         view.findViewById(R.id.label_mode_selected_button),
         LabelVisibilityMode.LABEL_VISIBILITY_SELECTED);
     initLabelVisibilityModeButton(
+        view.findViewById(R.id.label_mode_unselected_button),
+        LabelVisibilityMode.LABEL_VISIBILITY_UNSELECTED);
+    initLabelVisibilityModeButton(
         view.findViewById(R.id.label_mode_labeled_button),
         LabelVisibilityMode.LABEL_VISIBILITY_LABELED);
     initLabelVisibilityModeButton(

--- a/catalog/java/io/material/catalog/bottomnav/res/layout/cat_bottom_navs_label_visibility_controls.xml
+++ b/catalog/java/io/material/catalog/bottomnav/res/layout/cat_bottom_navs_label_visibility_controls.xml
@@ -92,6 +92,11 @@
         android:layout_height="wrap_content"
         android:text="@string/cat_bottom_nav_label_visibility_mode_selected"/>
     <RadioButton
+      android:id="@+id/label_mode_unselected_button"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/cat_bottom_nav_label_visibility_mode_selected"/>
+    <RadioButton
         android:id="@+id/label_mode_labeled_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/catalog/java/io/material/catalog/bottomnav/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/bottomnav/res/values/strings.xml
@@ -44,6 +44,7 @@
 
   <string name="cat_bottom_nav_label_visibility_mode_auto">Auto</string>
   <string name="cat_bottom_nav_label_visibility_mode_selected">Selected</string>
+  <string name="cat_bottom_nav_label_visibility_mode_unselected">Unselected</string>
   <string name="cat_bottom_nav_label_visibility_mode_labeled">Labeled</string>
   <string name="cat_bottom_nav_label_visibility_mode_unlabeled">Unlabeled</string>
 

--- a/lib/java/com/google/android/material/bottomnavigation/BottomNavigationItemView.java
+++ b/lib/java/com/google/android/material/bottomnavigation/BottomNavigationItemView.java
@@ -236,14 +236,10 @@ public class BottomNavigationItemView extends FrameLayout implements MenuView.It
         break;
 
       case LabelVisibilityMode.LABEL_VISIBILITY_SELECTED:
-        if (checked) {
-          setViewLayoutParams(icon, defaultMargin, Gravity.CENTER_HORIZONTAL | Gravity.TOP);
-          setViewValues(largeLabel, 1f, 1f, VISIBLE);
-        } else {
-          setViewLayoutParams(icon, defaultMargin, Gravity.CENTER);
-          setViewValues(largeLabel, 0.5f, 0.5f, INVISIBLE);
-        }
-        smallLabel.setVisibility(INVISIBLE);
+        setCheckedVisibilityMode(checked);
+        break;
+      case LabelVisibilityMode.LABEL_VISIBILITY_UNSELECTED:
+        setCheckedVisibilityMode(!checked);
         break;
 
       case LabelVisibilityMode.LABEL_VISIBILITY_LABELED:
@@ -488,5 +484,16 @@ public class BottomNavigationItemView extends FrameLayout implements MenuView.It
     }
     // TODO(b/138148581): Support displaying a badge on label-only bottom navigation views.
     return null;
+  }
+
+  private void setCheckedVisibilityMode(boolean checked) {
+    if (checked) {
+      setViewLayoutParams(icon, defaultMargin, Gravity.CENTER_HORIZONTAL | Gravity.TOP);
+      setViewValues(largeLabel, 1f, 1f, VISIBLE);
+    } else {
+      setViewLayoutParams(icon, defaultMargin, Gravity.CENTER);
+      setViewValues(largeLabel, 0.5f, 0.5f, INVISIBLE);
+    }
+    smallLabel.setVisibility(INVISIBLE);
   }
 }

--- a/lib/java/com/google/android/material/bottomnavigation/LabelVisibilityMode.java
+++ b/lib/java/com/google/android/material/bottomnavigation/LabelVisibilityMode.java
@@ -36,6 +36,7 @@ import java.lang.annotation.RetentionPolicy;
 @IntDef({
   LabelVisibilityMode.LABEL_VISIBILITY_AUTO,
   LabelVisibilityMode.LABEL_VISIBILITY_SELECTED,
+    LabelVisibilityMode.LABEL_VISIBILITY_UNSELECTED,
   LabelVisibilityMode.LABEL_VISIBILITY_LABELED,
   LabelVisibilityMode.LABEL_VISIBILITY_UNLABELED
 })
@@ -55,4 +56,7 @@ public @interface LabelVisibilityMode {
 
   /** Label is not shown on any navigation items. */
   int LABEL_VISIBILITY_UNLABELED = 2;
+
+  /** Label is not shown on the selected navigation item. */
+  int LABEL_VISIBILITY_UNSELECTED = 3;
 }

--- a/lib/java/com/google/android/material/bottomnavigation/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/bottomnavigation/res/values/attrs.xml
@@ -34,6 +34,8 @@
       <enum name="auto" value="-1"/>
       <!-- Label is shown on the selected navigation item. -->
       <enum name="selected" value="0"/>
+      <!-- label is not shown on the selected navigation item -->
+      <enum name="unselected" value="3"/>
       <!-- Label is shown on all navigation items. -->
       <enum name="labeled" value="1"/>
       <!-- Label is not shown on any navigation items. -->


### PR DESCRIPTION
#1494

A new behavior has been added for the label display modes
how to show only the icon, this mode and the inverse of LABEL_VISIBILITY_SELECTED

To take advantage of the behavior of LABEL_VISIBILITY_SELECTED I separated the method into a function setCheckedVisibilityMode, in this way it maintains the default behavior and to reverse the behavior a negation was used