### PR TITLE
[NavigationView] Fix obtaining Activity in setupInsetScrimsListener

### DIFF
--- a/lib/java/com/google/android/material/navigation/NavigationView.java
+++ b/lib/java/com/google/android/material/navigation/NavigationView.java
@@ -59,6 +59,7 @@ import androidx.annotation.RestrictTo;
 import androidx.annotation.StyleRes;
 import androidx.core.content.ContextCompat;
 import androidx.customview.view.AbsSavedState;
+import com.google.android.material.internal.ContextUtils;
 import com.google.android.material.internal.NavigationMenu;
 import com.google.android.material.internal.NavigationMenuPresenter;
 import com.google.android.material.internal.ScrimInsetsFrameLayout;
@@ -682,13 +683,12 @@ public class NavigationView extends ScrimInsetsFrameLayout {
         presenter.setBehindStatusBar(isBehindStatusBar);
         setDrawTopInsetForeground(isBehindStatusBar);
 
-        Context context = getContext();
-        if (context instanceof Activity && VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+        Activity activity = ContextUtils.getActivity(getContext());
+        if (activity != null && VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
           boolean isBehindSystemNav =
-              ((Activity) context).findViewById(android.R.id.content).getHeight()
-                  == getHeight();
+              activity.findViewById(android.R.id.content).getHeight() == getHeight();
           boolean hasNonZeroAlpha =
-              Color.alpha(((Activity) context).getWindow().getNavigationBarColor()) != 0;
+              Color.alpha(activity.getWindow().getNavigationBarColor()) != 0;
 
           setDrawBottomInsetForeground(isBehindSystemNav && hasNonZeroAlpha);
         }


### PR DESCRIPTION
Closes #1627 

`NavigationView#setupInsetScrimsListener` tries to obtain the containing Activity by casting `getContext()` to `Activity`. This will fail if the context is a ContextThemeWrapper, such as when setting `android:theme` on the view.

The fix is to use `ContextUtils.getActivity` to obtain the Activity instead, which walks through `ContextWrapper`s to find the containing Activity.

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
