### PR TITLE
[TextInputLayout] background color of the indicatorArea when error is displayed

### DIFF
--- a/lib/java/com/google/android/material/textfield/IndicatorViewController.java
+++ b/lib/java/com/google/android/material/textfield/IndicatorViewController.java
@@ -28,7 +28,9 @@ import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
 import android.os.Build.VERSION;
+import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.widget.TextViewCompat;
 import androidx.appcompat.widget.AppCompatTextView;
@@ -46,6 +48,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import com.google.android.material.animation.AnimationUtils;
 import com.google.android.material.animation.AnimatorSetCompat;
+import com.google.android.material.shape.MaterialShapeDrawable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
@@ -107,6 +110,7 @@ final class IndicatorViewController {
   @Nullable private CharSequence errorViewContentDescription;
   private int errorTextAppearance;
   @Nullable private ColorStateList errorViewTextColor;
+  @Nullable private ColorStateList indicatorAreaBackgroundColorOnError;
 
   private CharSequence helperText;
   private boolean helperTextEnabled;
@@ -158,6 +162,7 @@ final class IndicatorViewController {
     }
     updateCaptionViewsVisibility(
         captionDisplayed, captionToShow, shouldAnimateCaptionView(errorView, errorText));
+    tintIndicatorAreaBackground();
   }
 
   void hideError() {
@@ -175,6 +180,25 @@ final class IndicatorViewController {
     }
     updateCaptionViewsVisibility(
         captionDisplayed, captionToShow, shouldAnimateCaptionView(errorView, null));
+    removeIndicatorAreaBackground();
+  }
+
+  void tintIndicatorAreaBackground(){
+    if (indicatorAreaBackgroundColorOnError == null){
+      return;
+    }
+    Drawable indicatorAreaBackground = indicatorArea.getBackground();
+    if (indicatorAreaBackground == null){
+      indicatorAreaBackground = new MaterialShapeDrawable();
+    }
+    DrawableCompat.setTintList(indicatorAreaBackground, indicatorAreaBackgroundColorOnError);
+    ViewCompat.setBackground(indicatorArea,indicatorAreaBackground);
+  }
+
+  void removeIndicatorAreaBackground(){
+    if (indicatorArea.getBackground()!=null){
+      ViewCompat.setBackground(indicatorArea,null);
+    }
   }
 
   /**
@@ -559,6 +583,17 @@ final class IndicatorViewController {
     this.errorViewTextColor = errorViewTextColor;
     if (errorView != null && errorViewTextColor != null) {
       errorView.setTextColor(errorViewTextColor);
+    }
+  }
+
+  void setIndicatorAreaBackgroundColorOnError(ColorStateList indicatorAreaBackgroundColorOnError){
+    this.indicatorAreaBackgroundColorOnError = indicatorAreaBackgroundColorOnError;
+    if (errorView != null && (errorIsDisplayed() || !TextUtils.isEmpty(errorText))) {
+      if (indicatorAreaBackgroundColorOnError !=null) {
+        tintIndicatorAreaBackground();
+      } else {
+        removeIndicatorAreaBackground();
+      }
     }
   }
 

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -806,6 +806,10 @@ public class TextInputLayout extends LinearLayout {
 
     setEnabled(a.getBoolean(R.styleable.TextInputLayout_android_enabled, true));
 
+    if (a.hasValue(R.styleable.TextInputLayout_indicatorAreaBackgroundColorOnError)) {
+      setIndicatorAreaBackgroundColorOnError(a.getColorStateList(R.styleable.TextInputLayout_indicatorAreaBackgroundColorOnError));
+    }
+
     a.recycle();
 
     // For accessibility, consider TextInputLayout itself to be a simple container for an EditText,
@@ -1642,6 +1646,11 @@ public class TextInputLayout extends LinearLayout {
   @ColorInt
   public int getErrorCurrentTextColors() {
     return indicatorViewController.getErrorViewCurrentTextColor();
+  }
+
+  /** Sets the background color used by the error message in all states. */
+  public void setIndicatorAreaBackgroundColorOnError(@Nullable ColorStateList indicatorAreaBackgroundColorOnError) {
+    indicatorViewController.setIndicatorAreaBackgroundColorOnError(indicatorAreaBackgroundColorOnError);
   }
 
   /**

--- a/lib/java/com/google/android/material/textfield/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/textfield/res-public/values/public.xml
@@ -57,6 +57,7 @@
   <public name="errorIconDrawable" type="attr"/>
   <public name="errorIconTint" type="attr"/>
   <public name="errorIconTintMode" type="attr"/>
+  <public name="indicatorAreaBackgroundColoraOnError" type="attr"/>
   <public name="helperText" type="attr"/>
   <public name="helperTextEnabled" type="attr"/>
   <public name="helperTextTextAppearance" type="attr"/>

--- a/lib/java/com/google/android/material/textfield/res/color/mtrl_bg_indicatorarea_error.xml
+++ b/lib/java/com/google/android/material/textfield/res/color/mtrl_bg_indicatorarea_error.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2018 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:alpha="0.38" android:color="?attr/colorOnError" android:state_enabled="false"/>
+  <item android:color="?attr/colorOnError"/>
+</selector>

--- a/lib/java/com/google/android/material/textfield/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/attrs.xml
@@ -80,6 +80,7 @@
       <!-- [Sa + Da - Sa * Da, Sc + Dc - Sc * Dc] -->
       <enum name="screen" value="15"/>
     </attr>
+    <attr name="indicatorAreaBackgroundColorOnError" format="reference"/>
 
     <!-- Whether the layout is laid out as if the character counter will be displayed. -->
     <attr name="counterEnabled" format="boolean"/>

--- a/lib/java/com/google/android/material/textfield/res/values/styles.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/styles.xml
@@ -82,6 +82,7 @@
     <item name="counterOverflowTextColor">@color/mtrl_error</item>
     <item name="errorTextColor">@color/mtrl_error</item>
     <item name="helperTextTextColor">@color/mtrl_indicator_text_color</item>
+    <item name="indicatorAreaBackgroundColorOnError">@color/mtrl_bg_indicatorarea_error</item>
     <!-- The color of the label when it is collapsed and the text field is active -->
     <item name="hintTextColor">?attr/colorPrimary</item>
     <item name="placeholderTextColor">@color/mtrl_indicator_text_color</item>


### PR DESCRIPTION
Sometimes in the `TextInputLayout` the error text is not full visible.
Instead of changing the `errorTextColor` could be useful an option to change the background color leaving the std errorTextColor.
Example:
<img width="300" alt="Schermata 2020-08-06 alle 18 57 41" src="https://user-images.githubusercontent.com/2583078/89566699-d8701a80-d820-11ea-81e8-ff9241aab7f9.png">


This change adds an option to tint the background color of the indicatorArea when an error is displayed.  
The default background doesn't change the current behavior.

<img width="293" alt="Schermata 2020-08-06 alle 18 57 57" src="https://user-images.githubusercontent.com/2583078/89566550-a3fc5e80-d820-11ea-8337-4a89af1ad66c.png">

Example:

```
  <com.google.android.material.textfield.TextInputLayout
      app:indicatorAreaBackgroundColorOnError="@color/indicator_area_backgroundcolor_selector"
```

or:

`labelTextField.setIndicatorAreaBackgroundColorOnError(...);`

It is related to #1234 

