### PR TITLE
[MaterialDatePicker] clear_text as endIconMode in input picker

### DIFF
--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_text_input_date.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_text_input_date.xml
@@ -15,18 +15,20 @@
     limitations under the License.
 -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/mtrl_calendar_text_input_frame"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:paddingTop="@dimen/mtrl_calendar_text_input_padding_top"
-    android:paddingBottom="16dp"
-    android:paddingLeft="@dimen/mtrl_calendar_content_padding"
-    android:paddingRight="@dimen/mtrl_calendar_content_padding">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/mtrl_calendar_text_input_frame"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:paddingTop="@dimen/mtrl_calendar_text_input_padding_top"
+  android:paddingBottom="16dp"
+  android:paddingLeft="@dimen/mtrl_calendar_content_padding"
+  android:paddingRight="@dimen/mtrl_calendar_content_padding">
 
   <com.google.android.material.textfield.TextInputLayout
       android:id="@+id/mtrl_picker_text_input_date"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="wrap_content"
+      app:endIconMode="clear_text">
 
     <com.google.android.material.textfield.TextInputEditText
         android:layout_width="match_parent"

--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_text_input_date_range.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_text_input_date_range.xml
@@ -15,6 +15,7 @@
     limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingTop="16dp"
@@ -27,7 +28,8 @@
       android:id="@+id/mtrl_picker_text_input_range_start"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_weight="1">
+      android:layout_weight="1"
+      app:endIconMode="clear_text">
 
     <com.google.android.material.textfield.TextInputEditText
         android:layout_width="match_parent"
@@ -45,7 +47,8 @@
       android:id="@+id/mtrl_picker_text_input_range_end"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_weight="1">
+      android:layout_weight="1"
+      app:endIconMode="clear_text">
 
     <com.google.android.material.textfield.TextInputEditText
         android:layout_width="match_parent"


### PR DESCRIPTION
Added a `clear_text` icon as `endIconMode` in the input picker for single and range selectors.

I am not sure it is compliant with your material design guideline of MaterialDatePicker.
It is never displayed in the screens reported in the doc but it is not specify as "don't".

When a date (or range) is selected it could be useful to display the clear_text action to clear the selected date in a quick way.

<img width="260" alt="Schermata 2020-07-28 alle 00 58 25" src="https://user-images.githubusercontent.com/2583078/88599990-7586c280-d06d-11ea-8ca2-2b260586bfea.png">


