### PR TITLE
[NavigationView] Support for shapeAppearance and shapeAppearanceOverlay attributes

### DIFF
--- a/lib/java/com/google/android/material/navigation/NavigationView.java
+++ b/lib/java/com/google/android/material/navigation/NavigationView.java
@@ -145,8 +145,10 @@ public class NavigationView extends ScrimInsetsFrameLayout {
     // Set the background to a MaterialShapeDrawable if it hasn't been set or if it can be converted
     // to a MaterialShapeDrawable.
     if (getBackground() == null || getBackground() instanceof ColorDrawable) {
+      ShapeAppearanceModel shapeAppearanceModel =
+          ShapeAppearanceModel.builder(context, attrs, defStyleAttr, DEF_STYLE_RES).build();
       Drawable orig = getBackground();
-      MaterialShapeDrawable materialShapeDrawable = new MaterialShapeDrawable();
+      MaterialShapeDrawable materialShapeDrawable = new MaterialShapeDrawable(shapeAppearanceModel);
       if (orig instanceof ColorDrawable) {
         materialShapeDrawable.setFillColor(
             ColorStateList.valueOf(((ColorDrawable) orig).getColor()));

--- a/lib/java/com/google/android/material/navigation/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/navigation/res/values/attrs.xml
@@ -64,5 +64,12 @@
     <!-- Fill color for the item background shape. Used if itemBackground isn't set and there is an
          itemShapeAppearance or itemShapeAppearanceOverlay. -->
     <attr name="itemShapeFillColor" format="color"/>
+    <!-- Shape appearance style reference for NavigationView. Attribute declaration is in the Shape
+         package. -->
+    <attr name="shapeAppearance"/>
+    <!-- Shape appearance overlay style reference for NavigationView. To be used to augment
+         attributes declared in the shapeAppearance. Attribute declaration is in the Shape package.
+    -->
+    <attr name="shapeAppearanceOverlay"/>
   </declare-styleable>
 </resources>


### PR DESCRIPTION
According to material design [documentation ](https://material.io/design/shape/about-shape.html#components-and-shape) the `NavigationView` can support customized shapes.

<img width="351" alt="Schermata 2020-07-29 alle 00 11 19" src="https://user-images.githubusercontent.com/2583078/88727482-09b95e00-d130-11ea-8941-92e80af4f239.png">

With this change the `NavigationView` supports the `shapeAppearance` and `shapeAppearanceOverlay` attributes in the layout.

```
  <com.google.android.material.navigation.NavigationView
     app:shapeAppearance="@style/ShapeAppearance.MaterialComponents.LargeComponent"
     ../>
```
or:
```
  <com.google.android.material.navigation.NavigationView
    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.MaterialComponents.NavigationView"
     ../>
```
with:

```
    <style name="ShapeAppearanceOverlay.MaterialComponents.NavigationView" parent="">
       <item name="cornerSizeTopRight">24dp</item>
       <item name="cornerSizeBottomRight">24dp</item>
    </style>
```