### PR TITLE
[TextInputLayout] Added an option to achieve the collapsed hint with an empty background in outline box

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -411,6 +411,7 @@ public class TextInputLayout extends LinearLayout {
   private boolean inDrawableStateChanged;
 
   private boolean restoringSavedState;
+  private boolean emptyCollapsedHintBackground;
 
   public TextInputLayout(@NonNull Context context) {
     this(context, null);
@@ -821,6 +822,8 @@ public class TextInputLayout extends LinearLayout {
     setCounterEnabled(counterEnabled);
 
     setEnabled(a.getBoolean(R.styleable.TextInputLayout_android_enabled, true));
+    emptyCollapsedHintBackground =
+        a.getBoolean(R.styleable.TextInputLayout_emptyCollapsedHintBackground, false);
 
     a.recycle();
 
@@ -2425,6 +2428,29 @@ public class TextInputLayout extends LinearLayout {
     super.setEnabled(enabled);
   }
 
+  /**
+   * Sets whether the collapsed hint text will be displayed with an empty background with an outline box
+   *
+   * @see #isEmptyCollapsedHintBackground()
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_emptyCollapsedHintBackground
+   */
+  public void setEmptyCollapsedHintBackground(boolean emptyCollapsedHintBackground) {
+    if (this.emptyCollapsedHintBackground != emptyCollapsedHintBackground) {
+      this.emptyCollapsedHintBackground = emptyCollapsedHintBackground;
+      requestLayout();
+    }
+  }
+
+  /**
+   * Returns Whether the collapsed hint text will be displayed with an empty background with an an outline box
+   *
+   * @see #setEmptyCollapsedHintBackground(boolean)
+   * @attr ref com.google.android.material.R.styleable#TextInputLayout_emptyCollapsedHintBackground
+   */
+  public boolean isEmptyCollapsedHintBackground() {
+    return emptyCollapsedHintBackground;
+  }
+
   private static void recursiveSetEnabled(@NonNull final ViewGroup vg, final boolean enabled) {
     for (int i = 0, count = vg.getChildCount(); i < count; i++) {
       final View child = vg.getChildAt(i);
@@ -3898,6 +3924,10 @@ public class TextInputLayout extends LinearLayout {
     final RectF cutoutBounds = tmpRectF;
     collapsingTextHelper.getCollapsedTextActualBounds(
         cutoutBounds, editText.getWidth(), editText.getGravity());
+
+    if (isEmptyCollapsedHintBackground()) {
+      cutoutBounds.bottom = cutoutBounds.top + boxStrokeWidthPx;
+    }
     applyCutoutPadding(cutoutBounds);
     // Offset the cutout bounds by the TextInputLayout's left and top paddings to ensure that the
     // cutout is inset relative to the TextInputLayout's bounds.
@@ -3913,9 +3943,11 @@ public class TextInputLayout extends LinearLayout {
 
   private void applyCutoutPadding(@NonNull RectF cutoutBounds) {
     cutoutBounds.left -= boxLabelCutoutPaddingPx;
-    cutoutBounds.top -= boxLabelCutoutPaddingPx;
     cutoutBounds.right += boxLabelCutoutPaddingPx;
-    cutoutBounds.bottom += boxLabelCutoutPaddingPx;
+    if (!isEmptyCollapsedHintBackground()){
+      cutoutBounds.top -= boxLabelCutoutPaddingPx;
+      cutoutBounds.bottom += boxLabelCutoutPaddingPx;
+    }
   }
 
   @VisibleForTesting

--- a/lib/java/com/google/android/material/textfield/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/textfield/res-public/values/public.xml
@@ -91,6 +91,7 @@
   <public name="passwordToggleTintMode" type="attr"/>
 
   <public name="textInputLayoutFocusedRectEnabled" type="attr"/>
+  <public name="emptyCollapsedHintBackground" type="attr"/>
 
   <public name="Widget.Design.TextInputLayout" type="style"/>
   <public name="Widget.MaterialComponents.TextInputLayout.FilledBox" type="style"/>

--- a/lib/java/com/google/android/material/textfield/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/textfield/res/values/attrs.xml
@@ -258,6 +258,9 @@
       <!-- [Sa + Da - Sa * Da, Sc + Dc - Sc * Dc] -->
       <enum name="screen" value="15"/>
     </attr>
+    <!-- Whether the collapsed hint text will be displayed with an empty background,
+         with an outline box.-->
+    <attr name="emptyCollapsedHintBackground" format="boolean"/>
   </declare-styleable>
 
   <declare-styleable name="TextInputEditText">


### PR DESCRIPTION
It closes #1319.

With the current behavior we can have something like:
<img width="294" alt="Schermata 2020-08-26 alle 19 54 30" src="https://user-images.githubusercontent.com/2583078/91340662-a9721680-e7d8-11ea-8ca0-8b17274dacb1.png">

With this PR is possible to have an empty background like:

<img width="303" alt="Outlined" src="https://user-images.githubusercontent.com/2583078/91340666-abd47080-e7d8-11ea-96f2-9d1eb286866f.png">
<img width="271" alt="Detail" src="https://user-images.githubusercontent.com/2583078/91340672-ae36ca80-e7d8-11ea-956d-261548163f90.png">

The PR preserves the current behavior as default.

To test the PR:

```
<LinearLayout
    android:background="@color/...">

  <com.google.android.material.textfield.TextInputLayout
       style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
       app:emptyCollapsedHintBackground="true"
       app:boxBackgroundColor="#FFFFFF"
       >
 

</LinearLayout>
```
