### PR TITLE
[DatePicker] Use the selection as default openAt value

### DIFF
--- a/lib/java/com/google/android/material/datepicker/CalendarConstraints.java
+++ b/lib/java/com/google/android/material/datepicker/CalendarConstraints.java
@@ -32,8 +32,9 @@ public final class CalendarConstraints implements Parcelable {
 
   @NonNull private final Month start;
   @NonNull private final Month end;
-  @NonNull private final Month openAt;
+  @NonNull private Month openAt;
   private final DateValidator validator;
+  private boolean defaultOpenAt;
 
   private final int yearSpan;
   private final int monthSpan;
@@ -95,6 +96,11 @@ public final class CalendarConstraints implements Parcelable {
     return openAt;
   }
 
+  /** Sets the openAt month. */
+  void setOpenAt(@NonNull Month openAt) {
+    this.openAt = openAt;
+  }
+
   /**
    * Returns the total number of {@link java.util.Calendar#MONTH} included in {@code start} to
    * {@code end}.
@@ -109,6 +115,16 @@ public final class CalendarConstraints implements Parcelable {
    */
   int getYearSpan() {
     return yearSpan;
+  }
+
+  /** Sets whether the openAt value is configured as the default value  */
+  void setDefaultOpenAt(boolean defaultOpenAt) {
+    this.defaultOpenAt = defaultOpenAt;
+  }
+
+  /** Returns whether the openAt value is configured as the default value. */
+  boolean isDefaultOpenAt() {
+    return defaultOpenAt;
   }
 
   @Override
@@ -308,17 +324,21 @@ public final class CalendarConstraints implements Parcelable {
     /** Builds the {@link CalendarConstraints} object using the set parameters or defaults. */
     @NonNull
     public CalendarConstraints build() {
+      boolean defaultOpenAt = false;
       if (openAt == null) {
         long today = MaterialDatePicker.thisMonthInUtcMilliseconds();
         openAt = start <= today && today <= end ? today : start;
+        defaultOpenAt = true;
       }
       Bundle deepCopyBundle = new Bundle();
       deepCopyBundle.putParcelable(DEEP_COPY_VALIDATOR_KEY, validator);
-      return new CalendarConstraints(
+      CalendarConstraints calendarConstraints = new CalendarConstraints(
           Month.create(start),
           Month.create(end),
           Month.create(openAt),
           (DateValidator) deepCopyBundle.getParcelable(DEEP_COPY_VALIDATOR_KEY));
+      calendarConstraints.setDefaultOpenAt(defaultOpenAt);
+      return calendarConstraints;
     }
   }
 }

--- a/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
@@ -627,6 +627,12 @@ public final class MaterialDatePicker<S> extends DialogFragment {
       }
       if (selection != null) {
         dateSelector.setSelection(selection);
+        if (calendarConstraints.isDefaultOpenAt()){
+          if (dateSelector.getSelectedDays().iterator().hasNext()) {
+            Long firstSelectedDay = dateSelector.getSelectedDays().iterator().next();
+            calendarConstraints.setOpenAt(Month.create(firstSelectedDay));
+          }
+        }
       }
       return MaterialDatePicker.newInstance(this);
     }

--- a/lib/javatests/com/google/android/material/datepicker/MaterialDatePickerTest.java
+++ b/lib/javatests/com/google/android/material/datepicker/MaterialDatePickerTest.java
@@ -17,6 +17,7 @@
 package com.google.android.material.datepicker;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.time.Duration;
 import java.util.Calendar;
@@ -36,6 +37,10 @@ public class MaterialDatePickerTest {
   // Tuesday, January 1, 2020 09:00:00 AM UTC+13:00
   private static final long NEW_ZEALAND_TIME_2020_01_11_09_00_00_AM = 1577822400000L;
   private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
+
+  private static final long FEB_2016 = Month.create(2016, Calendar.FEBRUARY).timeInMillis;
+  private static final long MARCH_2016 = Month.create(2016, Calendar.MARCH).timeInMillis;
+  private static final long APRIL_2016 = Month.create(2016, Calendar.APRIL).timeInMillis;
 
   private static Calendar setTestLocalTime(long testTimeAsEpochMs, TimeZone timeZone) {
     TimeSource fixedTimeSource = TimeSource.fixed(testTimeAsEpochMs, timeZone);
@@ -81,6 +86,35 @@ public class MaterialDatePickerTest {
         .isEqualTo(firstMomentOfTodayInUtc.get(Calendar.MONTH));
     assertThat(outputUtcThisMonthInCalendar.get(Calendar.DATE)).isEqualTo(1);
   }
+
+  @Test
+  public void testSelectionAsOpenAt() {
+
+    MaterialDatePicker.Builder<Long> datePickerBuilder = MaterialDatePicker.Builder.datePicker();
+    CalendarConstraints calendarConstraints =
+        new CalendarConstraints.Builder().setStart(FEB_2016).setEnd(APRIL_2016).build();
+    datePickerBuilder.setCalendarConstraints(calendarConstraints);
+    datePickerBuilder.setSelection(APRIL_2016);
+    datePickerBuilder.build();
+    assertEquals(APRIL_2016, calendarConstraints.getOpenAt().timeInMillis);
+
+    MaterialDatePicker.Builder<Long> datePickerBuilder2 = MaterialDatePicker.Builder.datePicker();
+    CalendarConstraints calendarConstraints2 =
+        new CalendarConstraints.Builder().setStart(FEB_2016).setEnd(APRIL_2016).build();
+    datePickerBuilder2.setCalendarConstraints(calendarConstraints2);
+    datePickerBuilder2.build();
+    assertEquals(FEB_2016, calendarConstraints2.getOpenAt().timeInMillis);
+
+    MaterialDatePicker.Builder<Long> datePickerBuilder3 = MaterialDatePicker.Builder.datePicker();
+    CalendarConstraints calendarConstraints3 =
+        new CalendarConstraints.Builder().setStart(FEB_2016).setEnd(APRIL_2016)
+            .setOpenAt(MARCH_2016).build();
+    datePickerBuilder3.setCalendarConstraints(calendarConstraints3);
+    datePickerBuilder3.setSelection(APRIL_2016);
+    datePickerBuilder3.build();
+    assertEquals(MARCH_2016, calendarConstraints3.getOpenAt().timeInMillis);
+  }
+
 
   @Test
   public void testTodayInUtcMilliseconds() {


### PR DESCRIPTION
It closes #1199 

With this PR the `selection` value is used  as the default `openAt`.
If there is no selection, it continues to use the current default `openAt` logic.
It still supports setting a totally different/custom `openAt` value.

As described above this PR changes the current behavior.

It can be tested using the current catalog choosing the default value as opening month and the next month as default selection.
