### PR TITLE
[BottomSheet] Fix SettleRunnable leak

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -1315,7 +1315,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
             && (settleFromViewDragHelper
                 ? viewDragHelper.settleCapturedViewAt(child.getLeft(), top)
                 : viewDragHelper.smoothSlideViewTo(child, child.getLeft(), top));
-    if (startedSettling) {
+    if (startedSettling && ViewCompat.isAttachedToWindow(child)) {
       setStateInternal(STATE_SETTLING);
       // STATE_SETTLING won't animate the material shape, so do that here with the target state.
       updateDrawableForTargetState(state);
@@ -1324,7 +1324,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
         settleRunnable = new SettleRunnable(child, state);
       }
       // If the SettleRunnable has not been posted, post it with the correct state.
-      if (settleRunnable.isPosted == false) {
+      if (!settleRunnable.isPosted) {
         settleRunnable.targetState = state;
         ViewCompat.postOnAnimation(child, settleRunnable);
         settleRunnable.isPosted = true;
@@ -1533,7 +1533,9 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
 
     @Override
     public void run() {
-      if (viewDragHelper != null && viewDragHelper.continueSettling(true)) {
+      if (viewDragHelper != null
+          && viewDragHelper.continueSettling(true)
+          && ViewCompat.isAttachedToWindow(view)) {
         ViewCompat.postOnAnimation(view, this);
       } else {
         setStateInternal(targetState);


### PR DESCRIPTION
Ensures that we don't post the `SettleRunnable` if the view isn't attached, because otherwise if there is no alive activity that `SettleRunnable` can stay in the ViewRootImpl `RunQueue` until a new activity starts.

Fixes #1417.