### PR TITLE
[TextInputLayout] Fixed placeholder position in RTL mode

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -2076,6 +2076,9 @@ public class TextInputLayout extends LinearLayout {
       placeholderTextView = new AppCompatTextView(getContext());
       placeholderTextView.setId(R.id.textinput_placeholder);
 
+      LayoutParams params = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+      placeholderTextView.setLayoutParams(params);
+
       ViewCompat.setAccessibilityLiveRegion(
           placeholderTextView, ViewCompat.ACCESSIBILITY_LIVE_REGION_POLITE);
 


### PR DESCRIPTION
Disclaimer: I've verified that when using RTL characters in the EditText, the problem is not occurring and the placeholder and the hint are correctly placed in the right side.
This is because the `TextDirectionHeuristicsCompat` distinguish between a real RTL language and a device in RTL mode but using a LTR language in the input.
Is this the correct behaviour? 
A device with a RTL language set in the system, should be considered LTR if the characters provided to inputs are English ones? If yes you can close the PR without problems.
Otherwise, with this change the placeholder text will respect the layout direction mode of the view ignoring the nature of the characters in the input.

To reproduce the bug you can:
1) Change the device language to a RTL one.
2) In the catalog app open the "TextField" samples then open "Filled Text Field Demo"
3) You will notice that the "Placeholder text" is always on the left side

To test the fix you can:
1) Open the `cat_textfield_filled_content.xml`
2) Add `android:gravity="start"` and `android:textDirection="start"` to one (or both) the nested TextInputEditText