### PR TITLE
[Selection controls] textColor based on colorOnSurface instead of android:attr/textColorPrimaryDisableOnly

### DIFF
--- a/lib/java/com/google/android/material/checkbox/res/color/mtrl_checkbox_text_color_selector.xml
+++ b/lib/java/com/google/android/material/checkbox/res/color/mtrl_checkbox_text_color_selector.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2017 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="?attr/colorOnSurface" android:state_enabled="true"/>
+  <item android:alpha="0.50" android:color="?attr/colorOnSurface"/>
+</selector>

--- a/lib/java/com/google/android/material/checkbox/res/values/styles.xml
+++ b/lib/java/com/google/android/material/checkbox/res/values/styles.xml
@@ -19,6 +19,7 @@
   <style name="Widget.MaterialComponents.CompoundButton.CheckBox" parent="Widget.AppCompat.CompoundButton.CheckBox">
     <item name="enforceMaterialTheme">true</item>
     <item name="useMaterialThemeColors">true</item>
+    <item name="android:textColor">@color/mtrl_checkbox_text_color_selector</item>
     <item name="android:minWidth">?attr/minTouchTargetSize</item>
     <item name="android:minHeight">?attr/minTouchTargetSize</item>
   </style>

--- a/lib/java/com/google/android/material/radiobutton/res/color/mtrl_radiobutton_text_color_selector.xml
+++ b/lib/java/com/google/android/material/radiobutton/res/color/mtrl_radiobutton_text_color_selector.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2017 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="?attr/colorOnSurface" android:state_enabled="true"/>
+  <item android:alpha="0.50" android:color="?attr/colorOnSurface"/>
+</selector>

--- a/lib/java/com/google/android/material/radiobutton/res/values/styles.xml
+++ b/lib/java/com/google/android/material/radiobutton/res/values/styles.xml
@@ -19,6 +19,7 @@
   <style name="Widget.MaterialComponents.CompoundButton.RadioButton" parent="Widget.AppCompat.CompoundButton.RadioButton">
     <item name="enforceMaterialTheme">true</item>
     <item name="useMaterialThemeColors">true</item>
+    <item name="android:textColor">@color/mtrl_radiobutton_text_color_selector</item>
     <item name="android:minWidth">?attr/minTouchTargetSize</item>
     <item name="android:minHeight">?attr/minTouchTargetSize</item>
   </style>

--- a/lib/java/com/google/android/material/switchmaterial/res/color/mtrl_switch_text_color_selector.xml
+++ b/lib/java/com/google/android/material/switchmaterial/res/color/mtrl_switch_text_color_selector.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2017 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="?attr/colorOnSurface" android:state_enabled="true"/>
+  <item android:alpha="0.50" android:color="?attr/colorOnSurface"/>
+</selector>

--- a/lib/java/com/google/android/material/switchmaterial/res/values/styles.xml
+++ b/lib/java/com/google/android/material/switchmaterial/res/values/styles.xml
@@ -19,6 +19,7 @@
   <style name="Widget.MaterialComponents.CompoundButton.Switch" parent="Widget.AppCompat.CompoundButton.Switch">
     <item name="enforceMaterialTheme">true</item>
     <item name="useMaterialThemeColors">true</item>
+    <item name="android:textColor">@color/mtrl_switch_text_color_selector</item>
     <item name="android:minWidth">?attr/minTouchTargetSize</item>
     <item name="android:minHeight">?attr/minTouchTargetSize</item>
   </style>


### PR DESCRIPTION
Currently `MaterialRadioButton`, `MaterialCheckBox` and `SwitchMaterial` inherit the text color from `Widget.CompoundButton`, which sets it to the attribute `?android:attr/textColorPrimaryDisableOnly`.

With this PR the textcolor is based on `colorOnSurface` attribute.

It closes #1182

