### PR TITLE
[TextInputLayout] set the endIconOnClickListener also with endIconMode

### DIFF
--- a/lib/java/com/google/android/material/textfield/ClearTextEndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/ClearTextEndIconDelegate.java
@@ -108,7 +108,7 @@ class ClearTextEndIconDelegate extends EndIconDelegate {
         AppCompatResources.getDrawable(context, R.drawable.mtrl_ic_cancel));
     textInputLayout.setEndIconContentDescription(
         textInputLayout.getResources().getText(R.string.clear_text_end_icon_content_description));
-    textInputLayout.setEndIconOnClickListener(
+    textInputLayout.internalSetEndIconOnClickListener(
         new OnClickListener() {
           @Override
           public void onClick(View v) {
@@ -118,6 +118,7 @@ class ClearTextEndIconDelegate extends EndIconDelegate {
             }
 
             textInputLayout.refreshEndIconDrawableState();
+            callOriginalEndIconOnClickListener(v);
           }
         });
     textInputLayout.addOnEditTextAttachedListener(clearTextOnEditTextAttachedListener);

--- a/lib/java/com/google/android/material/textfield/CustomEndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/CustomEndIconDelegate.java
@@ -29,7 +29,7 @@ class CustomEndIconDelegate extends EndIconDelegate {
 
   @Override
   void initialize() {
-    textInputLayout.setEndIconOnClickListener(null);
+    textInputLayout.internalSetEndIconOnClickListener(null);
     textInputLayout.setEndIconOnLongClickListener(null);
   }
 }

--- a/lib/java/com/google/android/material/textfield/DropdownMenuEndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/DropdownMenuEndIconDelegate.java
@@ -237,12 +237,13 @@ class DropdownMenuEndIconDelegate extends EndIconDelegate {
     textInputLayout.setEndIconDrawable(AppCompatResources.getDrawable(context, drawableResId));
     textInputLayout.setEndIconContentDescription(
         textInputLayout.getResources().getText(R.string.exposed_dropdown_menu_content_description));
-    textInputLayout.setEndIconOnClickListener(
+    textInputLayout.internalSetEndIconOnClickListener(
         new OnClickListener() {
           @Override
           public void onClick(View v) {
             AutoCompleteTextView editText = (AutoCompleteTextView) textInputLayout.getEditText();
             showHideDropdown(editText);
+            callOriginalEndIconOnClickListener(v);
           }
         });
     textInputLayout.addOnEditTextAttachedListener(dropdownMenuOnEditTextAttachedListener);

--- a/lib/java/com/google/android/material/textfield/EndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/EndIconDelegate.java
@@ -17,6 +17,7 @@
 package com.google.android.material.textfield;
 
 import android.content.Context;
+import android.view.View;
 import androidx.annotation.NonNull;
 import com.google.android.material.internal.CheckableImageButton;
 import com.google.android.material.textfield.TextInputLayout.BoxBackgroundMode;
@@ -68,4 +69,16 @@ abstract class EndIconDelegate {
    * @param visible whether the icon should be set to visible
    */
   void onSuffixVisibilityChanged(boolean visible) {}
+
+  /**
+   * This method allows to call the {@link TextInputLayout#setEndIconOnClickListener} original set on the TextInputLayout
+   *
+   * @param view The view that was clicked
+   */
+  void callOriginalEndIconOnClickListener(View view){
+    if (textInputLayout.endIconOnClickListener != null) {
+      textInputLayout.endIconOnClickListener.onClick(view);
+    }
+  }
+
 }

--- a/lib/java/com/google/android/material/textfield/PasswordToggleEndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/PasswordToggleEndIconDelegate.java
@@ -81,7 +81,7 @@ class PasswordToggleEndIconDelegate extends EndIconDelegate {
         AppCompatResources.getDrawable(context, R.drawable.design_password_eye));
     textInputLayout.setEndIconContentDescription(
         textInputLayout.getResources().getText(R.string.password_toggle_content_description));
-    textInputLayout.setEndIconOnClickListener(
+    textInputLayout.internalSetEndIconOnClickListener(
         new OnClickListener() {
           @Override
           public void onClick(View v) {
@@ -102,6 +102,7 @@ class PasswordToggleEndIconDelegate extends EndIconDelegate {
             }
 
             textInputLayout.refreshEndIconDrawableState();
+            callOriginalEndIconOnClickListener(v);
           }
         });
     textInputLayout.addOnEditTextAttachedListener(onEditTextAttachedListener);

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -380,6 +380,7 @@ public class TextInputLayout extends LinearLayout {
   @Nullable private Drawable endDummyDrawable;
   private int endDummyDrawableWidth;
   private Drawable originalEditTextEndDrawable;
+  protected OnClickListener endIconOnClickListener;
   private OnLongClickListener endIconOnLongClickListener;
   private OnLongClickListener errorIconOnLongClickListener;
   @NonNull private final CheckableImageButton errorIconView;
@@ -3056,6 +3057,13 @@ public class TextInputLayout extends LinearLayout {
    *     will have
    */
   public void setEndIconOnClickListener(@Nullable OnClickListener endIconOnClickListener) {
+    this.endIconOnClickListener = endIconOnClickListener;
+    if (getEndIconMode() == END_ICON_NONE || getEndIconMode() == END_ICON_CUSTOM) {
+      internalSetEndIconOnClickListener(endIconOnClickListener);
+    }
+  }
+
+  void internalSetEndIconOnClickListener(@Nullable OnClickListener endIconOnClickListener) {
     setIconOnClickListener(endIconView, endIconOnClickListener, endIconOnLongClickListener);
   }
 


### PR DESCRIPTION
Currently the `endIconMode` overrides the `endIconOnClickListener`.
With this change it is possible to add an `endIconOnClickListener` also when the `endIconMode` is set.  
The listener is called after the `onClickListener` defined in the `EndIconDelegate`.