### PR TITLE
[CollapsingToolbarLayout] When scrimAnimator already created we must update the duration when calling `setScrimAnimationDuration`

### DIFF
--- a/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
+++ b/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
@@ -624,7 +624,6 @@ public class CollapsingToolbarLayout extends FrameLayout {
     ensureToolbar();
     if (scrimAnimator == null) {
       scrimAnimator = new ValueAnimator();
-      scrimAnimator.setDuration(scrimAnimationDuration);
       scrimAnimator.setInterpolator(
           targetAlpha > scrimAlpha
               ? AnimationUtils.FAST_OUT_LINEAR_IN_INTERPOLATOR
@@ -640,6 +639,7 @@ public class CollapsingToolbarLayout extends FrameLayout {
       scrimAnimator.cancel();
     }
 
+    scrimAnimator.setDuration(scrimAnimationDuration);
     scrimAnimator.setIntValues(scrimAlpha, targetAlpha);
     scrimAnimator.start();
   }


### PR DESCRIPTION
**Component:** CollapsingToolbarLayout

**Problem:** When calling `setScrimAnimationDuration` if the `scrimAnimator` is already created he duration of the animator must be updated.
On `animateScrim` the null verification protects the duration to be re-defined.