### PR TITLE
[MaterialDatePicker] Added a datevalidator for multiple range

### DIFF
--- a/catalog/java/io/material/catalog/datepicker/DatePickerMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/datepicker/DatePickerMainDemoFragment.java
@@ -31,8 +31,10 @@ import androidx.annotation.Nullable;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.datepicker.CalendarConstraints;
 import com.google.android.material.datepicker.CompositeDateValidator;
+import com.google.android.material.datepicker.DateValidatorPointBackward;
 import com.google.android.material.datepicker.DateValidatorPointForward;
 import com.google.android.material.datepicker.MaterialDatePicker;
+import com.google.android.material.datepicker.MultipleDateValidator;
 import com.google.android.material.snackbar.Snackbar;
 import io.material.catalog.feature.DemoFragment;
 import java.util.ArrayList;
@@ -204,6 +206,26 @@ public class DatePickerMainDemoFragment extends DemoFragment {
       validators.add(new DateValidatorWeekdays());
 
       constraintsBuilder.setValidator(CompositeDateValidator.allOf(validators));
+    } else if ((validationChoice == R.id.cat_picker_validation_multiple_range)) {
+      List<CalendarConstraints.DateValidator> validatorsMultple = new ArrayList<>();
+      Calendar lowerBoundCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+      Calendar utc = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+      utc.setTimeInMillis(today);
+      utc.set(Calendar.DATE, 10);
+      DateValidatorPointBackward pointBackward = DateValidatorPointBackward.before(utc.getTimeInMillis());
+      utc.set(Calendar.DATE, 20);
+
+      List<CalendarConstraints.DateValidator> validatorsComposite = new ArrayList<>();
+      DateValidatorPointForward pointForwardComposite = DateValidatorPointForward.from(utc.getTimeInMillis());
+      utc.set(Calendar.DATE, 26);
+      DateValidatorPointBackward pointBackwardComposite = DateValidatorPointBackward.before(utc.getTimeInMillis());
+      validatorsComposite.add(pointForwardComposite);
+      validatorsComposite.add(pointBackwardComposite);
+      CalendarConstraints.DateValidator compositeDateValidator  = CompositeDateValidator.allOf(validatorsComposite);
+
+      validatorsMultple.add(pointBackward);
+      validatorsMultple.add(compositeDateValidator);
+      constraintsBuilder.setValidator(MultipleDateValidator.allOf(validatorsMultple));
     }
     return constraintsBuilder;
   }

--- a/catalog/java/io/material/catalog/datepicker/res/layout/cat_picker_validation.xml
+++ b/catalog/java/io/material/catalog/datepicker/res/layout/cat_picker_validation.xml
@@ -59,6 +59,11 @@
       android:layout_height="wrap_content"
       android:text="@string/cat_picker_validation_last_two_weeks"
       android:textAppearance="?attr/textAppearanceBody1"/>
-
+    <RadioButton
+      android:id="@+id/cat_picker_validation_multiple_range"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/cat_picker_validation_multiple_range"
+      android:textAppearance="?attr/textAppearanceBody1"/>
   </RadioGroup>
 </LinearLayout>

--- a/catalog/java/io/material/catalog/datepicker/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/datepicker/res/values/strings.xml
@@ -69,6 +69,9 @@
   <string name="cat_picker_validation_weekdays">Weekdays</string>
   <!-- Indicates that only the last 2 weeks will be valid [CHAR LIMIT=25] -->
   <string name="cat_picker_validation_last_two_weeks">Last 2 weeks</string>
+  <!-- Indicates a multiple range [CHAR LIMIT=25] -->
+  <string name="cat_picker_validation_multiple_range">Multiple range</string>
+
 
   <!-- Grouping label for a set of radio buttons that choose the title [CHAR LIMIT=50] -->
   <string name="cat_picker_title">Picker Title</string>

--- a/lib/java/com/google/android/material/datepicker/MultipleDateValidator.java
+++ b/lib/java/com/google/android/material/datepicker/MultipleDateValidator.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.material.datepicker;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.material.datepicker.CalendarConstraints.DateValidator;
+
+import java.util.List;
+
+import static androidx.core.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link DateValidator} that accepts a list of Date Validators.
+ * The provided {@code date} is enabled if at least one validator is valid.
+ */
+public class MultipleDateValidator implements DateValidator {
+
+  @NonNull private final List<DateValidator> validators;
+
+  protected MultipleDateValidator(@NonNull List<DateValidator> validators) {
+    this.validators = validators;
+  }
+
+  /**
+   * Returns a {@link DateValidator} that can perform validation for every given validator.
+   */
+  @NonNull
+  public static DateValidator allOf(@NonNull List<DateValidator> validators) {
+    return new MultipleDateValidator(validators);
+  }
+
+  /** Part of {@link Parcelable} requirements. Do not use. */
+  public static final Creator<MultipleDateValidator> CREATOR =
+      new Creator<MultipleDateValidator>() {
+        @NonNull
+        @Override
+        public MultipleDateValidator createFromParcel(@NonNull Parcel source) {
+          @SuppressWarnings("unchecked")
+          List<DateValidator> validators =
+              source.readArrayList(DateValidator.class.getClassLoader());
+          return new MultipleDateValidator(checkNotNull(validators));
+        }
+
+        @NonNull
+        @Override
+        public MultipleDateValidator[] newArray(int size) {
+          return new MultipleDateValidator[size];
+        }
+      };
+
+  /**
+   * Performs the {@link DateValidator#isValid(long)} check as an OR of all validators.
+   * e.g. If one validator in this class returns `true` for each {@link
+   * DateValidator#isValid(long)}, this method will return true.
+   *
+   * @param date milliseconds date to validate against.
+   * @return True, if the given date is valid for at least one validator in this class.
+   */
+  @Override
+  public boolean isValid(long date) {
+    for (DateValidator validator : validators) {
+      if (validator == null) {
+        continue;
+      }
+      if (validator.isValid(date)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(@NonNull Parcel dest, int flags) {
+    dest.writeList(validators);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof MultipleDateValidator)) {
+      return false;
+    }
+
+    MultipleDateValidator that = (MultipleDateValidator) o;
+
+    return validators.equals(that.validators);
+  }
+
+  @Override
+  public int hashCode() {
+    return validators.hashCode();
+  }
+}

--- a/lib/javatests/com/google/android/material/datepicker/MultipleDateValidatorTest.java
+++ b/lib/javatests/com/google/android/material/datepicker/MultipleDateValidatorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.material.datepicker;
+
+import android.os.Parcel;
+
+import com.google.android.material.datepicker.CalendarConstraints.DateValidator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Test for {@link MultipleDateValidator} */
+@RunWith(RobolectricTestRunner.class)
+public class MultipleDateValidatorTest {
+
+  private DateValidator subject;
+
+  @Before
+  public void createSubject() {
+    DateValidator validator1 = DateValidatorPointBackward.before(5);
+    DateValidator validator2 = DateValidatorPointForward.from(10);
+
+    ArrayList<DateValidator> validators = new ArrayList<>(2);
+    validators.add(validator1);
+    validators.add(validator2);
+
+    subject = MultipleDateValidator.allOf(validators);
+  }
+
+  @Test
+  public void testValidDate() {
+    assertThat(subject.isValid(2)).isTrue();
+    assertThat(subject.isValid(5)).isTrue();
+    assertThat(subject.isValid(11)).isTrue();
+  }
+
+  @Test
+  public void testInvalidDate() {
+    assertThat(subject.isValid(6)).isFalse();
+    assertThat(subject.isValid(9)).isFalse();
+  }
+
+  @Test
+  public void testParcelable() {
+    DateValidator original = subject;
+
+    Parcel parcel = Parcel.obtain();
+    original.writeToParcel(parcel, 0);
+    parcel.setDataPosition(0);
+
+    DateValidator createdFromParcel = MultipleDateValidator.CREATOR.createFromParcel(parcel);
+    assertThat(original).isEqualTo(createdFromParcel);
+  }
+}


### PR DESCRIPTION
With the `MultipleDateValidator` the calendar date is enabled if at least one validator is valid.
It allows to create multiple ranges.

<img width="249" alt="Schermata 2020-08-16 alle 23 40 48" src="https://user-images.githubusercontent.com/2583078/90344490-a037bb80-e01a-11ea-9ef8-beec321c8dc2.png">
