### PR TITLE
[TextInputLayout] Added prefix/suffix start/end padding

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -37,6 +37,7 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Parcel;
 import android.os.Parcelable;
+import androidx.annotation.Px;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.core.view.GravityCompat;
@@ -214,6 +215,11 @@ public class TextInputLayout extends LinearLayout {
   @NonNull private final TextView prefixTextView;
   @Nullable private CharSequence suffixText;
   @NonNull private final TextView suffixTextView;
+
+  @Px private int prefixTextStartPadding;
+  @Px private int prefixTextEndPadding;
+  @Px private int suffixTextStartPadding;
+  @Px private int suffixTextEndPadding;
 
   private boolean hintEnabled;
   private CharSequence hint;
@@ -817,6 +823,10 @@ public class TextInputLayout extends LinearLayout {
     if (a.hasValue(R.styleable.TextInputLayout_suffixTextColor)) {
       setSuffixTextColor(a.getColorStateList(R.styleable.TextInputLayout_suffixTextColor));
     }
+    prefixTextStartPadding = a.getDimensionPixelSize(R.styleable.TextInputLayout_prefixTextStartPadding, 0);
+    prefixTextEndPadding = a.getDimensionPixelSize(R.styleable.TextInputLayout_prefixTextEndPadding, 0);
+    suffixTextStartPadding = a.getDimensionPixelSize(R.styleable.TextInputLayout_suffixTextStartPadding, 0);
+    suffixTextEndPadding = a.getDimensionPixelSize(R.styleable.TextInputLayout_suffixTextEndPadding, 0);
     setCounterEnabled(counterEnabled);
 
     setEnabled(a.getBoolean(R.styleable.TextInputLayout_android_enabled, true));
@@ -2316,6 +2326,83 @@ public class TextInputLayout extends LinearLayout {
     TextViewCompat.setTextAppearance(prefixTextView, prefixTextAppearance);
   }
 
+  /**
+   * Sets the padding before the prefix text and after the startIcon.
+   *
+   * @param prefixTextStartPadding Padding before the prefix text and after the startIcon
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_prefixTextStartPadding
+   * @see #getPrefixTextStartPadding
+   */
+  public void setPrefixTextStartPadding(@Px int prefixTextStartPadding) {
+    if (this.prefixTextStartPadding != prefixTextStartPadding) {
+      this.prefixTextStartPadding = prefixTextStartPadding;
+      updatePrefixTextViewPadding();
+    }
+  }
+
+  /**
+   * Sets the padding before the prefix text and after the startIcon, using a resource id.
+   *
+   * @param id The resource id for the padding before the prefix text and after the startIcon
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_prefixTextStartPadding
+   */
+  public void setPrefixTextStartPaddingResource(@DimenRes int id) {
+    if (id != NO_ID){
+      setPrefixTextStartPadding(getResources().getDimensionPixelSize(id));
+    }
+  }
+
+  /**
+   * Gets the padding before the prefix text and after the startIcon.
+   *
+   * @return Padding before the prefix text and after the startIcon.
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_prefixTextStartPadding
+   * @see #setPrefixTextStartPadding(int)
+   */
+  @Px
+  public int getPrefixTextStartPadding() {
+    return prefixTextStartPadding;
+  }
+
+  /**
+   * Sets the padding after the prefix text and before the EditText
+   *
+   * @param prefixTextEndPadding Padding after the prefix text and before the EditText
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_prefixTextEndPadding
+   * @see #getPrefixTextEndPadding
+   */
+  public void setPrefixTextEndPadding(@Px int prefixTextEndPadding) {
+    if (this.prefixTextEndPadding != prefixTextEndPadding) {
+      this.prefixTextEndPadding = prefixTextEndPadding;
+      updatePrefixTextViewPadding();
+    }
+  }
+
+  /**
+   * Sets the padding after the prefix text and before the EditText, using a resource id.
+   *
+   * @param id The resource id for the padding after the prefix text and before the EditText
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_prefixTextEndPadding
+   */
+  public void setPrefixTextEndPaddingResource(@DimenRes int id) {
+    if (id != NO_ID){
+      setPrefixTextEndPadding(getResources().getDimensionPixelSize(id));
+    }
+  }
+
+  /**
+   * Gets the padding after the prefix text
+   *
+   * @return Padding after the prefix text
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_prefixTextEndPadding
+   * @see #setPrefixTextEndPadding(int)
+   */
+  @Px
+  public int getPrefixTextEndPadding() {
+    return prefixTextEndPadding;
+  }
+
+
   private void updatePrefixTextViewPadding() {
     if (editText == null) {
       return;
@@ -2323,9 +2410,9 @@ public class TextInputLayout extends LinearLayout {
     int startPadding = isStartIconVisible() ? 0 : ViewCompat.getPaddingStart(editText);
     ViewCompat.setPaddingRelative(
         prefixTextView,
-        startPadding,
+        startPadding + prefixTextStartPadding,
         editText.getCompoundPaddingTop(),
-        0,
+        prefixTextEndPadding,
         editText.getCompoundPaddingBottom());
   }
 
@@ -2365,6 +2452,82 @@ public class TextInputLayout extends LinearLayout {
   @NonNull
   public TextView getSuffixTextView() {
     return suffixTextView;
+  }
+
+  /**
+   * Sets the padding before the suffix text and after the EditText.
+   *
+   * @param suffixTextStartPadding Padding before the suffix text and after the EditText
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_suffixTextStartPadding
+   * @see #getSuffixTextStartPadding
+   */
+  public void setSuffixTextStartPadding(@Px int suffixTextStartPadding) {
+    if (this.suffixTextStartPadding != suffixTextStartPadding) {
+      this.suffixTextStartPadding = suffixTextStartPadding;
+      updateSuffixTextViewPadding();
+    }
+  }
+
+  /**
+   * Sets the padding before the suffix text and after the EditText, using a resource id.
+   *
+   * @param id The resource id for the padding before the suffix text and after the EditText
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_suffixTextStartPadding
+   */
+  public void setSuffixTextStartPaddingResource(@DimenRes int id) {
+    if (id != NO_ID){
+      setSuffixTextStartPadding(getResources().getDimensionPixelSize(id));
+    }
+  }
+
+  /**
+   * Gets the padding before the suffix text and after the EditText.
+   *
+   * @return Padding before the suffix text and after the EditText.
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_suffixTextStartPadding
+   * @see #setSuffixTextStartPadding(int)
+   */
+  @Px
+  public int getSuffixTextStartPadding() {
+    return suffixTextStartPadding;
+  }
+
+  /**
+   * Sets the padding after the suffix text and before the endIcon
+   *
+   * @param suffixTextEndPadding Padding after the suffix text and before the endIcon
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_suffixTextEndPadding
+   * @see #getSuffixTextEndPadding
+   */
+  public void setSuffixTextEndPadding(@Px int suffixTextEndPadding) {
+    if (this.suffixTextEndPadding != suffixTextEndPadding) {
+      this.suffixTextEndPadding = suffixTextEndPadding;
+      updateSuffixTextViewPadding();
+    }
+  }
+
+  /**
+   * Sets the padding after the suffix text and before the endIcon, using a resource id.
+   *
+   * @param id The resource id for the padding after the suffix text and before the endIcon
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_suffixTextEndPadding
+   */
+  public void setSuffixTextEndPaddingResource(@DimenRes int id) {
+    if (id != NO_ID){
+      setSuffixTextEndPadding(getResources().getDimensionPixelSize(id));
+    }
+  }
+
+  /**
+   * Gets the padding after the suffix text and before the endIcon
+   *
+   * @return Padding after the suffix text and before the endIcon
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_suffixTextEndPadding
+   * @see #setSuffixTextEndPadding(int)
+   */
+  @Px
+  public int getSuffixTextEndPadding() {
+    return suffixTextEndPadding;
   }
 
   private void updateSuffixTextVisibility() {
@@ -2412,7 +2575,11 @@ public class TextInputLayout extends LinearLayout {
     int endPadding =
         (isEndIconVisible() || isErrorIconVisible()) ? 0 : ViewCompat.getPaddingEnd(editText);
     ViewCompat.setPaddingRelative(
-        suffixTextView, 0, editText.getPaddingTop(), endPadding, editText.getPaddingBottom());
+        suffixTextView,
+        suffixTextStartPadding,
+        editText.getPaddingTop(),
+        endPadding + suffixTextEndPadding,
+        editText.getPaddingBottom());
   }
 
   @Override

--- a/lib/java/com/google/android/material/textfield/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/textfield/res-public/values/public.xml
@@ -50,6 +50,10 @@
   <public name="suffixText" type="attr"/>
   <public name="suffixTextAppearance" type="attr"/>
   <public name="suffixTextColor" type="attr"/>
+  <public name="prefixTextStartPadding" type="attr"/>
+  <public name="prefixTextEndPadding" type="attr"/>
+  <public name="suffixTextStartPadding" type="attr"/>
+  <public name="suffixTextEndPadding" type="attr"/>
   <public name="errorEnabled" type="attr"/>
   <public name="errorTextAppearance" type="attr"/>
   <public name="errorTextColor" type="attr"/>

--- a/lib/java/com/google/android/material/textfield/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/attrs.xml
@@ -119,6 +119,15 @@
          If set, this takes precedence over suffixTextAppearance. -->
     <attr name="suffixTextColor" format="color"/>
 
+    <!-- Padding at the start of the prefix text, after the startIcon. -->
+    <attr name="prefixTextStartPadding" format="dimension"/>
+    <!-- Padding at the end of the prefix text, before the EditText. -->
+    <attr name="prefixTextEndPadding" format="dimension"/>
+    <!-- Padding at the start of the suffix text, after the EditText. -->
+    <attr name="suffixTextStartPadding" format="dimension"/>
+    <!-- Padding at the end of the suffix text, before the endIcon. -->
+    <attr name="suffixTextEndPadding" format="dimension"/>
+
     <!-- Drawable to use for the start icon. -->
     <attr name="startIconDrawable" format="reference"/>
     <!-- Text to set as the content description for the start icon. -->


### PR DESCRIPTION
In some scenarios it can be useful to set a padding for the `prefixText` and `suffixText`. For example if you set an `OnClickListener` on the `prefixTextView`/`suffixTextView`.

This PR adds these attributes:

- `prefixTextStartPadding`
- `prefixTextEndPadding`
- `suffixTextStartPadding`
- `suffixTextEndPadding`

<img width="305" alt="Schermata 2020-08-20 alle 09 21 36" src="https://user-images.githubusercontent.com/2583078/90742488-c0dc6b80-e2cf-11ea-9c32-cdacf34e88ce.png">
