### PR TITLE
[ExtendedFloatingActionButton] Fix padding and spacing

### DIFF
--- a/lib/java/com/google/android/material/floatingactionbutton/res/values/dimens.xml
+++ b/lib/java/com/google/android/material/floatingactionbutton/res/values/dimens.xml
@@ -31,12 +31,12 @@
 
   <dimen name="mtrl_extended_fab_top_padding">12dp</dimen>
   <dimen name="mtrl_extended_fab_bottom_padding">12dp</dimen>
-  <dimen name="mtrl_extended_fab_start_padding_icon">16dp</dimen>
-  <dimen name="mtrl_extended_fab_end_padding_icon">24dp</dimen>
+  <dimen name="mtrl_extended_fab_start_padding_icon">12dp</dimen>
+  <dimen name="mtrl_extended_fab_end_padding_icon">20dp</dimen>
   <dimen name="mtrl_extended_fab_start_padding">20dp</dimen>
   <dimen name="mtrl_extended_fab_end_padding">20dp</dimen>
   <dimen name="mtrl_extended_fab_icon_size">24dp</dimen>
-  <dimen name="mtrl_extended_fab_icon_text_spacing">16dp</dimen>
+  <dimen name="mtrl_extended_fab_icon_text_spacing">12dp</dimen>
   <dimen name="mtrl_extended_fab_corner_radius">24dp</dimen>
   <dimen name="mtrl_extended_fab_min_width">120dp</dimen>
   <dimen name="mtrl_extended_fab_min_height">48dp</dimen>


### PR DESCRIPTION
Based on those spec here: https://material.io/components/buttons-floating-action-button#specs
The extended FAB start padding should be 12dp and not 16dp
The extended FAB end padding should be 20dp and not 24dp
The extended FAB space between the icon and the text should be 12dp and not 16dp

Fixes #1654 