### PR TITLE
[Catalog] Replaced getFragmentManager because deprecated

### DIFF
--- a/catalog/java/io/material/catalog/bottomappbar/BottomAppBarMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/bottomappbar/BottomAppBarMainDemoFragment.java
@@ -62,7 +62,7 @@ public class BottomAppBarMainDemoFragment extends DemoFragment implements OnBack
 
     // The theme switcher helper is used in an adhoc way with the toolbar since the BottomAppBar is
     // set as the action bar.
-    themeSwitcherHelper = new ThemeSwitcherHelper(getFragmentManager());
+    themeSwitcherHelper = new ThemeSwitcherHelper(getParentFragmentManager());
   }
 
   @Override

--- a/catalog/java/io/material/catalog/datepicker/DatePickerMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/datepicker/DatePickerMainDemoFragment.java
@@ -133,7 +133,7 @@ public class DatePickerMainDemoFragment extends DemoFragment {
             builder.setCalendarConstraints(constraintsBuilder.build());
             MaterialDatePicker<?> picker = builder.build();
             addSnackBarListeners(picker);
-            picker.show(getFragmentManager(), picker.toString());
+            picker.show(getChildFragmentManager(), picker.toString());
           } catch (IllegalArgumentException e) {
             snackbar.setText(e.getMessage());
             snackbar.show();

--- a/catalog/java/io/material/catalog/themeswitcher/ThemeSwitcherHelper.java
+++ b/catalog/java/io/material/catalog/themeswitcher/ThemeSwitcherHelper.java
@@ -30,7 +30,7 @@ public class ThemeSwitcherHelper {
   private final boolean enabled;
 
   public <F extends Fragment & ThemeSwitcherFragment> ThemeSwitcherHelper(F fragment) {
-    fragmentManager = fragment.getFragmentManager();
+    fragmentManager = fragment.getParentFragmentManager();
     enabled =
         fragment.shouldShowDefaultDemoActionBar()
             && fragment.getActivity() instanceof ThemeSwitcherActivity;

--- a/catalog/java/io/material/catalog/transition/hero/TransitionMusicLibraryDemoFragment.java
+++ b/catalog/java/io/material/catalog/transition/hero/TransitionMusicLibraryDemoFragment.java
@@ -95,7 +95,7 @@ public class TransitionMusicLibraryDemoFragment extends Fragment
     TransitionMusicAlbumDemoFragment fragment =
         TransitionMusicAlbumDemoFragment.newInstance(album.id);
 
-    getFragmentManager()
+    getParentFragmentManager()
         .beginTransaction()
         .addSharedElement(view, ViewCompat.getTransitionName(view))
         .replace(R.id.fragment_container, fragment, TransitionMusicAlbumDemoFragment.TAG)


### PR DESCRIPTION
### Thanks for starting a pull request on Material Components!

#### Overview
`getFragmentManager` was deprecated in API level 28.  

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
