### PR TITLE
[MaterialDatePicker] Option to hide the inputmode toggle in header

### DIFF
--- a/catalog/java/io/material/catalog/datepicker/DatePickerMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/datepicker/DatePickerMainDemoFragment.java
@@ -99,6 +99,7 @@ public class DatePickerMainDemoFragment extends DemoFragment {
     final RadioGroup opening = root.findViewById(R.id.cat_picker_opening_month_group);
     final RadioGroup selection = root.findViewById(R.id.cat_picker_selection_group);
     final RadioGroup inputMode = root.findViewById(R.id.cat_picker_input_mode_group);
+    final RadioGroup toggleInputMode = root.findViewById(R.id.cat_picker_toggle_input_mode_group);
 
     launcher.setOnClickListener(
         v -> {
@@ -111,6 +112,7 @@ public class DatePickerMainDemoFragment extends DemoFragment {
           int openingChoice = opening.getCheckedRadioButtonId();
           int selectionChoice = selection.getCheckedRadioButtonId();
           int inputModeChoices = inputMode.getCheckedRadioButtonId();
+          int toggleInputModeChoices = toggleInputMode.getCheckedRadioButtonId();
 
           MaterialDatePicker.Builder<?> builder =
               setupDateSelectorBuilder(selectionModeChoice, selectionChoice, inputModeChoices);
@@ -125,6 +127,10 @@ public class DatePickerMainDemoFragment extends DemoFragment {
 
           if (titleChoice == R.id.cat_picker_title_custom) {
             builder.setTitleText(R.string.cat_picker_title_custom);
+          }
+
+          if (toggleInputModeChoices == R.id.cat_picker_toggle_input_mode_hidden){
+            builder.showToggleInputMode(false);
           }
 
           try {

--- a/catalog/java/io/material/catalog/datepicker/res/layout/cat_picker_show_toggle_input_mode.xml
+++ b/catalog/java/io/material/catalog/datepicker/res/layout/cat_picker_show_toggle_input_mode.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2020 The Android Open Source Project
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/cat_picker_input_mode"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:padding="@dimen/cat_picker_demo_padding"
+  android:orientation="vertical">
+  <TextView
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:text="@string/cat_picker_toggle_input_mode"
+    android:textAppearance="?attr/textAppearanceHeadline5"/>
+  <RadioGroup
+    android:id="@+id/cat_picker_toggle_input_mode_group"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+    <RadioButton
+      android:id="@+id/cat_picker_toggle_input_mode_enabled"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:checked="true"
+      android:text="@string/cat_picker_toggle_input_mode_enabled"
+      android:textAppearance="?attr/textAppearanceBody1"/>
+    <RadioButton
+      android:id="@+id/cat_picker_toggle_input_mode_hidden"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/cat_picker_demo_padding"
+      android:layout_marginLeft="@dimen/cat_picker_demo_padding"
+      android:text="@string/cat_picker_toggle_input_mode_disabled"
+      android:textAppearance="?attr/textAppearanceBody1"/>
+
+  </RadioGroup>
+</LinearLayout>

--- a/catalog/java/io/material/catalog/datepicker/res/layout/picker_main_demo.xml
+++ b/catalog/java/io/material/catalog/datepicker/res/layout/picker_main_demo.xml
@@ -42,6 +42,7 @@
     <include layout="@layout/cat_picker_opening_month"/>
     <include layout="@layout/cat_picker_selection"/>
     <include layout="@layout/cat_picker_input_mode"/>
+    <include layout="@layout/cat_picker_show_toggle_input_mode"/>
 
   </LinearLayout>
 

--- a/catalog/java/io/material/catalog/datepicker/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/datepicker/res/values/strings.xml
@@ -100,4 +100,10 @@
   <!-- Indicates that the picker will start with text input mode [CHAR LIMIT=25] -->
   <string name="cat_picker_input_mode_text">Text Input</string>
 
+  <!-- Grouping label for a set of radio buttons to show the toggle for the input mode [CHAR LIMIT=50] -->
+  <string name="cat_picker_toggle_input_mode">Toggle Input Mode</string>
+  <!-- Indicates that the toggle for the input mode is displayed [CHAR LIMIT=25] -->
+  <string name="cat_picker_toggle_input_mode_enabled">Show</string>
+  <!-- Indicates that the toggle for the input mode is hidden [CHAR LIMIT=25] -->
+  <string name="cat_picker_toggle_input_mode_disabled">Hide</string>
 </resources>

--- a/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
@@ -67,6 +67,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
   private static final String TITLE_TEXT_RES_ID_KEY = "TITLE_TEXT_RES_ID_KEY";
   private static final String TITLE_TEXT_KEY = "TITLE_TEXT_KEY";
   private static final String INPUT_MODE_KEY = "INPUT_MODE_KEY";
+  private static final String SHOW_TOGGLE_INPUT_MODE_KEY = "SHOW_TOGGLE_INPUT_MODE_KEY";
 
   static final Object CONFIRM_BUTTON_TAG = "CONFIRM_BUTTON_TAG";
   static final Object CANCEL_BUTTON_TAG = "CANCEL_BUTTON_TAG";
@@ -123,6 +124,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
   private CharSequence titleText;
   private boolean fullscreen;
   @InputMode private int inputMode;
+  private boolean showToggleInputMode;
 
   private TextView headerSelectionText;
   private CheckableImageButton headerToggleButton;
@@ -139,6 +141,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     args.putInt(TITLE_TEXT_RES_ID_KEY, options.titleTextResId);
     args.putCharSequence(TITLE_TEXT_KEY, options.titleText);
     args.putInt(INPUT_MODE_KEY, options.inputMode);
+    args.putBoolean(SHOW_TOGGLE_INPUT_MODE_KEY,options.showToggleInputMode);
     materialDatePickerDialogFragment.setArguments(args);
     return materialDatePickerDialogFragment;
   }
@@ -157,6 +160,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     bundle.putParcelable(CALENDAR_CONSTRAINTS_KEY, constraintsBuilder.build());
     bundle.putInt(TITLE_TEXT_RES_ID_KEY, titleTextResId);
     bundle.putCharSequence(TITLE_TEXT_KEY, titleText);
+    bundle.putBoolean(SHOW_TOGGLE_INPUT_MODE_KEY, showToggleInputMode);
   }
 
   @Override
@@ -169,6 +173,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     titleTextResId = activeBundle.getInt(TITLE_TEXT_RES_ID_KEY);
     titleText = activeBundle.getCharSequence(TITLE_TEXT_KEY);
     inputMode = activeBundle.getInt(INPUT_MODE_KEY);
+    showToggleInputMode = activeBundle.getBoolean(SHOW_TOGGLE_INPUT_MODE_KEY);
   }
 
   private int getThemeResId(Context context) {
@@ -232,6 +237,11 @@ public final class MaterialDatePicker<S> extends DialogFragment {
       titleTextView.setText(titleTextResId);
     }
     initHeaderToggle(context);
+    if (showToggleInputMode){
+      headerToggleButton.setVisibility(View.VISIBLE);
+    } else {
+      headerToggleButton.setVisibility(View.GONE);
+    }
 
     confirmButton = root.findViewById(R.id.confirm_button);
     if (dateSelector.isSelectionComplete()) {
@@ -534,6 +544,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     CharSequence titleText = null;
     @Nullable S selection = null;
     @InputMode int inputMode = INPUT_MODE_CALENDAR;
+    boolean showToggleInputMode = true;
 
     private Builder(DateSelector<S> dateSelector) {
       this.dateSelector = dateSelector;
@@ -614,6 +625,12 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     @NonNull
     public Builder<S> setInputMode(@InputMode int inputMode) {
       this.inputMode = inputMode;
+      return this;
+    }
+
+    /** Used to enable the button to change the input mode */
+    public  Builder<S> showToggleInputMode(boolean showToggleInputMode) {
+      this.showToggleInputMode = showToggleInputMode;
       return this;
     }
 


### PR DESCRIPTION
Added an option to hide the toggle in header to change the input mode.
Updated the demo with the new option.

To hide the toggle just use:
`builder.showToggleInputMode(false);`

The default value of the new option is true.
#1380