### PR TITLE
[Slider] Fixed trackSidePadding when thumbRadius >= 16dp

### DIFF
--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -439,10 +439,6 @@ abstract class BaseSlider<
       setEnabled(false);
     }
 
-    if (thumbRadius >= trackSidePadding) {
-      trackSidePadding = thumbRadius + 1;
-    }
-
     a.recycle();
   }
 
@@ -454,6 +450,12 @@ abstract class BaseSlider<
         null,
         0,
         a.getResourceId(R.styleable.Slider_labelStyle, R.style.Widget_MaterialComponents_Tooltip));
+  }
+
+  private void validateTrackSidePadding () {
+    if (thumbRadius >= trackSidePadding) {
+      trackSidePadding = thumbRadius + 1;
+    };
   }
 
   private void validateValueFrom() {
@@ -857,6 +859,7 @@ abstract class BaseSlider<
     }
 
     thumbRadius = radius;
+    validateTrackSidePadding();
 
     thumbDrawable.setShapeAppearanceModel(
         ShapeAppearanceModel.builder().setAllCorners(CornerFamily.ROUNDED, thumbRadius).build());

--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -439,6 +439,10 @@ abstract class BaseSlider<
       setEnabled(false);
     }
 
+    if (thumbRadius >= trackSidePadding) {
+      trackSidePadding = thumbRadius + 1;
+    }
+
     a.recycle();
   }
 


### PR DESCRIPTION
If the `thumbRadius >= 16dp` the thumb is cut off.

Just an example:

<img width="307" alt="Schermata 2020-08-07 alle 10 31 43" src="https://user-images.githubusercontent.com/2583078/89633718-8d97e680-d8a4-11ea-8c56-eb8855d125eb.png">
<img width="305" alt="Schermata 2020-08-07 alle 10 31 22" src="https://user-images.githubusercontent.com/2583078/89633720-8e307d00-d8a4-11ea-9f40-66f386740066.png">

It closes #1579.

<img width="314" alt="Schermata 2020-08-07 alle 11 27 02" src="https://user-images.githubusercontent.com/2583078/89633849-b5874a00-d8a4-11ea-9e67-c984f72a6c52.png">
