### PR TITLE
[TextInputLayout] Fixed wrong hint position when an error is shown and field is empty and unfocused

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -1484,13 +1484,14 @@ public class TextInputLayout extends LinearLayout {
       collapsingTextHelper.setExpandedTextColor(ColorStateList.valueOf(disabledHintColor));
     } else if (errorShouldBeShown) {
       collapsingTextHelper.setCollapsedTextColor(indicatorViewController.getErrorViewTextColors());
+      collapsingTextHelper.setExpandedTextColor(indicatorViewController.getErrorViewTextColors());
     } else if (counterOverflowed && counterView != null) {
       collapsingTextHelper.setCollapsedTextColor(counterView.getTextColors());
     } else if (hasFocus && focusedTextColor != null) {
       collapsingTextHelper.setCollapsedTextColor(focusedTextColor);
     } // If none of these states apply, leave the expanded and collapsed colors as they are.
 
-    if (hasText || (isEnabled() && (hasFocus || errorShouldBeShown))) {
+    if (hasText || (isEnabled() && (hasFocus))) {
       // We should be showing the label so do so if it isn't already
       if (force || hintExpanded) {
         collapseHint(animate);


### PR DESCRIPTION
It closes #1275.

**Currently** as described in the issue when an error is shown and the field is empty and unfocused:
-  the position of the hint text is collapsed

<img width="303" alt="Schermata 2020-08-26 alle 23 30 54" src="https://user-images.githubusercontent.com/2583078/91359104-32e31200-e7f4-11ea-86e9-b657f7176da1.png">

Following the https://material.io/components/text-fields the hint text should be expanded with the error color.

<img width="284" alt="Schermata 2020-08-26 alle 23 32 32" src="https://user-images.githubusercontent.com/2583078/91359222-6de54580-e7f4-11ea-83b4-4a8997a7b2be.png">

It can be reproduced with the catalog demo.

**With this PR**:

Unfocused, with an error and without text:
<img width="303" alt="Schermata 2020-08-26 alle 23 27 20" src="https://user-images.githubusercontent.com/2583078/91359487-eb10ba80-e7f4-11ea-8cf5-10a1cf3c5b24.png">

Focused, with an error and with text:
<img width="303" alt="Schermata 2020-08-26 alle 23 26 56" src="https://user-images.githubusercontent.com/2583078/91359481-e946f700-e7f4-11ea-8258-e65e1671c936.png">

Unfocused, with an error and with text:
<img width="304" alt="Schermata 2020-08-26 alle 23 27 09" src="https://user-images.githubusercontent.com/2583078/91359484-ea782400-e7f4-11ea-944b-6ca32141559f.png">


