### PR TITLE
[Snackbar] bugfix: setting layoutParams for snackbarLayout `Open #1076`

### DIFF
--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -430,9 +430,9 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
     int extraBottomMargin =
         anchorView != null ? extraBottomMarginAnchorView : extraBottomMarginWindowInset;
     MarginLayoutParams marginParams = (MarginLayoutParams) layoutParams;
-    marginParams.bottomMargin = originalMargins.bottom + extraBottomMargin;
-    marginParams.leftMargin = originalMargins.left + extraLeftMarginWindowInset;
-    marginParams.rightMargin = originalMargins.right + extraRightMarginWindowInset;
+    marginParams.bottomMargin += originalMargins.bottom + extraBottomMargin;
+    marginParams.leftMargin += originalMargins.left + extraLeftMarginWindowInset;
+    marginParams.rightMargin += originalMargins.right + extraRightMarginWindowInset;
     view.requestLayout();
 
     if (VERSION.SDK_INT >= VERSION_CODES.Q && shouldUpdateGestureInset()) {


### PR DESCRIPTION
Solve issue:[Setting LayoutParams for SnackbarLayout doesn't work bug]
https://github.com/material-components/material-components-android/issues/1076

Reason: BaseTransientBottomBar#updateMargins ignored the original layoutParams in the view and simply cover it with a new value.