### PR TITLE
[MaterialDatePicker] added methods to use custom text for positive and negative button

### DIFF
--- a/catalog/java/io/material/catalog/datepicker/DatePickerMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/datepicker/DatePickerMainDemoFragment.java
@@ -99,6 +99,8 @@ public class DatePickerMainDemoFragment extends DemoFragment {
     final RadioGroup opening = root.findViewById(R.id.cat_picker_opening_month_group);
     final RadioGroup selection = root.findViewById(R.id.cat_picker_selection_group);
     final RadioGroup inputMode = root.findViewById(R.id.cat_picker_input_mode_group);
+    final RadioGroup positiveButton = root.findViewById(R.id.cat_picker_positive_button_group);
+    final RadioGroup negativeButton = root.findViewById(R.id.cat_picker_negative_button_group);
 
     launcher.setOnClickListener(
         v -> {
@@ -111,6 +113,8 @@ public class DatePickerMainDemoFragment extends DemoFragment {
           int openingChoice = opening.getCheckedRadioButtonId();
           int selectionChoice = selection.getCheckedRadioButtonId();
           int inputModeChoices = inputMode.getCheckedRadioButtonId();
+          int positiveButtonChoice = positiveButton.getCheckedRadioButtonId();
+          int negativeButtonChoice = negativeButton.getCheckedRadioButtonId();
 
           MaterialDatePicker.Builder<?> builder =
               setupDateSelectorBuilder(selectionModeChoice, selectionChoice, inputModeChoices);
@@ -127,6 +131,14 @@ public class DatePickerMainDemoFragment extends DemoFragment {
 
           if (titleChoice == R.id.cat_picker_title_custom) {
             builder.setTitleText(R.string.cat_picker_title_custom);
+          }
+
+          if (positiveButtonChoice == R.id.cat_picker_positive_button_custom){
+            builder.setPositiveButton(R.string.cat_picker_positive_button_text);
+          }
+
+          if (negativeButtonChoice == R.id.cat_picker_negative_button_custom){
+            builder.setNegativeButton(R.string.cat_picker_negative_button_text);
           }
 
           try {

--- a/catalog/java/io/material/catalog/datepicker/res/layout/cat_picker_negative_button.xml
+++ b/catalog/java/io/material/catalog/datepicker/res/layout/cat_picker_negative_button.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2019 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/cat_picker_negative_button"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/cat_picker_demo_padding"
+    android:orientation="vertical">
+
+  <TextView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/cat_picker_negative_button"
+      android:textAppearance="?attr/textAppearanceHeadline5"/>
+  <RadioGroup
+      android:id="@+id/cat_picker_negative_button_group"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+    <RadioButton
+        android:id="@+id/cat_picker_negative_button_default"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:text="@string/cat_picker_negative_button_default"
+        android:textAppearance="?attr/textAppearanceBody1"/>
+    <RadioButton
+        android:id="@+id/cat_picker_negative_button_custom"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/cat_picker_demo_padding"
+        android:layout_marginLeft="@dimen/cat_picker_demo_padding"
+        android:text="@string/cat_picker_negative_button_custom"
+        android:textAppearance="?attr/textAppearanceBody1"/>
+
+  </RadioGroup>
+</LinearLayout>

--- a/catalog/java/io/material/catalog/datepicker/res/layout/cat_picker_positive_button.xml
+++ b/catalog/java/io/material/catalog/datepicker/res/layout/cat_picker_positive_button.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Copyright 2019 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/cat_picker_positive_button"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/cat_picker_demo_padding"
+    android:orientation="vertical">
+
+  <TextView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/cat_picker_positive_button"
+      android:textAppearance="?attr/textAppearanceHeadline5"/>
+  <RadioGroup
+      android:id="@+id/cat_picker_positive_button_group"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+    <RadioButton
+        android:id="@+id/cat_picker_positive_button_default"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:text="@string/cat_picker_positive_button_default"
+        android:textAppearance="?attr/textAppearanceBody1"/>
+    <RadioButton
+        android:id="@+id/cat_picker_positive_button_custom"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/cat_picker_demo_padding"
+        android:layout_marginLeft="@dimen/cat_picker_demo_padding"
+        android:text="@string/cat_picker_positive_button_custom"
+        android:textAppearance="?attr/textAppearanceBody1"/>
+
+  </RadioGroup>
+</LinearLayout>

--- a/catalog/java/io/material/catalog/datepicker/res/layout/picker_main_demo.xml
+++ b/catalog/java/io/material/catalog/datepicker/res/layout/picker_main_demo.xml
@@ -39,6 +39,8 @@
     <include layout="@layout/cat_picker_bounds"/>
     <include layout="@layout/cat_picker_validation"/>
     <include layout="@layout/cat_picker_title"/>
+    <include layout="@layout/cat_picker_positive_button"/>
+    <include layout="@layout/cat_picker_negative_button"/>
     <include layout="@layout/cat_picker_opening_month"/>
     <include layout="@layout/cat_picker_selection"/>
     <include layout="@layout/cat_picker_input_mode"/>

--- a/catalog/java/io/material/catalog/datepicker/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/datepicker/res/values/strings.xml
@@ -102,4 +102,22 @@
   <!-- Indicates that the picker will start with text input mode [CHAR LIMIT=25] -->
   <string name="cat_picker_input_mode_text">Text Input</string>
 
+  <!-- Grouping label for a set of radio buttons that choose the positive button [CHAR LIMIT=50] -->
+  <string name="cat_picker_positive_button">Picker Positive Button</string>
+  <!-- Indicates that the default title will be used [CHAR LIMIT=25] -->
+  <string name="cat_picker_positive_button_default">Default</string>
+  <!-- Indicates that a custom title will be used [CHAR LIMIT=25] -->
+  <string name="cat_picker_positive_button_custom">Custom</string>
+
+  <!-- Grouping label for a set of radio buttons that choose the negative button [CHAR LIMIT=50] -->
+  <string name="cat_picker_negative_button">Picker Negative Button</string>
+  <!-- Indicates that the default title will be used [CHAR LIMIT=25] -->
+  <string name="cat_picker_negative_button_default">Default</string>
+  <!-- Indicates that a custom title will be used [CHAR LIMIT=25] -->
+  <string name="cat_picker_negative_button_custom">Custom</string>
+
+  <!-- The custom positive button text -->
+  <string name="cat_picker_positive_button_text">DONE</string>
+  <!-- The custom negative button text -->
+  <string name="cat_picker_negative_button_text">Negative</string>
 </resources>

--- a/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
@@ -260,10 +260,10 @@ public final class MaterialDatePicker<S> extends DialogFragment {
       confirmButton.setEnabled(false);
     }
     confirmButton.setTag(CONFIRM_BUTTON_TAG);
-    if (positiveButtonTextResId != 0){
-      confirmButton.setText(positiveButtonTextResId);
-    } else if (positiveButtonText != null){
+    if (positiveButtonText != null){
       confirmButton.setText(positiveButtonText);
+    } else if (positiveButtonTextResId != 0){
+      confirmButton.setText(positiveButtonTextResId);
     }
     confirmButton.setOnClickListener(
         new View.OnClickListener() {
@@ -279,10 +279,10 @@ public final class MaterialDatePicker<S> extends DialogFragment {
 
     Button cancelButton = root.findViewById(R.id.cancel_button);
     cancelButton.setTag(CANCEL_BUTTON_TAG);
-    if (negativeButtonTextResId != 0){
-      cancelButton.setText(negativeButtonTextResId);
-    } else if (negativeButtonText != null){
+    if (negativeButtonText != null){
       cancelButton.setText(negativeButtonText);
+    } else if (negativeButtonTextResId != 0){
+      cancelButton.setText(negativeButtonTextResId);
     }
     cancelButton.setOnClickListener(
         new View.OnClickListener() {
@@ -649,7 +649,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
      * @param textId resource id to be used as text in the positive button
      */
     @NonNull
-    public Builder<S> setPositiveButton(@StringRes int textId){
+    public Builder<S> setPositiveButtonText(@StringRes int textId){
       this.positiveButtonTextResId = textId;
       this.positiveButtonText = null;
       return this;
@@ -660,7 +660,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
      *
      * @param text text used in the positive button
      */
-    public Builder<S> setPositiveButton(CharSequence text){
+    public Builder<S> setPositiveButtonText(CharSequence text){
       this.positiveButtonText = text;
       this.positiveButtonTextResId = 0;
       return this;
@@ -672,7 +672,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
      * @param textId resource id to be used as text in the negative button
      */
     @NonNull
-    public Builder<S> setNegativeButton(@StringRes int textId){
+    public Builder<S> setNegativeButtonText(@StringRes int textId){
       this.negativeButtonTextResId = textId;
       this.negativeButtonText = null;
       return this;
@@ -683,7 +683,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
      *
      * @param text text used in the negative button
      */
-    public Builder<S> setNegativeButton(CharSequence text){
+    public Builder<S> setNegativeButtonText(CharSequence text){
       this.negativeButtonText = text;
       this.negativeButtonTextResId = 0;
       return this;

--- a/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
@@ -66,6 +66,10 @@ public final class MaterialDatePicker<S> extends DialogFragment {
   private static final String CALENDAR_CONSTRAINTS_KEY = "CALENDAR_CONSTRAINTS_KEY";
   private static final String TITLE_TEXT_RES_ID_KEY = "TITLE_TEXT_RES_ID_KEY";
   private static final String TITLE_TEXT_KEY = "TITLE_TEXT_KEY";
+  private static final String POSITIVE_BUTTON_TEXT_RES_ID_KEY = "POSITIVE_BUTTON_TEXT_RES_ID_KEY";
+  private static final String POSITIVE_BUTTON_TEXT_KEY = "POSITIVE_BUTTON_TEXT_KEY";
+  private static final String NEGATIVE_BUTTON_TEXT_RES_ID_KEY = "NEGATIVE_BUTTON_TEXT_RES_ID_KEY";
+  private static final String NEGATIVE_BUTTON_TEXT_KEY = "NEGATIVE_BUTTON_TEXT_KEY";
   private static final String INPUT_MODE_KEY = "INPUT_MODE_KEY";
 
   static final Object CONFIRM_BUTTON_TAG = "CONFIRM_BUTTON_TAG";
@@ -123,6 +127,10 @@ public final class MaterialDatePicker<S> extends DialogFragment {
   private CharSequence titleText;
   private boolean fullscreen;
   @InputMode private int inputMode;
+  @StringRes private int positiveButtonTextResId;
+  private CharSequence positiveButtonText;
+  @StringRes private int negativeButtonTextResId;
+  private CharSequence negativeButtonText;
 
   private TextView headerSelectionText;
   private CheckableImageButton headerToggleButton;
@@ -139,6 +147,10 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     args.putInt(TITLE_TEXT_RES_ID_KEY, options.titleTextResId);
     args.putCharSequence(TITLE_TEXT_KEY, options.titleText);
     args.putInt(INPUT_MODE_KEY, options.inputMode);
+    args.putInt(POSITIVE_BUTTON_TEXT_RES_ID_KEY,options.positiveButtonTextResId);
+    args.putCharSequence(POSITIVE_BUTTON_TEXT_KEY,options.positiveButtonText);
+    args.putInt(NEGATIVE_BUTTON_TEXT_RES_ID_KEY,options.negativeButtonTextResId);
+    args.putCharSequence(NEGATIVE_BUTTON_TEXT_KEY,options.negativeButtonText);
     materialDatePickerDialogFragment.setArguments(args);
     return materialDatePickerDialogFragment;
   }
@@ -157,6 +169,10 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     bundle.putParcelable(CALENDAR_CONSTRAINTS_KEY, constraintsBuilder.build());
     bundle.putInt(TITLE_TEXT_RES_ID_KEY, titleTextResId);
     bundle.putCharSequence(TITLE_TEXT_KEY, titleText);
+    bundle.putInt(POSITIVE_BUTTON_TEXT_RES_ID_KEY, positiveButtonTextResId);
+    bundle.putCharSequence(POSITIVE_BUTTON_TEXT_KEY, positiveButtonText);
+    bundle.putInt(NEGATIVE_BUTTON_TEXT_RES_ID_KEY, negativeButtonTextResId);
+    bundle.putCharSequence(NEGATIVE_BUTTON_TEXT_KEY, negativeButtonText);
   }
 
   @Override
@@ -169,6 +185,10 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     titleTextResId = activeBundle.getInt(TITLE_TEXT_RES_ID_KEY);
     titleText = activeBundle.getCharSequence(TITLE_TEXT_KEY);
     inputMode = activeBundle.getInt(INPUT_MODE_KEY);
+    positiveButtonTextResId = activeBundle.getInt(POSITIVE_BUTTON_TEXT_RES_ID_KEY);
+    positiveButtonText = activeBundle.getCharSequence(POSITIVE_BUTTON_TEXT_KEY);
+    negativeButtonTextResId = activeBundle.getInt(NEGATIVE_BUTTON_TEXT_RES_ID_KEY);
+    negativeButtonText = activeBundle.getCharSequence(NEGATIVE_BUTTON_TEXT_KEY);
   }
 
   private int getThemeResId(Context context) {
@@ -240,6 +260,11 @@ public final class MaterialDatePicker<S> extends DialogFragment {
       confirmButton.setEnabled(false);
     }
     confirmButton.setTag(CONFIRM_BUTTON_TAG);
+    if (positiveButtonTextResId != 0){
+      confirmButton.setText(positiveButtonTextResId);
+    } else if (positiveButtonText != null){
+      confirmButton.setText(positiveButtonText);
+    }
     confirmButton.setOnClickListener(
         new View.OnClickListener() {
           @Override
@@ -254,6 +279,11 @@ public final class MaterialDatePicker<S> extends DialogFragment {
 
     Button cancelButton = root.findViewById(R.id.cancel_button);
     cancelButton.setTag(CANCEL_BUTTON_TAG);
+    if (negativeButtonTextResId != 0){
+      cancelButton.setText(negativeButtonTextResId);
+    } else if (negativeButtonText != null){
+      cancelButton.setText(negativeButtonText);
+    }
     cancelButton.setOnClickListener(
         new View.OnClickListener() {
           @Override
@@ -531,6 +561,10 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     CalendarConstraints calendarConstraints;
     int titleTextResId = 0;
     CharSequence titleText = null;
+    int positiveButtonTextResId = 0;
+    CharSequence positiveButtonText = null;
+    int negativeButtonTextResId = 0;
+    CharSequence negativeButtonText = null;
     @Nullable S selection = null;
     @InputMode int inputMode = INPUT_MODE_CALENDAR;
 
@@ -606,6 +640,52 @@ public final class MaterialDatePicker<S> extends DialogFragment {
     public Builder<S> setTitleText(@Nullable CharSequence charSequence) {
       this.titleText = charSequence;
       this.titleTextResId = 0;
+      return this;
+    }
+
+    /**
+     * Sets the text used in the positive button
+     *
+     * @param textId resource id to be used as text in the positive button
+     */
+    @NonNull
+    public Builder<S> setPositiveButton(@StringRes int textId){
+      this.positiveButtonTextResId = textId;
+      this.positiveButtonText = null;
+      return this;
+    }
+
+    /**
+     * Sets the text used in the positive button
+     *
+     * @param text text used in the positive button
+     */
+    public Builder<S> setPositiveButton(CharSequence text){
+      this.positiveButtonText = text;
+      this.positiveButtonTextResId = 0;
+      return this;
+    }
+
+    /**
+     * Sets the text used in the negative button
+     *
+     * @param textId resource id to be used as text in the negative button
+     */
+    @NonNull
+    public Builder<S> setNegativeButton(@StringRes int textId){
+      this.negativeButtonTextResId = textId;
+      this.negativeButtonText = null;
+      return this;
+    }
+
+    /**
+     * Sets the text used in the negative button
+     *
+     * @param text text used in the negative button
+     */
+    public Builder<S> setNegativeButton(CharSequence text){
+      this.negativeButtonText = text;
+      this.negativeButtonTextResId = 0;
       return this;
     }
 


### PR DESCRIPTION
Currently the positive and negative button in the `MaterialDatePicker` use a text defined in the layout.

```
  <Button
    android:id="@+id/cancel_button"
    android:text="@string/mtrl_picker_cancel"/>

  <Button
    android:id="@+id/confirm_button"
    android:text="@string/mtrl_picker_confirm"/>
```

With this PR it is possible to use a custom text:

```
builder.setPositiveButton(...);
builder.setNegativeButton(...);
```

The current default behavior doesn't change.

<img width="265" alt="Schermata 2020-08-11 alle 22 48 23" src="https://user-images.githubusercontent.com/2583078/89948456-74859180-dc26-11ea-9737-2e7e2cccdc0e.png">
<img width="322" alt="Schermata 2020-08-11 alle 22 47 56" src="https://user-images.githubusercontent.com/2583078/89948462-77808200-dc26-11ea-8b33-6a3fca41c379.png">

It can close #1292.