### PR TITLE
Removed re-throw of exception on ViewOverlayApi14

### DIFF
--- a/lib/java/com/google/android/material/internal/ViewOverlayApi14.java
+++ b/lib/java/com/google/android/material/internal/ViewOverlayApi14.java
@@ -95,11 +95,11 @@ class ViewOverlayApi14 implements ViewOverlayImpl {
 
     static {
       try {
+        //noinspection JavaReflectionMemberAccess
         invalidateChildInParentFastMethod =
             ViewGroup.class.getDeclaredMethod(
                 "invalidateChildInParentFast", int.class, int.class, Rect.class);
-      } catch (NoSuchMethodException e) {
-        throw new RuntimeException(e);
+      } catch (NoSuchMethodException ignored) {
       }
     }
 


### PR DESCRIPTION
Possible fix for the RuntimeException in a try/catch which should not crash if the method is not there

Fixes #1486 
