### PR TITLE
[MaterialToolbar] Add Shape and shape customization to MaterialToolbar

### DIFF
--- a/lib/java/com/google/android/material/appbar/MaterialToolbar.java
+++ b/lib/java/com/google/android/material/appbar/MaterialToolbar.java
@@ -16,25 +16,25 @@
 
 package com.google.android.material.appbar;
 
-import com.google.android.material.R;
-
-import static com.google.android.material.theme.overlay.MaterialThemeOverlay.wrap;
-
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build.VERSION_CODES;
-import androidx.core.view.ViewCompat;
-import androidx.appcompat.widget.Toolbar;
 import android.util.AttributeSet;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.view.ViewCompat;
+import com.google.android.material.R;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.MaterialShapeUtils;
 import com.google.android.material.shape.ShapeAppearanceModel;
+import com.google.android.material.shape.Shapeable;
+
+import static com.google.android.material.theme.overlay.MaterialThemeOverlay.wrap;
 
 /**
  * {@code MaterialToolbar} is a {@link Toolbar} that implements certain Material features, such as
@@ -57,7 +57,7 @@ import com.google.android.material.shape.ShapeAppearanceModel;
  *         android:layout_height=&quot;wrap_content&quot;/&gt;
  * </pre>
  */
-public class MaterialToolbar extends Toolbar {
+public class MaterialToolbar extends Toolbar implements Shapeable {
 
   private ShapeAppearanceModel shapeAppearanceModel;
 
@@ -108,5 +108,17 @@ public class MaterialToolbar extends Toolbar {
     materialShapeDrawable.initializeElevationOverlay(context);
     materialShapeDrawable.setElevation(ViewCompat.getElevation(this));
     ViewCompat.setBackground(this, materialShapeDrawable);
+  }
+
+  @Override
+  public void setShapeAppearanceModel(@NonNull ShapeAppearanceModel shapeAppearanceModel) {
+    this.shapeAppearanceModel = shapeAppearanceModel;
+    initBackground(getContext());
+  }
+
+  @NonNull
+  @Override
+  public ShapeAppearanceModel getShapeAppearanceModel() {
+    return shapeAppearanceModel;
   }
 }

--- a/lib/java/com/google/android/material/appbar/MaterialToolbar.java
+++ b/lib/java/com/google/android/material/appbar/MaterialToolbar.java
@@ -38,7 +38,7 @@ import static com.google.android.material.theme.overlay.MaterialThemeOverlay.wra
 
 /**
  * {@code MaterialToolbar} is a {@link Toolbar} that implements certain Material features, such as
- * elevation overlays for Dark Themes.
+ * elevation overlays for Dark Themes and Shape.
  *
  * <p>Regarding the Dark Theme elevation overlays, it's important to note that the Material {@link
  * AppBarLayout} component also provides elevation overlay support, and operates under the

--- a/lib/java/com/google/android/material/appbar/MaterialToolbar.java
+++ b/lib/java/com/google/android/material/appbar/MaterialToolbar.java
@@ -34,6 +34,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.MaterialShapeUtils;
+import com.google.android.material.shape.ShapeAppearanceModel;
 
 /**
  * {@code MaterialToolbar} is a {@link Toolbar} that implements certain Material features, such as
@@ -58,6 +59,8 @@ import com.google.android.material.shape.MaterialShapeUtils;
  */
 public class MaterialToolbar extends Toolbar {
 
+  private ShapeAppearanceModel shapeAppearanceModel;
+
   private static final int DEF_STYLE_RES = R.style.Widget_MaterialComponents_Toolbar;
 
   public MaterialToolbar(@NonNull Context context) {
@@ -68,10 +71,12 @@ public class MaterialToolbar extends Toolbar {
     this(context, attrs, R.attr.toolbarStyle);
   }
 
-  public MaterialToolbar(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
-    super(wrap(context, attrs, defStyleAttr, DEF_STYLE_RES), attrs, defStyleAttr);
+  public MaterialToolbar(@NonNull Context context, @Nullable AttributeSet attrs, int defStyle) {
+    super(wrap(context, attrs, defStyle, DEF_STYLE_RES), attrs, defStyle);
     // Ensure we are using the correctly themed context rather than the context that was passed in.
     context = getContext();
+
+    shapeAppearanceModel = ShapeAppearanceModel.builder(context, attrs, defStyle, DEF_STYLE_RES).build();
 
     initBackground(context);
   }
@@ -96,7 +101,7 @@ public class MaterialToolbar extends Toolbar {
     if (background != null && !(background instanceof ColorDrawable)) {
       return;
     }
-    MaterialShapeDrawable materialShapeDrawable = new MaterialShapeDrawable();
+    MaterialShapeDrawable materialShapeDrawable = new MaterialShapeDrawable(shapeAppearanceModel);
     int backgroundColor =
         background != null ? ((ColorDrawable) background).getColor() : Color.TRANSPARENT;
     materialShapeDrawable.setFillColor(ColorStateList.valueOf(backgroundColor));

--- a/lib/java/com/google/android/material/appbar/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/appbar/res/values/attrs.xml
@@ -214,4 +214,14 @@
     <attr name="layout_collapseParallaxMultiplier" format="float"/>
   </declare-styleable>
 
+  <declare-styleable name="MaterialToolbar">
+    <!-- Shape appearance style reference for MaterialToolbar. Attribute declaration is in the
+     shape package. -->
+    <attr name="shapeAppearance" />
+    <!-- Shape appearance overlay style reference for MaterialToolbar. To be used to augment
+         attributes declared in the shapeAppearance. Attribute declaration is in the shape package.
+         -->
+    <attr name="shapeAppearanceOverlay" />
+  </declare-styleable>
+
 </resources>


### PR DESCRIPTION
### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
- [ ] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

I've recently seen that `MaterialToolbar` uses MaterialShapeDrawable to customize the color on dark mode.

But unfortunately it has no effect if we want to customize the shape of it, as we needed to use a custom xml drawable, or set `MaterialShapeDrawable` manually.

This PR adds shape customization to `MaterialToolbar`

## Screenshots
Rounded | Cut | Dark
---|---|---
<img width="280" src="https://user-images.githubusercontent.com/887462/91947225-ca1dfd00-ecff-11ea-83f5-6ff1ecdd481f.png" /> | <img width="280" src="https://user-images.githubusercontent.com/887462/91947138-c38f8580-ecff-11ea-8a8a-7474d64c4838.png" /> | <img width="280" src="https://user-images.githubusercontent.com/887462/91951483-f4bc8580-ed00-11ea-95dc-8b17e3a28ca0.png" />

Questions:

* How can I make it work with theme configuration dialog fragment?
