### PR TITLE
[TextInputLayout] Added option to have prefix-suffix always visible

### DIFF
--- a/catalog/java/io/material/catalog/textfield/TextFieldPrefixSuffixDemoFragment.java
+++ b/catalog/java/io/material/catalog/textfield/TextFieldPrefixSuffixDemoFragment.java
@@ -16,9 +16,13 @@
 
 package io.material.catalog.textfield;
 
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
 import io.material.catalog.R;
-
 import androidx.annotation.LayoutRes;
+import com.google.android.material.textfield.TextInputLayout;
 
 /** A fragment that displays the filled text field demos with controls for the Catalog app. */
 public class TextFieldPrefixSuffixDemoFragment extends TextFieldControllableDemoFragment {
@@ -28,4 +32,36 @@ public class TextFieldPrefixSuffixDemoFragment extends TextFieldControllableDemo
   public int getTextFieldContent() {
     return R.layout.cat_textfield_prefix_suffix_content;
   }
+
+  @Override
+  public void initTextFieldDemoControls(LayoutInflater layoutInflater, View view) {
+    super.initTextFieldDemoControls(layoutInflater, view);
+
+    Button togglePrefixSuffixButton = view.findViewById(R.id.button_toggle_prefixsuffix);
+    togglePrefixSuffixButton.setOnClickListener(
+        v -> {
+          if (!textfields.get(0).isPrefixAlwaysVisible()) {
+            setAllPrefixSuffixAlwaysVisible(true);
+            togglePrefixSuffixButton.setText(
+                getResources().getString(R.string.cat_textfield_always_visible_false_text));
+          } else {
+            setAllPrefixSuffixAlwaysVisible(false);
+            togglePrefixSuffixButton.setText(
+                getResources().getString(R.string.cat_textfield_always_visible_true_text));
+          }
+        });
+  }
+
+  private void setAllPrefixSuffixAlwaysVisible(boolean alwaysVisible) {
+    ViewGroup parent = (ViewGroup) textfields.get(0).getParent();
+    for (TextInputLayout textfield : textfields) {
+      if (textfield.getPrefixText() != null) {
+        textfield.setPrefixAlwaysVisible(alwaysVisible);
+      }
+      if (textfield.getSuffixText() != null) {
+        textfield.setSuffixAlwaysVisible(alwaysVisible);
+      }
+    }
+  }
+
 }

--- a/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_prefix_suffix_content.xml
+++ b/catalog/java/io/material/catalog/textfield/res/layout/cat_textfield_prefix_suffix_content.xml
@@ -162,4 +162,19 @@
         android:inputType="numberDecimal"/>
   </com.google.android.material.textfield.TextInputLayout>
 
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/cat_textfield_standard_spacing"
+    android:orientation="vertical">
+
+    <Button
+      android:id="@+id/button_toggle_prefixsuffix"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal"
+      android:text="@string/cat_textfield_always_visible_true_text"/>
+
+  </LinearLayout>
+
 </LinearLayout>

--- a/catalog/java/io/material/catalog/textfield/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/textfield/res/values/strings.xml
@@ -84,6 +84,8 @@
   <string name="cat_textfield_null_input_error_text" translatable="false">Enter a value</string>
   <string name="cat_textfield_show_error_text" translatable="false">Show error</string>
   <string name="cat_textfield_hide_error_text" translatable="false">Hide error</string>
+  <string name="cat_textfield_always_visible_true_text" translatable="false">Prefix/suffix always visible</string>
+  <string name="cat_textfield_always_visible_false_text" translatable="false">Prefix/suffix default visibility</string>
 
   <string-array name="cat_textfield_exposed_dropdown_content" translatable="false">
     <item>Item 1</item>

--- a/lib/java/com/google/android/material/textfield/ClearTextEndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/ClearTextEndIconDelegate.java
@@ -64,7 +64,8 @@ class ClearTextEndIconDelegate extends EndIconDelegate {
         @Override
         public void onFocusChange(View v, boolean hasFocus) {
           boolean hasText = !TextUtils.isEmpty(((EditText) v).getText());
-          animateIcon(hasText && hasFocus);
+          animateIcon(hasFocus && (hasText ||
+              (textInputLayout.isSuffixAlwaysVisible() && textInputLayout.getSuffixText()!= null)));
         }
       };
   private final OnEditTextAttachedListener clearTextOnEditTextAttachedListener =
@@ -127,7 +128,7 @@ class ClearTextEndIconDelegate extends EndIconDelegate {
 
   @Override
   void onSuffixVisibilityChanged(boolean visible) {
-    if (textInputLayout.getSuffixText() == null) {
+    if (textInputLayout.getSuffixText() == null || !textInputLayout.getEditText().isFocused()) {
       return;
     }
     animateIcon(visible);

--- a/lib/java/com/google/android/material/textfield/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/textfield/res-public/values/public.xml
@@ -47,9 +47,11 @@
   <public name="prefixText" type="attr"/>
   <public name="prefixTextAppearance" type="attr"/>
   <public name="prefixTextColor" type="attr"/>
+  <public name="prefixAlwaysVisible" type="attr" />
   <public name="suffixText" type="attr"/>
   <public name="suffixTextAppearance" type="attr"/>
   <public name="suffixTextColor" type="attr"/>
+  <public name="suffixAlwaysVisible" type="attr" />
   <public name="errorEnabled" type="attr"/>
   <public name="errorTextAppearance" type="attr"/>
   <public name="errorTextColor" type="attr"/>

--- a/lib/java/com/google/android/material/textfield/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/attrs.xml
@@ -111,6 +111,8 @@
     <!-- Text color of the prefix text displayed in the text input area.
          If set, this takes precedence over prefixTextAppearance. -->
     <attr name="prefixTextColor" format="color"/>
+    <!-- Whether to always show the prefix text -->
+    <attr name="prefixAlwaysVisible" format="boolean"/>
     <!-- The text to display as suffix text in the text input area. -->
     <attr name="suffixText" format="string"/>
     <!-- TextAppearance of the suffix text displayed in the text input area. -->
@@ -118,6 +120,8 @@
     <!-- Text color of the suffix text displayed in the text input area.
          If set, this takes precedence over suffixTextAppearance. -->
     <attr name="suffixTextColor" format="color"/>
+    <!-- Whether to always show the suffix text -->
+    <attr name="suffixAlwaysVisible" format="boolean"/>
 
     <!-- Drawable to use for the start icon. -->
     <attr name="startIconDrawable" format="reference"/>


### PR DESCRIPTION
It closes #1459 

Currently the suffix/prefix view is visible only when the `EditText` is focused.
With this change it is possible to set prefix and/or suffix always visible.
The PR preserves the current behavior as default (`prefixAlwaysVisible` and `suffixAlwaysVisible` = `false`).

Updated also the catalog with an example.

<img width="304" alt="Schermata 2020-08-20 alle 01 07 43" src="https://user-images.githubusercontent.com/2583078/90699774-71bd1900-e284-11ea-8dd6-5135f2137ea3.png">

