### PR TITLE
[Slider] option to show/hide tick marks in discrete mode

### DIFF
--- a/catalog/java/io/material/catalog/slider/SliderDiscreteDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderDiscreteDemoFragment.java
@@ -48,6 +48,7 @@ public class SliderDiscreteDemoFragment extends DemoFragment {
     setUpSlider(view, R.id.switch_button_3, R.id.slider_3, null);
     setUpSlider(view, R.id.switch_button_4, R.id.slider_4, new BasicLabelFormatter());
     setUpSlider(view, R.id.switch_button_5, R.id.slider_5, null);
+    setUpSlider(view, R.id.switch_button_6, R.id.slider_6, null);
 
     return view;
   }

--- a/catalog/java/io/material/catalog/slider/res/layout/cat_slider_demo_discrete.xml
+++ b/catalog/java/io/material/catalog/slider/res/layout/cat_slider_demo_discrete.xml
@@ -16,6 +16,7 @@
   -->
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -174,6 +175,37 @@
           android:valueFrom="0"
           android:valueTo="5.75"
           android:stepSize="0.25" />
+    </LinearLayout>
+
+    <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:paddingTop="@dimen/cat_slider_title_top_padding"
+      android:text="@string/cat_slider_title_6"/>
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:gravity="center_vertical">
+
+      <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switch_button_6"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.SecondaryPalette.Green" />
+
+      <com.google.android.material.slider.Slider
+        android:id="@+id/slider_6"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginLeft="@dimen/cat_slider_left_margin"
+        android:layout_marginStart="@dimen/cat_slider_left_margin"
+        android:theme="@style/ThemeOverlay.PrimaryPalette.Green"
+        android:valueFrom="0"
+        android:valueTo="10"
+        android:stepSize="1"
+        app:tickVisible="false"/>
     </LinearLayout>
   </LinearLayout>
 </ScrollView>

--- a/catalog/java/io/material/catalog/slider/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/slider/res/values/strings.xml
@@ -34,6 +34,7 @@
   <string name="cat_slider_title_3" description="The title for a demonstration slider">Negative numbers!</string>
   <string name="cat_slider_title_4" description="The title for a demonstration slider">With a label formatter</string>
   <string name="cat_slider_title_5" description="The title for a demonstration slider">I can have decimal numbers?</string>
+  <string name="cat_slider_title_6" description="The title for a demonstration slider">Without tick marks</string>
   <string name="cat_slider_start_touch_description" description="Indicates the slider is now being touched">Slider started being touched</string>
   <string name="cat_slider_stop_touch_description" description="Indicates the slider stopped being touched">Slider stopped being touched</string>
 

--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -117,6 +117,7 @@ import java.util.List;
  *   <li>{@code thumbColor}: the color of the slider's thumb.
  *   <li>{@code thumbElevation}: the elevation of the slider's thumb.
  *   <li>{@code thumbRadius}: The radius of the slider's thumb.
+ *   <li>{@code tickVisible}: Whether to show the tick marks. Only used when the slider is in discrete mode.
  *   <li>{@code tickColorActive}: the color of the slider's tick marks for the active part of the
  *       track. Only used when the slider is in discrete mode.
  *   <li>{@code tickColorInactive}: the color of the slider's tick marks for the inactive part of
@@ -164,6 +165,7 @@ import java.util.List;
  * @attr ref com.google.android.material.R.styleable#Slider_thumbColor
  * @attr ref com.google.android.material.R.styleable#Slider_thumbElevation
  * @attr ref com.google.android.material.R.styleable#Slider_thumbRadius
+ * @attr ref com.google.android.material.R.styleable#Slider_tickVisible
  * @attr ref com.google.android.material.R.styleable#Slider_tickColor
  * @attr ref com.google.android.material.R.styleable#Slider_tickColorActive
  * @attr ref com.google.android.material.R.styleable#Slider_tickColorInactive
@@ -248,6 +250,7 @@ abstract class BaseSlider<
   private boolean forceDrawCompatHalo;
   private boolean isLongPress = false;
   private boolean dirtyConfig;
+  private boolean tickVisible = true;
 
   @NonNull private ColorStateList haloColor;
   @NonNull private ColorStateList tickColorActive;
@@ -401,6 +404,7 @@ abstract class BaseSlider<
             ? haloColor
             : AppCompatResources.getColorStateList(context, R.color.material_slider_halo_color));
 
+    tickVisible = a.getBoolean(R.styleable.Slider_tickVisible, true);
     boolean hasTickColor = a.hasValue(R.styleable.Slider_tickColor);
     int tickColorInactiveRes =
         hasTickColor ? R.styleable.Slider_tickColor : R.styleable.Slider_tickColorInactive;
@@ -1120,6 +1124,29 @@ abstract class BaseSlider<
   }
 
   /**
+   * Returns whether the tick marks are visible. Only used when the slider is in discrete mode
+   *
+   * @see #setTickVisible(boolean)
+   * @attr ref com.google.android.material.R.styleable#Slider_tickVisible
+   */
+  public boolean isTickVisible() {
+    return tickVisible;
+  }
+
+  /**
+   * Sets whether these tick marks are visible. Only used when the slider is in discrete mode
+   *
+   * @param tickVisible The visibility of tick marks.
+   * @attr ref com.google.android.material.R.styleable#Slider_tickVisible
+   */
+  public void setTickVisible(boolean tickVisible) {
+    if (this.tickVisible != tickVisible){
+      this.tickVisible = tickVisible;
+      postInvalidate();
+    }
+  }
+
+  /**
    * Returns the color of the track if the active and inactive parts aren't different.
    *
    * @throws IllegalStateException If {@code trackColorActive} and {@code trackColorInactive} have
@@ -1396,26 +1423,28 @@ abstract class BaseSlider<
   }
 
   private void drawTicks(@NonNull Canvas canvas) {
-    float[] activeRange = getActiveRange();
-    int leftPivotIndex = pivotIndex(ticksCoordinates, activeRange[0]);
-    int rightPivotIndex = pivotIndex(ticksCoordinates, activeRange[1]);
+    if (tickVisible) {
+      float[] activeRange = getActiveRange();
+      int leftPivotIndex = pivotIndex(ticksCoordinates, activeRange[0]);
+      int rightPivotIndex = pivotIndex(ticksCoordinates, activeRange[1]);
 
-    // Draw inactive ticks to the left of the smallest thumb.
-    canvas.drawPoints(ticksCoordinates, 0, leftPivotIndex * 2, inactiveTicksPaint);
+      // Draw inactive ticks to the left of the smallest thumb.
+      canvas.drawPoints(ticksCoordinates, 0, leftPivotIndex * 2, inactiveTicksPaint);
 
-    // Draw active ticks between the thumbs.
-    canvas.drawPoints(
-        ticksCoordinates,
-        leftPivotIndex * 2,
-        rightPivotIndex * 2 - leftPivotIndex * 2,
-        activeTicksPaint);
+      // Draw active ticks between the thumbs.
+      canvas.drawPoints(
+          ticksCoordinates,
+          leftPivotIndex * 2,
+          rightPivotIndex * 2 - leftPivotIndex * 2,
+          activeTicksPaint);
 
-    // Draw inactive ticks to the right of the largest thumb.
-    canvas.drawPoints(
-        ticksCoordinates,
-        rightPivotIndex * 2,
-        ticksCoordinates.length - rightPivotIndex * 2,
-        inactiveTicksPaint);
+      // Draw inactive ticks to the right of the largest thumb.
+      canvas.drawPoints(
+          ticksCoordinates,
+          rightPivotIndex * 2,
+          ticksCoordinates.length - rightPivotIndex * 2,
+          inactiveTicksPaint);
+    }
   }
 
   private void drawThumbs(@NonNull Canvas canvas, int width, int top) {

--- a/lib/java/com/google/android/material/slider/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/slider/res/values/attrs.xml
@@ -43,6 +43,8 @@
     <attr name="thumbElevation" format="dimension" />
     <!-- The radius of the thumb. -->
     <attr name="thumbRadius" format="dimension" />
+    <!-- Whether to show the tick marks. Only used when the slider is in discrete mode. -->
+    <attr name="tickVisible" format="boolean" />
     <!-- The color of the slider's tick marks. Only used when the slider is in discrete mode. -->
     <attr name="tickColor" format="color" />
     <!-- The color of the slider's tick marks for the active portion of the track. Only used when


### PR DESCRIPTION
According to the [material design doc](https://material.io/components/sliders#discrete-sliders)

<img width="390" alt="Schermata 2020-07-31 alle 00 30 59" src="https://user-images.githubusercontent.com/2583078/88980970-28049280-d2c5-11ea-9ded-8149569c31f0.png">

the tick marks could be optional in a discrete mode.

This PR added a new option `tickVisible` to show/hide the tick marks in discrete mode.
The default value is `true`.

     <com.google.android.material.slider.Slider
        app:tickVisible="false"
         .../>

<img width="321" alt="Schermata 2020-07-31 alle 00 30 31" src="https://user-images.githubusercontent.com/2583078/88980980-2aff8300-d2c5-11ea-9b13-139ea42d46b0.png">



