### PR TITLE
[Catalog] Updated timepicker demo with input mode option

### DIFF
--- a/catalog/java/io/material/catalog/timepicker/TimePickerMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/timepicker/TimePickerMainDemoFragment.java
@@ -27,6 +27,7 @@ import android.widget.Button;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
 import com.google.android.material.button.MaterialButtonToggleGroup;
+import com.google.android.material.datepicker.MaterialDatePicker.InputMode;
 import com.google.android.material.timepicker.MaterialTimePicker;
 import com.google.android.material.timepicker.TimeFormat;
 import io.material.catalog.feature.DemoFragment;
@@ -42,6 +43,7 @@ public class TimePickerMainDemoFragment extends DemoFragment {
 
   private final SimpleDateFormat formatter = new SimpleDateFormat("hh:mm a", Locale.getDefault());
   @TimeFormat private int clockFormat;
+  @InputMode private int timeInputMode;
   private TextView textView;
 
   @Override
@@ -56,6 +58,9 @@ public class TimePickerMainDemoFragment extends DemoFragment {
     MaterialButtonToggleGroup timeFormatToggle = view.findViewById(R.id.time_format_toggle);
     clockFormat = TimeFormat.CLOCK_12H;
     timeFormatToggle.check(R.id.time_format_12h);
+    MaterialButtonToggleGroup timeInputModeToggle = view.findViewById(R.id.time_inputmode_toggle);
+    timeInputModeToggle.check(R.id.time_inputmode_timepicker);
+    timeInputMode = MaterialTimePicker.INPUT_MODE_CLOCK;
 
     timeFormatToggle.addOnButtonCheckedListener(
         (group, checkedId, isChecked) -> {
@@ -65,6 +70,20 @@ public class TimePickerMainDemoFragment extends DemoFragment {
                   || (checkedId == R.id.time_format_system && isSystem24Hour);
 
           clockFormat = is24Hour ? TimeFormat.CLOCK_24H : TimeFormat.CLOCK_12H;
+        });
+
+    timeInputModeToggle.addOnButtonCheckedListener(
+        (group, checkedId, isChecked) -> {
+          if (isChecked) {
+            switch (checkedId) {
+              case R.id.time_inputmode_timepicker:
+                timeInputMode = MaterialTimePicker.INPUT_MODE_CLOCK;
+                break;
+              case R.id.time_inputmode_inputtext:
+                timeInputMode = MaterialTimePicker.INPUT_MODE_KEYBOARD;
+                break;
+            }
+          }
         });
 
     SwitchCompat frameworkSwitch = view.findViewById(R.id.framework_switch);
@@ -78,6 +97,7 @@ public class TimePickerMainDemoFragment extends DemoFragment {
           .setTimeFormat(clockFormat)
           .setHour(hour)
           .setMinute(minute)
+          .setInputMode(timeInputMode)
           .build();
 
       materialTimePicker.show(requireFragmentManager(), "fragment_tag");

--- a/catalog/java/io/material/catalog/timepicker/res/layout/time_picker_main_demo.xml
+++ b/catalog/java/io/material/catalog/timepicker/res/layout/time_picker_main_demo.xml
@@ -45,17 +45,37 @@
       app:layout_constraintStart_toEndOf="@id/timepicker_button"
       app:layout_constraintTop_toTopOf="@id/timepicker_button" />
 
-    <com.google.android.material.button.MaterialButtonToggleGroup
+    <LinearLayout
+      android:id="@+id/time_timeformat_container"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="16dp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      android:gravity="center_horizontal"
+      android:orientation="horizontal">
+
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/cat_time_picker_timeformat"
+        android:layout_gravity="center_vertical"
+        />
+
+
+      <com.google.android.material.button.MaterialButtonToggleGroup
       android:id="@+id/time_format_toggle"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_margin="16dp"
       android:orientation="horizontal"
+      android:layout_marginLeft="4dp"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
       app:selectionRequired="true"
       app:singleSelection="true">
+
       <Button
         android:id="@+id/time_format_12h"
         style="?attr/materialButtonOutlinedStyle"
@@ -79,6 +99,53 @@
 
     </com.google.android.material.button.MaterialButtonToggleGroup>
 
+    </LinearLayout>
+
+    <LinearLayout
+      android:id="@+id/time_inputmode_container"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="16dp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/time_timeformat_container"
+      android:gravity="center_horizontal"
+      android:orientation="horizontal">
+
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/cat_time_picker_inputmode"
+        android:layout_gravity="center_vertical"
+         />
+
+      <com.google.android.material.button.MaterialButtonToggleGroup
+        android:id="@+id/time_inputmode_toggle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="4dp"
+        android:orientation="horizontal"
+        app:selectionRequired="true"
+        app:singleSelection="true">
+        <Button
+          android:id="@+id/time_inputmode_timepicker"
+          style="?attr/materialButtonOutlinedStyle"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/cat_time_picker_inputmode_clock" />
+
+        <Button
+          android:id="@+id/time_inputmode_inputtext"
+          style="?attr/materialButtonOutlinedStyle"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/cat_time_picker_inputmode_inputtext" />
+
+
+      </com.google.android.material.button.MaterialButtonToggleGroup>
+
+    </LinearLayout>>
+
     <com.google.android.material.switchmaterial.SwitchMaterial
       android:id="@+id/framework_switch"
       android:layout_width="wrap_content"
@@ -87,7 +154,7 @@
       android:text="@string/use_framework_dialog"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/time_format_toggle" />
+      app:layout_constraintTop_toBottomOf="@+id/time_inputmode_container" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/catalog/java/io/material/catalog/timepicker/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/timepicker/res/values/strings.xml
@@ -32,5 +32,13 @@
   <string name="time_format_12">12H</string>
   <!-- Label for an option to choose the same time format as the system [CHAR LIMIT=16] -->
   <string name="time_format_system">System</string>
+  <!-- Label for an option to choose the time format -->
+  <string name="cat_time_picker_timeformat">Time format</string>
+  <!-- Label for an option to choose the input mode -->
+  <string name="cat_time_picker_inputmode">Input mode</string>
+  <!-- Indicates that the picker will start with clock mode [CHAR LIMIT=25] -->
+  <string name="cat_time_picker_inputmode_clock">Clock</string>
+  <!-- Indicates that the picker will start with text input mode [CHAR LIMIT=25] -->
+  <string name="cat_time_picker_inputmode_inputtext">Text Input</string>
 
 </resources>


### PR DESCRIPTION
Updated the demo with an option to choose the inputmode.

<img width="316" alt="Schermata 2020-08-14 alle 11 49 48" src="https://user-images.githubusercontent.com/2583078/90238106-af094d00-de25-11ea-964f-9e0d95e9b64e.png">

