### PR TITLE
[ShapeableImageView] Respect strokeWidth in ShapeMask

### DIFF
--- a/lib/java/com/google/android/material/imageview/ShapeableImageView.java
+++ b/lib/java/com/google/android/material/imageview/ShapeableImageView.java
@@ -153,8 +153,12 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   }
 
   private void updateShapeMask(int width, int height) {
+    final float strokeOffset = getStrokeWidth() / 2f;
     destination.set(
-        getPaddingLeft(), getPaddingTop(), width - getPaddingRight(), height - getPaddingBottom());
+        getPaddingLeft() + strokeOffset,
+        getPaddingTop() + strokeOffset,
+        width - getPaddingRight() - strokeOffset,
+        height - getPaddingBottom() - strokeOffset);
     pathProvider.calculatePath(shapeAppearanceModel, 1f /*interpolation*/, destination, path);
     // Remove path from rect to draw with clear paint.
     maskPath.rewind();


### PR DESCRIPTION
Problem:
When stroke is set it is rendered so that half of the stroke is inside of the bounds of the ImageView and half is outside. The problem is that anything that is outside of the bounds of the View gets clipped and thus won't be visible. That leads to incorrectly rendered stroke. Normally this should be fixed by telling the parent to not clip
its children, but that doesn't work here as here it gets actually clipped by the view itself by its ShapeMask.

Changes:
Offset the shape mask by half of the stroke width on all sides.

Screenshot:
Here is a screenshot from a little sample app I built: 
On the top is ShapeableImageView, on the bottom is a patched version. 
<img width="553" alt="image" src="https://user-images.githubusercontent.com/483556/89778551-05b51500-db0e-11ea-80e8-9f67e7f724ab.png">

Sample app:
[ImageViewFix.zip](https://github.com/material-components/material-components-android/files/5050571/ImageViewFix.zip)