### PR TITLE
[CollapsingToolbarLayout] If scrimAnimator already created we must update the duration when calling `setScrimAnimationDuration`

### DIFF
--- a/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
+++ b/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
@@ -639,7 +639,7 @@ public class CollapsingToolbarLayout extends FrameLayout {
     } else if (scrimAnimator.isRunning()) {
       scrimAnimator.cancel();
     }
-
+    scrimAnimator.setDuration(scrimAnimationDuration);
     scrimAnimator.setIntValues(scrimAlpha, targetAlpha);
     scrimAnimator.start();
   }


### PR DESCRIPTION
**Component:** CollapsingToolbarLayout

**Problem:** When calling `setScrimAnimationDuration` if the `scrimAnimator` is already created he duration of the animator must be updated.
On the `animateScrim` the null verification protects the duration to be re-defined.
