### PR TITLE
[Slider] Added an option to allow a subset of tick marks in discrete mode

### DIFF
--- a/catalog/java/io/material/catalog/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/res/values/strings.xml
@@ -17,4 +17,5 @@
 
 <resources>
   <string name="cat_app_name">Material Components Catalog</string>
+    <string-array name="allowed_tick_values" />
 </resources>

--- a/catalog/java/io/material/catalog/slider/SliderDiscreteDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderDiscreteDemoFragment.java
@@ -49,6 +49,7 @@ public class SliderDiscreteDemoFragment extends DemoFragment {
     setUpSlider(view, R.id.switch_button_4, R.id.slider_4, new BasicLabelFormatter());
     setUpSlider(view, R.id.switch_button_5, R.id.slider_5, null);
     setUpSlider(view, R.id.switch_button_6, R.id.slider_6, null);
+    setUpSlider(view, R.id.switch_button_7, R.id.slider_7, null);
 
     return view;
   }

--- a/catalog/java/io/material/catalog/slider/res/layout/cat_slider_demo_discrete.xml
+++ b/catalog/java/io/material/catalog/slider/res/layout/cat_slider_demo_discrete.xml
@@ -207,5 +207,37 @@
         android:stepSize="1"
         app:tickVisible="false"/>
     </LinearLayout>
+
+    <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:paddingTop="@dimen/cat_slider_title_top_padding"
+      android:text="@string/cat_slider_title_7"/>
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:gravity="center_vertical">
+
+      <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switch_button_7"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.SecondaryPalette.Indigo" />
+
+      <com.google.android.material.slider.Slider
+        android:id="@+id/slider_7"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginLeft="@dimen/cat_slider_left_margin"
+        android:layout_marginStart="@dimen/cat_slider_left_margin"
+        android:theme="@style/ThemeOverlay.PrimaryPalette.Indigo"
+        android:valueFrom="0"
+        android:valueTo="1000"
+        android:stepSize="50"
+        app:trackHeight="6dp"
+        app:tickValues="@array/subset_tick_values" />
+    </LinearLayout>
   </LinearLayout>
 </ScrollView>

--- a/catalog/java/io/material/catalog/slider/res/values/arrays.xml
+++ b/catalog/java/io/material/catalog/slider/res/values/arrays.xml
@@ -18,4 +18,12 @@
     <item>2.0</item>
     <item>7.0</item>
   </array>
+  <array name="subset_tick_values">
+    <item>0.0</item>
+    <item>100</item>
+    <item>250</item>
+    <item>500</item>
+    <item>750</item>
+    <item>1000</item>
+  </array>
 </resources>

--- a/catalog/java/io/material/catalog/slider/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/slider/res/values/strings.xml
@@ -35,6 +35,7 @@
   <string name="cat_slider_title_4" description="The title for a demonstration slider">With a label formatter</string>
   <string name="cat_slider_title_5" description="The title for a demonstration slider">I can have decimal numbers?</string>
   <string name="cat_slider_title_6" description="The title for a demonstration slider">Without tick marks</string>
+  <string name="cat_slider_title_7" description="The title for a demonstration slider">Subset of tick marks</string>
   <string name="cat_slider_start_touch_description" description="Indicates the slider is now being touched">Slider started being touched</string>
   <string name="cat_slider_stop_touch_description" description="Indicates the slider stopped being touched">Slider stopped being touched</string>
 

--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -414,6 +414,7 @@ abstract class BaseSlider<
       int valuesId = a.getResourceId(R.styleable.Slider_tickValues, 0);
       TypedArray tickValues = a.getResources().obtainTypedArray(valuesId);
       setTickValues(convertToFloat(tickValues));
+      tickValues.recycle();
     }
     boolean hasTickColor = a.hasValue(R.styleable.Slider_tickColor);
     int tickColorInactiveRes =
@@ -532,7 +533,7 @@ abstract class BaseSlider<
                 Float.toString(stepSize),
                 Float.toString(stepSize)));
       }
-      if (tickValues.size() > 0){
+      if (!tickValues.isEmpty()){
         if (!tickValues.contains(value)){
           throw new IllegalStateException(
               String.format(
@@ -807,7 +808,7 @@ abstract class BaseSlider<
    */
   private void setTickValuesInternal(@NonNull ArrayList<Float> tickValues) {
     if (tickValues.isEmpty()) {
-      return;
+      throw new IllegalArgumentException("At least one value must be set");
     }
 
     Collections.sort(tickValues);
@@ -828,7 +829,7 @@ abstract class BaseSlider<
    */
   @NonNull
   public List<Float> getTickValues() {
-    return this.tickValues;
+    return tickValues;
   }
 
   /** Returns the index of the currently focused thumb */
@@ -1436,7 +1437,7 @@ abstract class BaseSlider<
     tickCount = Math.min(tickCount, trackWidth / (trackHeight * 2) + 1);
     float interval = trackWidth / (float) (tickCount - 1);
 
-    if (tickValues.size() > 0){
+    if (!tickValues.isEmpty()){
       tickCount = tickValues.size();
       maybeCalculateInternalTickValuesPosition();
     }
@@ -1445,7 +1446,7 @@ abstract class BaseSlider<
     }
 
     for (int i = 0; i < tickCount * 2; i += 2) {
-      if (tickValues.size() == 0) {
+      if (tickValues.isEmpty()) {
         ticksCoordinates[i] = trackSidePadding + i / 2 * interval;
       }else{
         ticksCoordinates[i] = trackSidePadding + (tickValues.get(i/2)-valueFrom)/ stepSize * interval;
@@ -1730,7 +1731,7 @@ abstract class BaseSlider<
 
   private double snapPosition(float position) {
     if (stepSize > 0.0f) {
-      if (tickValues.size() == 0) {
+      if (tickValues.isEmpty()) {
         int stepCount = (int) ((valueTo - valueFrom) / stepSize);
         return Math.round(position * stepCount) / (double) stepCount;
       } else {

--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -194,6 +194,8 @@ abstract class BaseSlider<
       "valueTo(%s) must be greater than valueFrom(%s)";
   private static final String EXCEPTION_ILLEGAL_STEP_SIZE =
       "The stepSize(%s) must be 0, or a factor of the valueFrom(%s)-valueTo(%s) range";
+  private static final String EXCEPTION_ILLEGAL_TICK_VALUE =
+      "Value(%s) must be a valid tickValue(%s)";
 
   private static final int TIMEOUT_SEND_ACCESSIBILITY_EVENT = 200;
   private static final int HALO_ALPHA = 63;
@@ -241,6 +243,8 @@ abstract class BaseSlider<
   // Holds the values set to this slider. We keep this array sorted in order to check if the value
   // has been changed when a new value is set and to find the minimum and maximum values.
   private ArrayList<Float> values = new ArrayList<>();
+  private ArrayList<Float> tickValues = new ArrayList<>();
+  private ArrayList<Double> internalTickValuesPosition = new ArrayList();
   // The index of the currently touched thumb.
   private int activeThumbIdx = -1;
   // The index of the currently focused thumb.
@@ -406,6 +410,11 @@ abstract class BaseSlider<
             : AppCompatResources.getColorStateList(context, R.color.material_slider_halo_color));
 
     tickVisible = a.getBoolean(R.styleable.Slider_tickVisible, true);
+    if (a.hasValue(R.styleable.Slider_tickValues)) {
+      int valuesId = a.getResourceId(R.styleable.Slider_tickValues, 0);
+      TypedArray tickValues = a.getResources().obtainTypedArray(valuesId);
+      setTickValues(convertToFloat(tickValues));
+    }
     boolean hasTickColor = a.hasValue(R.styleable.Slider_tickColor);
     int tickColorInactiveRes =
         hasTickColor ? R.styleable.Slider_tickColor : R.styleable.Slider_tickColorInactive;
@@ -479,6 +488,31 @@ abstract class BaseSlider<
     }
   }
 
+  private void validateTickValues() {
+    if (stepSize == 0.0) {
+      return;
+    }
+    for (Float tickValue : tickValues){
+      if (tickValue < valueFrom || tickValue > valueTo) {
+        throw new IllegalStateException(
+            String.format(
+                EXCEPTION_ILLEGAL_VALUE,
+                Float.toString(tickValue),
+                Float.toString(valueFrom),
+                Float.toString(valueTo)));
+      }
+      if (((tickValue - valueFrom) / stepSize) % 1 > THRESHOLD) {
+        throw new IllegalStateException(
+            String.format(
+                EXCEPTION_ILLEGAL_DISCRETE_VALUE,
+                Float.toString(tickValue),
+                Float.toString(valueFrom),
+                Float.toString(stepSize),
+                Float.toString(stepSize)));
+      }
+    }
+  }
+
   private void validateValues() {
     for (Float value : values) {
       if (value < valueFrom || value > valueTo) {
@@ -498,6 +532,15 @@ abstract class BaseSlider<
                 Float.toString(stepSize),
                 Float.toString(stepSize)));
       }
+      if (tickValues.size() > 0){
+        if (!tickValues.contains(value)){
+          throw new IllegalStateException(
+              String.format(
+                  EXCEPTION_ILLEGAL_TICK_VALUE,
+                  Float.toString(value),
+                  tickValues.toString()));
+        }
+      }
     }
   }
 
@@ -507,8 +550,17 @@ abstract class BaseSlider<
       validateValueTo();
       validateStepSize();
       validateValues();
+      validateTickValues();
       dirtyConfig = false;
     }
+  }
+
+  private static List<Float> convertToFloat(TypedArray values) {
+    List<Float> ret = new ArrayList<>();
+    for (int i = 0; i < values.length(); ++i) {
+      ret.add(values.getFloat(i, -1));
+    }
+    return ret;
   }
 
   /**
@@ -708,6 +760,75 @@ abstract class BaseSlider<
       dirtyConfig = true;
       postInvalidate();
     }
+  }
+
+  /**
+   * Sets the allowed values for the tick marks. Each value will represent a different tick.
+   *
+   * <p>Each value must be greater or equal to {@code valueFrom}, and lesser or equal
+   * valueTo}. If that is not the case, an {@link IllegalStateException} will be throw
+   * view is laid out.
+   *
+   * <p>The tick value must be set to a value falls on an existing tick based on the {@code stepSize}
+   * If that is not the case an {IllegalStateException} will be thrown when the view is laid out.
+   *
+   * @param tickValues An array of allowed tick values to set.
+   * @throws IllegalArgumentException If {@code tickValues} is invalid.
+   *
+   * @see #getTickValues()
+   */
+  public void setTickValues(@NonNull Float... tickValues) {
+    ArrayList<Float> list = new ArrayList<>();
+    Collections.addAll(list, tickValues);
+    setValuesInternal(list);
+  }
+
+  /**
+   * Sets the allowed values for the tick marks. Each value will represent a different tick.
+   *
+   * <p>Each value must be greater or equal to {@code valueFrom}, and lesser or equal
+   * valueTo}. If that is not the case, an {@link IllegalStateException} will be throw
+   * view is laid out.
+   *
+   * <p>The tick value must be set to a value falls on an existing tick based on the {@code stepSize}
+   * If that is not the case an {IllegalStateException} will be thrown when the view is laid out.
+   *
+   * @param tickValues A List of allowed tick values to set.
+   * @throws IllegalArgumentException If {@code tickValues} is invalid.
+   *
+   * @see #getTickValues()
+   */
+  public void setTickValues(@NonNull List<Float> tickValues) {
+    setTickValuesInternal(new ArrayList<>(tickValues));
+  }
+
+  /**
+   *
+   */
+  private void setTickValuesInternal(@NonNull ArrayList<Float> tickValues) {
+    if (tickValues.isEmpty()) {
+      return;
+    }
+
+    Collections.sort(tickValues);
+
+    if (this.tickValues.size() == tickValues.size()) {
+      if (this.tickValues.equals(tickValues)) {
+        return;
+      }
+    }
+
+    this.tickValues = tickValues;
+    dirtyConfig = true;
+    postInvalidate();
+  }
+
+  /**
+   * Returns the tick values
+   */
+  @NonNull
+  public List<Float> getTickValues() {
+    return this.tickValues;
   }
 
   /** Returns the index of the currently focused thumb */
@@ -1313,14 +1434,34 @@ abstract class BaseSlider<
     int tickCount = (int) ((valueTo - valueFrom) / stepSize + 1);
     // Limit the tickCount if they will be too dense.
     tickCount = Math.min(tickCount, trackWidth / (trackHeight * 2) + 1);
+    float interval = trackWidth / (float) (tickCount - 1);
+
+    if (tickValues.size() > 0){
+      tickCount = tickValues.size();
+      maybeCalculateInternalTickValuesPosition();
+    }
     if (ticksCoordinates == null || ticksCoordinates.length != tickCount * 2) {
       ticksCoordinates = new float[tickCount * 2];
     }
 
-    float interval = trackWidth / (float) (tickCount - 1);
     for (int i = 0; i < tickCount * 2; i += 2) {
-      ticksCoordinates[i] = trackSidePadding + i / 2 * interval;
+      if (tickValues.size() == 0) {
+        ticksCoordinates[i] = trackSidePadding + i / 2 * interval;
+      }else{
+        ticksCoordinates[i] = trackSidePadding + (tickValues.get(i/2)-valueFrom)/ stepSize * interval;
+      }
       ticksCoordinates[i + 1] = calculateTop();
+    }
+  }
+
+  private void maybeCalculateInternalTickValuesPosition(){
+
+    int stepCount = (int) ((valueTo - valueFrom) / stepSize);
+    double interval = (double) 1 / stepCount;
+    internalTickValuesPosition.clear();
+
+    for (double tickValue:this.tickValues){
+      internalTickValuesPosition.add((tickValue - valueFrom)/ stepSize * interval);
     }
   }
 
@@ -1589,10 +1730,19 @@ abstract class BaseSlider<
 
   private double snapPosition(float position) {
     if (stepSize > 0.0f) {
-      int stepCount = (int) ((valueTo - valueFrom) / stepSize);
-      return Math.round(position * stepCount) / (double) stepCount;
+      if (tickValues.size() == 0) {
+        int stepCount = (int) ((valueTo - valueFrom) / stepSize);
+        return Math.round(position * stepCount) / (double) stepCount;
+      } else {
+        Double closestTickValue = null;
+        for (double tickValuePosition:internalTickValuesPosition) {
+          if (closestTickValue == null || Math.abs(position - closestTickValue) > Math.abs(tickValuePosition - position)) {
+            closestTickValue = tickValuePosition;
+          }
+        }
+        return closestTickValue;
+      }
     }
-
     return position;
   }
 

--- a/lib/java/com/google/android/material/slider/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/slider/res/values/attrs.xml
@@ -53,6 +53,8 @@
     <attr name="tickColorInactive" format="color" />
     <!-- Whether to show the tick marks. Only used when the slider is in discrete mode. -->
     <attr name="tickVisible" format="boolean" />
+    <!-- valid tick marks -->
+    <attr name="tickValues" format="reference" />
     <!-- The color of the track. -->
     <attr name="trackColor" />
     <!-- The color of active portion of the track. -->


### PR DESCRIPTION
With this option you can use a subset of the tick marks in respect of `stepSize` attribute.

<img width="315" alt="screen" src="https://user-images.githubusercontent.com/2583078/89315696-72965e00-d67b-11ea-8d84-abc78553e364.png">

Example: 
```
  <com.google.android.material.slider.Slider
    android:valueFrom="0"
    android:valueTo="1000"
    android:stepSize="50"
    app:tickValues="@array/subset_tick_values" />
```

with:

```
  <array name="subset_tick_values">
    <item>0.0</item>
    <item>100</item>
    <item>250</item>
    <item>500</item>
    <item>750</item>
    <item>1000</item>
  </array>
```

![video](https://user-images.githubusercontent.com/2583078/89316242-20097180-d67c-11ea-9806-04caba022473.gif)

The `tickValues` must contains values:
- >= `valueFrom`
- <= `valueTo`
- = `valueFrom` + a multiple of `stepSize`


