### PR TITLE
[Chip] Fixed wrong behavior when checked chip with id = NO_ID is added to ChipGroup

### DIFF
--- a/lib/java/com/google/android/material/chip/ChipGroup.java
+++ b/lib/java/com/google/android/material/chip/ChipGroup.java
@@ -571,7 +571,11 @@ public class ChipGroup extends FlowLayout {
           id = ViewCompat.generateViewId();
           child.setId(id);
         }
-        ((Chip) child).setOnCheckedChangeListenerInternal(checkedStateTracker);
+        Chip chip = ((Chip) child);
+        if (chip.isChecked()){
+          ((ChipGroup) parent).check(chip.getId());
+        }
+        chip.setOnCheckedChangeListenerInternal(checkedStateTracker);
       }
 
       if (onHierarchyChangeListener != null) {

--- a/lib/javatests/com/google/android/material/chip/ChipGroupTest.java
+++ b/lib/javatests/com/google/android/material/chip/ChipGroupTest.java
@@ -26,6 +26,7 @@ import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.CollectionInfoCompat;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.CollectionItemInfoCompat;
 import androidx.appcompat.app.AppCompatActivity;
+import android.content.Context;
 import android.view.View;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.material.chip.ChipGroup.OnCheckedChangeListener;
@@ -43,11 +44,11 @@ public class ChipGroupTest {
   private static final int CHIP_GROUP_SPACING = 4;
   private ChipGroup chipgroup;
   private int checkedChangeCallCount;
+  private final Context context = ApplicationProvider.getApplicationContext();
 
   @Before
   public void themeApplicationContext() {
-    ApplicationProvider.getApplicationContext().setTheme(
-        R.style.Theme_MaterialComponents_Light_NoActionBar_Bridge);
+    context.setTheme(R.style.Theme_MaterialComponents_Light_NoActionBar_Bridge);
     AppCompatActivity activity = Robolectric.buildActivity(AppCompatActivity.class).setup().get();
     View inflated = activity.getLayoutInflater().inflate(R.layout.test_reflow_chipgroup, null);
     chipgroup = inflated.findViewById(R.id.chip_group);
@@ -93,6 +94,31 @@ public class ChipGroupTest {
     int checkedId2 = chipgroup.getCheckedChipId();
     assertThat(checkedId1).isEqualTo(checkedId2);
   }
+
+  @Test
+  public void testSingleSelection_AddingCheckedChipWithoutId() {
+    chipgroup.setSingleSelection(true);
+    int chipId = chipgroup.getChildAt(2).getId();
+    chipgroup.check(chipId);
+
+    Chip chipNotChecked = new Chip(context);
+    chipgroup.addView(chipNotChecked);
+    assertThat(chipgroup.getCheckedChipIds()).hasSize(1);
+    int checkedId = chipgroup.getCheckedChipId();
+    assertThat(checkedId).isEqualTo(chipId);
+
+    //Add a checked Chip
+    Chip chipChecked = new Chip(context);
+    chipChecked.setCheckable(true);
+    chipChecked.setChecked(true);
+    chipgroup.addView(chipChecked);
+
+    int newChipId = chipChecked.getId();
+    assertThat(chipgroup.getCheckedChipIds()).hasSize(1);
+    int checkedId2 = chipgroup.getCheckedChipId();
+    assertThat(checkedId2).isEqualTo(newChipId);
+  }
+
 
   @Test
   public void singleSelection_withSelectionRequired_doesNotUnSelect() {


### PR DESCRIPTION
Currently there are some issues when you are setting the checked state on a chip without id before it gets added to the `ChipGroup`.

It closes #1647.
You can also refer to #1178.

Also if you use something like:

```
       val group : ChipGroup = findViewById(R.id.chip_group)
        group.isSingleSelection = true

        val chip1 = layoutInflater.inflate(R.layout.single_chip_layout, group, false) as Chip
        chip1.isChecked = true
        group.addView(chip1)

        val chip2 =
            layoutInflater.inflate(R.layout.single_chip_layout, group, false) as Chip
        chip2.isChecked = true
        group.addView(chip2)
```
you will obtain a chipGroup with singleSelection = true and 2 chips checked.

This PR sets the selection in the group after the `Chip` is added and after an `id` is assigned.