### PR TITLE
[MaterialAlertDialog] Changed default elevation to 24 dp

### DIFF
--- a/lib/java/com/google/android/material/dialog/res/values-v21/themes_base.xml
+++ b/lib/java/com/google/android/material/dialog/res/values-v21/themes_base.xml
@@ -44,4 +44,9 @@
 
   <style name="Base.Theme.MaterialComponents.Light.Dialog" parent="Base.V21.Theme.MaterialComponents.Light.Dialog"/>
 
+  <style name="Base.ThemeOverlay.MaterialComponents.MaterialAlertDialog" parent="Base.V21.ThemeOverlay.MaterialComponents.MaterialAlertDialog"/>
+
+  <style name="Base.V21.ThemeOverlay.MaterialComponents.MaterialAlertDialog" parent="Base.V14.ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+    <item name="android:windowElevation">@dimen/mtrl_alert_dialog_elevation</item>
+  </style>
 </resources>

--- a/lib/java/com/google/android/material/dialog/res/values/dimens.xml
+++ b/lib/java/com/google/android/material/dialog/res/values/dimens.xml
@@ -20,6 +20,7 @@
   <dimen name="mtrl_alert_dialog_background_inset_top">80dp</dimen>
   <dimen name="mtrl_alert_dialog_background_inset_end">24dp</dimen>
   <dimen name="mtrl_alert_dialog_background_inset_bottom">80dp</dimen>
+  <dimen name="mtrl_alert_dialog_elevation">24dp</dimen>
   <!-- 16dp from abc_dialog_material_background.xml -->
   <dimen name="appcompat_dialog_background_inset">16dp</dimen>
 </resources>


### PR DESCRIPTION
According to the [material design doc](https://material.io/design/environment/elevation.html#default-elevations)  the default elevation for the `MaterialAlertDialog` should be `24dp`.

<img width="450" alt="Schermata 2020-07-31 alle 23 17 15" src="https://user-images.githubusercontent.com/2583078/89078113-04545180-d384-11ea-8e35-1d983d06ea10.png">

Currently the `MaterialAlertDialog` seems to use a value of `16dp` inheriting the value from `<item name="android:windowElevation">@dimen/abc_floating_window_z</item>` defined in the AppCompat theme.  
Using the dark mode with a `CardView `with `16dp` and a `CardView `with `24dp` you can check:

<img width="450" alt="current" src="https://user-images.githubusercontent.com/2583078/89078012-d111c280-d383-11ea-956d-8ea09769d68c.png">

With this PR the value is overridden in the default `ThemeOverlay.MaterialComponents.MaterialAlertDialog`.

It closes #1255.