### PR TITLE
[MaterialButtonToggleGroup] Reset MaterialButtonToggleGroup children margins correctly

### DIFF
--- a/catalog/java/io/material/catalog/button/ButtonToggleGroupDemoFragment.java
+++ b/catalog/java/io/material/catalog/button/ButtonToggleGroupDemoFragment.java
@@ -22,6 +22,10 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CompoundButton;
+import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.LinearLayout;
+
 import androidx.annotation.LayoutRes;
 import androidx.annotation.Nullable;
 import com.google.android.material.button.MaterialButtonToggleGroup;
@@ -47,17 +51,26 @@ public class ButtonToggleGroupDemoFragment extends DemoFragment {
         layoutInflater.inflate(getButtonToggleGroupContent(), viewGroup, /* attachToRoot= */ false);
     SwitchMaterial requireSelectionToggle = view.findViewById(R.id.switch_toggle);
 
-    requireSelectionToggle.setOnCheckedChangeListener(
-        (buttonView, isChecked) -> {
-          List<MaterialButtonToggleGroup> toggleGroups =
+      List<MaterialButtonToggleGroup> toggleGroups =
               DemoUtils.findViewsWithType(view, MaterialButtonToggleGroup.class);
-          for (MaterialButtonToggleGroup toggleGroup : toggleGroups) {
-            toggleGroup.setSelectionRequired(isChecked);
-          }
-        });
+      requireSelectionToggle.setOnCheckedChangeListener(
+              (buttonView, isChecked) -> {
+                  for (MaterialButtonToggleGroup toggleGroup : toggleGroups) {
+                      toggleGroup.setSelectionRequired(isChecked);
+                  }
+              });
 
-    List<MaterialButtonToggleGroup> toggleGroups =
-        DemoUtils.findViewsWithType(view, MaterialButtonToggleGroup.class);
+      SwitchMaterial verticalOrientationToggle = view.findViewById(R.id.orientation_switch_toggle);
+      verticalOrientationToggle.setOnCheckedChangeListener((buttonView, isChecked) -> {
+          for (MaterialButtonToggleGroup toggleGroup : toggleGroups) {
+              if (isChecked) {
+                  toggleGroup.setOrientation(LinearLayout.VERTICAL);
+              } else {
+                  toggleGroup.setOrientation(LinearLayout.HORIZONTAL);
+              }
+          }
+      });
+
     for (MaterialButtonToggleGroup toggleGroup : toggleGroups) {
       toggleGroup.addOnButtonCheckedListener(
           new OnButtonCheckedListener() {
@@ -69,8 +82,7 @@ public class ButtonToggleGroupDemoFragment extends DemoFragment {
             }
           });
     }
-    ;
-    return view;
+      return view;
   }
 
   @LayoutRes

--- a/catalog/java/io/material/catalog/button/res/layout/cat_buttons_toggle_group_fragment.xml
+++ b/catalog/java/io/material/catalog/button/res/layout/cat_buttons_toggle_group_fragment.xml
@@ -153,5 +153,15 @@
       android:enabled="true"
       android:text="@string/cat_button_require_selection" />
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/orientation_switch_toggle"
+        android:paddingTop="16dp"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:checked="false"
+        android:enabled="true"
+        android:text="@string/cat_button_vertical_orientation" />
+
   </LinearLayout>
 </ScrollView>

--- a/catalog/java/io/material/catalog/button/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/button/res/values/strings.xml
@@ -63,4 +63,5 @@
   <string description="A label for an icon-only button [CHAR LIMIT=NONE]"
       name="cat_icon_button_label_dialog">Dialog icon</string>
   <string name="cat_button_require_selection" translatable="false">Require Selection</string>
+  <string name="cat_button_vertical_orientation" translatable="false">Vertical Orientation</string>
 </resources>

--- a/lib/java/com/google/android/material/button/MaterialButtonToggleGroup.java
+++ b/lib/java/com/google/android/material/button/MaterialButtonToggleGroup.java
@@ -544,9 +544,11 @@ public class MaterialButtonToggleGroup extends LinearLayout {
       if (getOrientation() == HORIZONTAL) {
         MarginLayoutParamsCompat.setMarginEnd(params, 0);
         MarginLayoutParamsCompat.setMarginStart(params, -smallestStrokeWidth);
+        params.topMargin = 0;
       } else {
         params.bottomMargin = 0;
         params.topMargin = -smallestStrokeWidth;
+        MarginLayoutParamsCompat.setMarginStart(params, 0);
       }
 
       currentButton.setLayoutParams(params);


### PR DESCRIPTION
**Background:**
When changing a `MaterialButtonToggleGroup`'s orientation
programatically the children's margins are not reset correctly. This
causes the buttons to render incorrectly since the borders are missing.

**Modifications:**
* Update `MaterialButtonToggleGroup.adjustChildMarginsAndUpdateLayout`
to reset the top/start margins so the buttons render correctly.
* Add a new toggle to `ButtonToggleGroupDemoFragment` to programatically
switch the orientation of all the toggle groups between
vertical/horizontal in order to reproduce this issue.

### Issue
![image](https://user-images.githubusercontent.com/1526881/88466994-0b142d80-ce87-11ea-880a-61f3d06cea48.png)

### Fixed
![image](https://user-images.githubusercontent.com/1526881/88466996-0fd8e180-ce87-11ea-98cc-df4cc7c1e756.png)

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.
