### PR TITLE
[MaterialDatePicker] placeholder text in input picker

### DIFF
--- a/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
+++ b/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
@@ -200,6 +200,8 @@ public class RangeDateSelector implements DateSelector<Pair<Long, Long>> {
     }
 
     String formatHint = UtcDates.getTextInputHint(root.getResources(), format);
+    startTextInput.setPlaceholderText(formatHint);
+    endTextInput.setPlaceholderText(formatHint);
 
     startEditText.addTextChangedListener(
         new DateFormatTextWatcher(formatHint, format, startTextInput, constraints) {

--- a/lib/java/com/google/android/material/datepicker/SingleDateSelector.java
+++ b/lib/java/com/google/android/material/datepicker/SingleDateSelector.java
@@ -109,6 +109,7 @@ public class SingleDateSelector implements DateSelector<Long> {
     SimpleDateFormat format = UtcDates.getTextInputFormat();
     String formatHint = UtcDates.getTextInputHint(root.getResources(), format);
 
+    dateTextInput.setPlaceholderText(formatHint);
     if (selectedItem != null) {
       dateEditText.setText(format.format(selectedItem));
     }


### PR DESCRIPTION
According to [material design doc](https://material.io/components/pickers#anatomy) the input picker should display a placeholder text with the date format.

Added the placeholder text in input pickers with single and range selectors.

<img width="229" alt="Schermata 2020-07-28 alle 00 31 38" src="https://user-images.githubusercontent.com/2583078/88598509-b7156e80-d069-11ea-9d5d-74470b5cc8e9.png">

<img width="266" alt="Schermata 2020-07-28 alle 00 30 44" src="https://user-images.githubusercontent.com/2583078/88598457-9b11cd00-d069-11ea-869e-b0d0e1292e9d.png">

