### PR TITLE
[Catalog] Fix the wrong use of FragmentManager in TabsControllableDemoFragment

### DIFF
--- a/catalog/java/io/material/catalog/tabs/TabsControllableDemoFragment.java
+++ b/catalog/java/io/material/catalog/tabs/TabsControllableDemoFragment.java
@@ -170,7 +170,7 @@ public class TabsControllableDemoFragment extends DemoFragment {
   }
 
   private void setupViewPager() {
-    pager.setAdapter(new TabsPagerAdapter(getFragmentManager(), getContext(), TAB_COUNT));
+    pager.setAdapter(new TabsPagerAdapter(getChildFragmentManager(), getContext(), TAB_COUNT));
     for (TabLayout tabLayout : tabLayouts) {
       tabLayout.setupWithViewPager(pager);
     }


### PR DESCRIPTION
Fix the issue #1553 