### PR TITLE
[MaterialCardView] Added options to set custom checkedIcon size and margin

### DIFF
--- a/docs/components/Card.md
+++ b/docs/components/Card.md
@@ -370,11 +370,13 @@ border, regardless of the `app:strokeWidth` value._
 
 #### Checked icon attributes
 
-&nbsp;        | Attribute           | Related method(s)                                                  | Default value
-------------- | ------------------- | ------------------------------------------------------------------ | -------------
-**Icon**      | `checkedIcon`       | `setCheckedIcon`<br/>`setCheckedIconResource`<br/>`getCheckedIcon` | [`@drawable/ic_mtrl_checked_circle.xml`](https://github.com/material-components/material-components-android/tree/master/lib/java/com/google/android/material/resources/res/drawable/ic_mtrl_checked_circle.xml)
-**Color**     | `checkedIconTint`   | `setCheckedIconTint`<br/>`getCheckedIconTint`                      | `?attr/colorPrimary`
-**Checkable** | `android:checkable` | `setCheckable`<br/>`isCheckable`                                   | `false`
+&nbsp;        | Attribute            | Related method(s)                                                  | Default value
+------------- | -------------------- | ------------------------------------------------------------------ | -------------
+**Icon**      | `checkedIcon`        | `setCheckedIcon`<br/>`setCheckedIconResource`<br/>`getCheckedIcon` | [`@drawable/ic_mtrl_checked_circle.xml`](https://github.com/material-components/material-components-android/tree/master/lib/java/com/google/android/material/resources/res/drawable/ic_mtrl_checked_circle.xml)
+**Color**     | `checkedIconTint`    | `setCheckedIconTint`<br/>`getCheckedIconTint`                      | `?attr/colorPrimary`
+**Checkable** | `android:checkable`  | `setCheckable`<br/>`isCheckable`                                   | `false`
+**Size**      | `checkedIconSize`    | `setCheckedIconSize`<br/>`setCheckedIconSizeResource`<br/>`getCheckedIconSize` | `24dp`
+**Margin**    | `checkedIconMargin`  | `setCheckedIconMargin`<br/>`setCheckedIconMarginResource`<br/>`getCheckedIconMargin` | `8dp`
 
 #### States
 

--- a/lib/java/com/google/android/material/card/MaterialCardView.java
+++ b/lib/java/com/google/android/material/card/MaterialCardView.java
@@ -27,6 +27,7 @@ import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
+import androidx.annotation.DimenRes;
 import androidx.appcompat.content.res.AppCompatResources;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -547,6 +548,70 @@ public class MaterialCardView extends CardView implements Checkable, Shapeable {
    */
   public void setCheckedIconTint(@Nullable ColorStateList checkedIconTint) {
     cardViewHelper.setCheckedIconTint(checkedIconTint);
+  }
+
+  /**
+   * Returns the checked icon size
+   *
+   * @return the checked icon size
+   */
+  @Dimension
+  public int getCheckedIconSize() {
+    return cardViewHelper.getCheckedIconSize();
+  }
+
+  /**
+   * Sets the size of the checked icon
+   *
+   * @param checkedIconSize checked icon size
+   * @attr ref com.google.android.material.R.styleable#MaterialCardView_checkedIconSize
+   */
+  public void setCheckedIconSize(@Dimension int checkedIconSize) {
+    cardViewHelper.setCheckedIconSize(checkedIconSize);
+  }
+
+  /**
+   * Sets the size of the checked icon using a resource id.
+   *
+   * @param checkedIconSizeResId The resource id of this Card's checked icon size
+   * @attr ref com.google.android.material.R.styleable#MaterialCardView_checkedIconSize
+   */
+  public void setCheckedIconSizeResource(@DimenRes int checkedIconSizeResId) {
+    if (checkedIconSizeResId != 0) {
+      cardViewHelper.setCheckedIconSize(getResources().getDimensionPixelSize(checkedIconSizeResId));
+    }
+  }
+
+  /**
+   * Returns the checked icon margin
+   *
+   * @return the checked icon margin
+   */
+  @Dimension
+  public int getCheckedIconMargin() {
+    return cardViewHelper.getCheckedIconMargin();
+  }
+
+  /**
+   * Sets the size of the checked margin
+   *
+   * @param checkedIconMargin checked icon margin
+   * @attr ref com.google.android.material.R.styleable#MaterialCardView_checkedIconMargin
+   */
+  public void setCheckedIconMargin(@Dimension int checkedIconMargin) {
+    cardViewHelper.setCheckedIconMargin(checkedIconMargin);
+  }
+
+  /**
+   * Sets the margin of the checked icon using a resource id.
+   *
+   * @param checkedIconMarginResId The resource id of this Card's checked icon margin
+   * @attr ref com.google.android.material.R.styleable#MaterialCardView_checkedIconMargin
+   */
+  public void setCheckedIconMarginResource(@DimenRes int checkedIconMarginResId) {
+    if (checkedIconMarginResId != 0) {
+      cardViewHelper.setCheckedIconMargin(getResources().getDimensionPixelSize(checkedIconMarginResId));
+    }
   }
 
   @NonNull

--- a/lib/java/com/google/android/material/card/MaterialCardView.java
+++ b/lib/java/com/google/android/material/card/MaterialCardView.java
@@ -550,11 +550,6 @@ public class MaterialCardView extends CardView implements Checkable, Shapeable {
     cardViewHelper.setCheckedIconTint(checkedIconTint);
   }
 
-  /**
-   * Returns the checked icon size
-   *
-   * @return the checked icon size
-   */
   @Dimension
   public int getCheckedIconSize() {
     return cardViewHelper.getCheckedIconSize();
@@ -582,22 +577,11 @@ public class MaterialCardView extends CardView implements Checkable, Shapeable {
     }
   }
 
-  /**
-   * Returns the checked icon margin
-   *
-   * @return the checked icon margin
-   */
   @Dimension
   public int getCheckedIconMargin() {
     return cardViewHelper.getCheckedIconMargin();
   }
 
-  /**
-   * Sets the size of the checked margin
-   *
-   * @param checkedIconMargin checked icon margin
-   * @attr ref com.google.android.material.R.styleable#MaterialCardView_checkedIconMargin
-   */
   public void setCheckedIconMargin(@Dimension int checkedIconMargin) {
     cardViewHelper.setCheckedIconMargin(checkedIconMargin);
   }
@@ -609,7 +593,7 @@ public class MaterialCardView extends CardView implements Checkable, Shapeable {
    * @attr ref com.google.android.material.R.styleable#MaterialCardView_checkedIconMargin
    */
   public void setCheckedIconMarginResource(@DimenRes int checkedIconMarginResId) {
-    if (checkedIconMarginResId != 0) {
+    if (checkedIconMarginResId != NO_ID) {
       cardViewHelper.setCheckedIconMargin(getResources().getDimensionPixelSize(checkedIconMarginResId));
     }
   }

--- a/lib/java/com/google/android/material/card/MaterialCardViewHelper.java
+++ b/lib/java/com/google/android/material/card/MaterialCardViewHelper.java
@@ -160,13 +160,10 @@ class MaterialCardViewHelper {
     setCheckedIcon(
         MaterialResources.getDrawable(
             materialCardView.getContext(), attributes, R.styleable.MaterialCardView_checkedIcon));
-    Resources resources = materialCardView.getResources();
     setCheckedIconSize(
-        attributes.getDimensionPixelSize(R.styleable.MaterialCardView_checkedIconSize,
-            resources.getDimensionPixelSize(R.dimen.mtrl_card_checked_icon_size)));
+        attributes.getDimensionPixelSize(R.styleable.MaterialCardView_checkedIconSize,0));
     setCheckedIconMargin(
-        attributes.getDimensionPixelSize(R.styleable.MaterialCardView_checkedIconMargin,
-            resources.getDimensionPixelSize(R.dimen.mtrl_card_checked_icon_margin)));
+        attributes.getDimensionPixelSize(R.styleable.MaterialCardView_checkedIconMargin,0));
 
     rippleColor =
         MaterialResources.getColorStateList(
@@ -400,20 +397,20 @@ class MaterialCardViewHelper {
   }
 
   @Dimension
-  public int getCheckedIconSize() {
+  int getCheckedIconSize() {
     return checkedIconSize;
   }
 
-  public void setCheckedIconSize(@Dimension int checkedIconSize) {
+  void setCheckedIconSize(@Dimension int checkedIconSize) {
     this.checkedIconSize = checkedIconSize;
   }
 
   @Dimension
-  public int getCheckedIconMargin() {
+  int getCheckedIconMargin() {
     return checkedIconMargin;
   }
 
-  public void setCheckedIconMargin(@Dimension int checkedIconMargin) {
+  void setCheckedIconMargin(@Dimension int checkedIconMargin) {
     this.checkedIconMargin = checkedIconMargin;
   }
 

--- a/lib/java/com/google/android/material/card/MaterialCardViewHelper.java
+++ b/lib/java/com/google/android/material/card/MaterialCardViewHelper.java
@@ -97,8 +97,8 @@ class MaterialCardViewHelper {
   // Will always wrapped in an InsetDrawable
   @NonNull private final MaterialShapeDrawable foregroundContentDrawable;
 
-  @Dimension private final int checkedIconMargin;
-  @Dimension private final int checkedIconSize;
+  @Dimension private int checkedIconMargin;
+  @Dimension private int checkedIconSize;
   @Dimension private int strokeWidth;
 
   // If card is clickable, this is the clickableForegroundDrawable otherwise it draws the stroke.
@@ -140,11 +140,6 @@ class MaterialCardViewHelper {
     foregroundContentDrawable = new MaterialShapeDrawable();
     setShapeAppearanceModel(shapeAppearanceModelBuilder.build());
 
-    Resources resources = card.getResources();
-    // TODO(b/145298914): support custom sizing
-    checkedIconMargin = resources.getDimensionPixelSize(R.dimen.mtrl_card_checked_icon_margin);
-    checkedIconSize = resources.getDimensionPixelSize(R.dimen.mtrl_card_checked_icon_size);
-
     cardViewAttributes.recycle();
   }
 
@@ -165,6 +160,13 @@ class MaterialCardViewHelper {
     setCheckedIcon(
         MaterialResources.getDrawable(
             materialCardView.getContext(), attributes, R.styleable.MaterialCardView_checkedIcon));
+    Resources resources = materialCardView.getResources();
+    setCheckedIconSize(
+        attributes.getDimensionPixelSize(R.styleable.MaterialCardView_checkedIconSize,
+            resources.getDimensionPixelSize(R.dimen.mtrl_card_checked_icon_size)));
+    setCheckedIconMargin(
+        attributes.getDimensionPixelSize(R.styleable.MaterialCardView_checkedIconMargin,
+            resources.getDimensionPixelSize(R.dimen.mtrl_card_checked_icon_margin)));
 
     rippleColor =
         MaterialResources.getColorStateList(
@@ -395,6 +397,24 @@ class MaterialCardViewHelper {
       clickableForegroundDrawable.setDrawableByLayerId(
           R.id.mtrl_card_checked_layer_id, checkedLayer);
     }
+  }
+
+  @Dimension
+  public int getCheckedIconSize() {
+    return checkedIconSize;
+  }
+
+  public void setCheckedIconSize(@Dimension int checkedIconSize) {
+    this.checkedIconSize = checkedIconSize;
+  }
+
+  @Dimension
+  public int getCheckedIconMargin() {
+    return checkedIconMargin;
+  }
+
+  public void setCheckedIconMargin(@Dimension int checkedIconMargin) {
+    this.checkedIconMargin = checkedIconMargin;
   }
 
   void onMeasure(int measuredWidth, int measuredHeight) {

--- a/lib/java/com/google/android/material/card/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/card/res/values/attrs.xml
@@ -32,6 +32,10 @@
     <attr name="checkedIcon"/>
     <!-- Tint color for the checked icon. -->
     <attr name="checkedIconTint"/>
+    <!-- Check icon size -->
+    <attr name="checkedIconSize" format="dimension"/>
+    <!-- Check icon margin -->
+    <attr name="checkedIconMargin" format="dimension"/>
     <!-- Ripple color for the Card. -->
     <attr name="rippleColor"/>
     <!-- State when a Card is being dragged. -->

--- a/lib/java/com/google/android/material/card/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/card/res/values/attrs.xml
@@ -32,9 +32,9 @@
     <attr name="checkedIcon"/>
     <!-- Tint color for the checked icon. -->
     <attr name="checkedIconTint"/>
-    <!-- Check icon size -->
+    <!-- Check icon size for Checkable Cards-->
     <attr name="checkedIconSize" format="dimension"/>
-    <!-- Check icon margin -->
+    <!-- Check icon margin for Checkable Cards-->
     <attr name="checkedIconMargin" format="dimension"/>
     <!-- Ripple color for the Card. -->
     <attr name="rippleColor"/>

--- a/lib/java/com/google/android/material/card/res/values/styles.xml
+++ b/lib/java/com/google/android/material/card/res/values/styles.xml
@@ -30,6 +30,8 @@
     <item name="cardForegroundColor">@color/mtrl_card_view_foreground</item>
     <item name="checkedIcon">@drawable/ic_mtrl_checked_circle</item>
     <item name="checkedIconTint">?attr/colorPrimary</item>
+    <item name="checkedIconSize">@dimen/mtrl_card_checked_icon_size</item>
+    <item name="checkedIconMargin">@dimen/mtrl_card_checked_icon_margin</item>
     <item name="rippleColor">@color/mtrl_card_view_ripple</item>
     <item name="shapeAppearance">?attr/shapeAppearanceMediumComponent</item>
   </style>


### PR DESCRIPTION
Currently the checked icon has fixed size and margin defined in `dimens.xml` file.

With this PR it is possible to set a custom size and a custom margin.

<img width="302" alt="Schermata 2020-08-13 alle 11 03 01" src="https://user-images.githubusercontent.com/2583078/90121043-c67c0380-dd5b-11ea-9e32-025e952443de.png">

It closes #1261.