### PR TITLE
[TextInputLayout] Exposed the style of the ExposedDropDownMenu

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -400,6 +400,8 @@ public class TextInputLayout extends LinearLayout {
 
   @ColorInt private int disabledColor;
 
+  @StyleRes protected int exposedDropDownMenuStyle;
+
   // Only used for testing
   private boolean hintExpanded;
 
@@ -674,6 +676,10 @@ public class TextInputLayout extends LinearLayout {
     setBoxBackgroundMode(
         a.getInt(R.styleable.TextInputLayout_boxBackgroundMode, BOX_BACKGROUND_NONE));
 
+    if (a.hasValue(R.styleable.TextInputLayout_exposedDropDownMenuStyle)){
+      exposedDropDownMenuStyle = a.getResourceId(R.styleable.TextInputLayout_exposedDropDownMenuStyle,
+          R.style.Widget_MaterialComponents_ExposedDropdownMenu_TextInputLayout_FilledBox);
+    }
     // Initialize end icon view.
     endIconView =
         (CheckableImageButton)

--- a/lib/java/com/google/android/material/textfield/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/textfield/res-public/values/public.xml
@@ -91,6 +91,7 @@
   <public name="passwordToggleTintMode" type="attr"/>
 
   <public name="textInputLayoutFocusedRectEnabled" type="attr"/>
+  <public name="exposedDropDownMenuStyle" type="attr"/>
 
   <public name="Widget.Design.TextInputLayout" type="style"/>
   <public name="Widget.MaterialComponents.TextInputLayout.FilledBox" type="style"/>
@@ -101,4 +102,8 @@
   <public name="Widget.MaterialComponents.TextInputLayout.FilledBox.Dense.ExposedDropdownMenu" type="style"/>
   <public name="Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu" type="style"/>
   <public name="Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense.ExposedDropdownMenu" type="style"/>
+  <public name="Widget.MaterialComponents.ExposedDropDownMenu" type="style"/>
+  <public name="Widget.MaterialComponents.ExposedDropDownMenu.TextInputLayout" type="style"/>
+  <public name="Widget.MaterialComponents.ExposedDropDownMenu.TextInputLayout.FilledBox" type="style"/>
+  <public name="Widget.MaterialComponents.ExposedDropDownMenu.TextInputLayout.OutlinedBox" type="style"/>
 </resources>

--- a/lib/java/com/google/android/material/textfield/res/values-v21/styles.xml
+++ b/lib/java/com/google/android/material/textfield/res/values-v21/styles.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2019 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+  <style name="Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout" parent="Base.Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout">
+    <item name="endIconDrawable">@drawable/mtrl_dropdown_arrow</item>
+  </style>
+
+</resources>

--- a/lib/java/com/google/android/material/textfield/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/attrs.xml
@@ -258,6 +258,8 @@
       <!-- [Sa + Da - Sa * Da, Sc + Dc - Sc * Dc] -->
       <enum name="screen" value="15"/>
     </attr>
+    <!-- The style used for the exposed dropDownMenu. -->
+    <attr name="exposedDropDownMenuStyle" format="reference" />
   </declare-styleable>
 
   <declare-styleable name="TextInputEditText">
@@ -268,6 +270,22 @@
 
   <declare-styleable name="MaterialAutoCompleteTextView" parent="AppCompatAutoCompleteTextView">
     <attr name="android:inputType"/>
+  </declare-styleable>
+
+  <declare-styleable name="TextInputLayout.ExposedDropDownMenu">
+    <!-- Whether the flat top corners should be used in DropDownMenu -->
+    <attr name="enforceFlatTopCorners" format="boolean"/>
+    <!-- popupVerticalPadding for DropDownMenu in TextInputLayout. -->
+    <attr name="popupVerticalPadding" format="dimension"/>
+    <!-- popupElevation for DropDownMenu in TextInputLayout. -->
+    <attr name="popupElevation" format="dimension"/>
+    <!-- Shape appearance style reference for DropDownMenu in TextInputLayout.
+    Attribute declaration is in the Shape package. -->
+    <attr name="shapeAppearance"/>
+    <!-- Shape appearance overlay style reference for DropDownMenu in  TextInputLayout.
+         To be used to augment attributes declared in the shapeAppearance. Attribute
+         declaration is in the Shape package. -->
+    <attr name="shapeAppearanceOverlay"/>
   </declare-styleable>
 
 </resources>

--- a/lib/java/com/google/android/material/textfield/res/values/styles.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/styles.xml
@@ -92,6 +92,7 @@
 
     <item name="shapeAppearance">?attr/shapeAppearanceSmallComponent</item>
     <item name="shapeAppearanceOverlay">@null</item>
+    <item name="exposedDropDownMenuStyle">@null</item>
   </style>
 
   <style name="Widget.MaterialComponents.TextInputLayout.FilledBox" parent="Base.Widget.MaterialComponents.TextInputLayout">
@@ -135,6 +136,7 @@
       @style/ThemeOverlay.MaterialComponents.AutoCompleteTextView.FilledBox
     </item>
     <item name="endIconMode">dropdown_menu</item>
+    <item name="exposedDropDownMenuStyle">@style/Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout.FilledBox</item>
   </style>
 
   <style name="Widget.MaterialComponents.TextInputLayout.FilledBox.Dense.ExposedDropdownMenu">
@@ -142,6 +144,7 @@
       @style/ThemeOverlay.MaterialComponents.AutoCompleteTextView.FilledBox.Dense
     </item>
     <item name="endIconMode">dropdown_menu</item>
+    <item name="exposedDropDownMenuStyle">@style/Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout.FilledBox</item>
   </style>
 
   <style name="Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
@@ -149,6 +152,7 @@
       @style/ThemeOverlay.MaterialComponents.AutoCompleteTextView.OutlinedBox
     </item>
     <item name="endIconMode">dropdown_menu</item>
+    <item name="exposedDropDownMenuStyle">@style/Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout.OutlinedBox</item>
   </style>
 
   <style name="Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense.ExposedDropdownMenu">
@@ -156,6 +160,7 @@
       @style/ThemeOverlay.MaterialComponents.AutoCompleteTextView.OutlinedBox.Dense
     </item>
     <item name="endIconMode">dropdown_menu</item>
+    <item name="exposedDropDownMenuStyle">@style/Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout.OutlinedBox</item>
   </style>
 
   <style name="Widget.Design.TextInputEditText" parent="Widget.AppCompat.EditText">
@@ -316,4 +321,21 @@
     <item name="cornerSizeBottomRight">@dimen/mtrl_textinput_box_corner_radius_small</item>
   </style>
 
+  <style name="Widget.MaterialComponents.ExposedDropdownMenu" parent="android:Widget"/>
+
+  <style name="Base.Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout" parent="Widget.MaterialComponents.ExposedDropdownMenu">
+    <item name="endIconDrawable">@drawable/mtrl_ic_arrow_drop_down</item>
+    <item name="popupVerticalPadding">@dimen/mtrl_exposed_dropdown_menu_popup_vertical_padding</item>
+    <item name="popupElevation">@dimen/mtrl_exposed_dropdown_menu_popup_elevation</item>
+    <item name="enforceFlatTopCorners">false</item>
+    <item name="shapeAppearance">?attr/shapeAppearanceMediumComponent</item>
+  </style>
+
+  <style name="Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout" parent="Base.Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout"/>
+
+  <style name="Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout.FilledBox">
+    <item name="enforceFlatTopCorners">true</item>
+  </style>
+
+  <style name="Widget.MaterialComponents.ExposedDropdownMenu.TextInputLayout.OutlinedBox"/>
 </resources>


### PR DESCRIPTION
Currently the ExposedDropDownMenu provided by `DropdownMenuEndIconDelegate` doesn't use the `shapeAppearance` defined in the app theme and the corner radius are defined by code.

With this change:
- the ExposedDropDownMenu uses the `shapeAppearance` defined in the app theme
- there is a new attribute `exposedDropDownMenuStyle` defined in the `TextInputLayout` style with allows to customize the `shapeAppearance` /`shapeAppearanceOverlay` (and some other properties) of the ExposedDropDownMenu.

This change can be tested with the current catalog (changing the  `shapeAppearance`).


<img width="303" alt="Schermata 2020-08-05 alle 21 32 38" src="https://user-images.githubusercontent.com/2583078/89457343-84ecc680-d765-11ea-8982-9d17ef551dfe.png">
<img width="305" alt="Schermata 2020-08-05 alle 21 32 48" src="https://user-images.githubusercontent.com/2583078/89457397-9fbf3b00-d765-11ea-9b88-2625829772ab.png">


<img width="309" alt="Schermata 2020-08-05 alle 21 33 14" src="https://user-images.githubusercontent.com/2583078/89457404-a2ba2b80-d765-11ea-9683-14c132adc62d.png">

