### PR TITLE
[MaterialCardView] Added option to set the checkedIcon gravity

### DIFF
--- a/lib/java/com/google/android/material/card/MaterialCardView.java
+++ b/lib/java/com/google/android/material/card/MaterialCardView.java
@@ -27,6 +27,7 @@ import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
+import androidx.annotation.IntDef;
 import androidx.appcompat.content.res.AppCompatResources;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -47,6 +48,8 @@ import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.MaterialShapeUtils;
 import com.google.android.material.shape.ShapeAppearanceModel;
 import com.google.android.material.shape.Shapeable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
  * Provides a Material card.
@@ -92,6 +95,49 @@ public class MaterialCardView extends CardView implements Checkable, Shapeable {
   private static final int DEF_STYLE_RES = R.style.Widget_MaterialComponents_CardView;
   private static final String LOG_TAG = "MaterialCardView";
   private static final String ACCESSIBILITY_CLASS_NAME = "androidx.cardview.widget.CardView";
+
+  /**
+   * Gravity used to position the checked icon at the top|start of the Card.
+   *
+   * @see #setCheckedIconGravity(int)
+   * @see #getCheckedIconGravity()
+   */
+  public static final int CHECKED_ICON_GRAVITY_TOP_START = 0x1;
+
+  /**
+   * Gravity used to position the checked icon at the bottom|start of the Card.
+   *
+   * @see #setCheckedIconGravity(int)
+   * @see #getCheckedIconGravity()
+   */
+  public static final int CHECKED_ICON_GRAVITY_BOTTOM_START = 0x2;
+
+  /**
+   * Gravity used to position the checked icon at the top|end of the Card.
+   *
+   * @see #setCheckedIconGravity(int)
+   * @see #getCheckedIconGravity()
+   */
+  public static final int CHECKED_ICON_GRAVITY_TOP_END = 0x3;
+
+  /**
+   * Gravity used to position the checked icon at the bottom|end of the Card.
+   *
+   * @see #setCheckedIconGravity(int)
+   * @see #getCheckedIconGravity()
+   */
+  public static final int CHECKED_ICON_GRAVITY_BOTTOM_END = 0x4;
+
+  /** Positions the icon can be set to. */
+  @IntDef({
+      CHECKED_ICON_GRAVITY_TOP_START,
+      CHECKED_ICON_GRAVITY_BOTTOM_START,
+      CHECKED_ICON_GRAVITY_TOP_END,
+      CHECKED_ICON_GRAVITY_BOTTOM_END
+  })
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface CheckedIconGravity{}
+
 
   @NonNull private final MaterialCardViewHelper cardViewHelper;
 
@@ -582,4 +628,30 @@ public class MaterialCardView extends CardView implements Checkable, Shapeable {
       cardViewHelper.forceRippleRedraw();
     }
   }
+
+  /**
+   * Gets the checked icon gravity for this card
+   *
+   * @return Checked Icon gravity of the card.
+   * @attr ref com.google.android.material.R.styleable#MaterialCard_checkedIconGravity
+   * @see #setCheckedIconGravity(int)
+   */
+  @CheckedIconGravity
+  public int getCheckedIconGravity() {
+    return cardViewHelper.getCheckedIconGravity();
+  }
+
+  /**
+   * Sets the checked icon gravity for this card
+   *
+   * @attr ref com.google.android.material.R.styleable#MaterialCard_checkedIconGravity
+   * @param checkedIconGravity checked icon gravity for this card
+   * @see #getCheckedIconGravity()
+   */
+  public void setCheckedIconGravity(@CheckedIconGravity int checkedIconGravity) {
+    if (cardViewHelper.getCheckedIconGravity() != checkedIconGravity) {
+      cardViewHelper.setCheckedIconGravity(checkedIconGravity);
+    }
+  }
+
 }

--- a/lib/java/com/google/android/material/card/MaterialCardViewHelper.java
+++ b/lib/java/com/google/android/material/card/MaterialCardViewHelper.java
@@ -19,7 +19,10 @@ package com.google.android.material.card;
 import com.google.android.material.R;
 
 import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
-
+import static com.google.android.material.card.MaterialCardView.CHECKED_ICON_GRAVITY_BOTTOM_END;
+import static com.google.android.material.card.MaterialCardView.CHECKED_ICON_GRAVITY_BOTTOM_START;
+import static com.google.android.material.card.MaterialCardView.CHECKED_ICON_GRAVITY_TOP_END;
+import static com.google.android.material.card.MaterialCardView.CHECKED_ICON_GRAVITY_TOP_START;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -46,6 +49,7 @@ import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.StyleRes;
 import androidx.cardview.widget.CardView;
+import com.google.android.material.card.MaterialCardView.CheckedIconGravity;
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.resources.MaterialResources;
 import com.google.android.material.ripple.RippleUtils;
@@ -99,6 +103,7 @@ class MaterialCardViewHelper {
 
   @Dimension private final int checkedIconMargin;
   @Dimension private final int checkedIconSize;
+  @CheckedIconGravity private int checkedIconGravity;
   @Dimension private int strokeWidth;
 
   // If card is clickable, this is the clickableForegroundDrawable otherwise it draws the stroke.
@@ -165,6 +170,8 @@ class MaterialCardViewHelper {
     setCheckedIcon(
         MaterialResources.getDrawable(
             materialCardView.getContext(), attributes, R.styleable.MaterialCardView_checkedIcon));
+    checkedIconGravity =attributes.getInteger(
+        R.styleable.MaterialCardView_checkedIconGravity, CHECKED_ICON_GRAVITY_TOP_END);
 
     rippleColor =
         MaterialResources.getColorStateList(
@@ -399,15 +406,29 @@ class MaterialCardViewHelper {
 
   void onMeasure(int measuredWidth, int measuredHeight) {
     if (clickableForegroundDrawable != null) {
-      int left = measuredWidth - checkedIconMargin - checkedIconSize;
+      int left = checkedIconMargin;
       int bottom = measuredHeight - checkedIconMargin - checkedIconSize;
+
+      if (isCheckedIconEnd()) {
+        left = measuredWidth - checkedIconMargin - checkedIconSize;
+      }
+      if (isCheckedIconBottom()){
+        bottom = checkedIconMargin;
+      }
       boolean isPreLollipop = VERSION.SDK_INT < VERSION_CODES.LOLLIPOP;
       if (isPreLollipop || materialCardView.getUseCompatPadding()) {
         bottom -= (int) Math.ceil(2f * calculateVerticalBackgroundPadding());
         left -= (int) Math.ceil(2f * calculateHorizontalBackgroundPadding());
       }
 
-      int right = checkedIconMargin;
+      int right = measuredWidth - checkedIconMargin - checkedIconSize;
+      if (isCheckedIconEnd()){
+        right = checkedIconMargin;
+      }
+      int top = checkedIconMargin;
+      if (isCheckedIconBottom()){
+        top = measuredHeight - checkedIconMargin - checkedIconSize;
+      }
       if (ViewCompat.getLayoutDirection(materialCardView) == ViewCompat.LAYOUT_DIRECTION_RTL) {
         // swap left and right
         int tmp = right;
@@ -416,7 +437,7 @@ class MaterialCardViewHelper {
       }
 
       clickableForegroundDrawable.setLayerInset(
-          CHECKED_ICON_LAYER_INDEX, left, checkedIconMargin /* top */, right, bottom);
+          CHECKED_ICON_LAYER_INDEX, left, top /* top */, right, bottom);
     }
   }
 
@@ -646,4 +667,30 @@ class MaterialCardViewHelper {
   private MaterialShapeDrawable createForegroundShapeDrawable() {
     return new MaterialShapeDrawable(shapeAppearanceModel);
   }
+
+  @CheckedIconGravity
+  int getCheckedIconGravity() {
+    return checkedIconGravity;
+  }
+
+  void setCheckedIconGravity(@CheckedIconGravity int checkedIconGravity) {
+    this.checkedIconGravity = checkedIconGravity;
+  }
+
+  private boolean isCheckedIconStart() {
+    return checkedIconGravity == CHECKED_ICON_GRAVITY_TOP_START || checkedIconGravity == CHECKED_ICON_GRAVITY_BOTTOM_START;
+  }
+
+  private boolean isCheckedIconEnd() {
+    return checkedIconGravity == CHECKED_ICON_GRAVITY_TOP_END || checkedIconGravity == CHECKED_ICON_GRAVITY_BOTTOM_END;
+  }
+
+  private boolean isCheckedIconTop() {
+    return checkedIconGravity == CHECKED_ICON_GRAVITY_TOP_START || checkedIconGravity == CHECKED_ICON_GRAVITY_TOP_END;
+  }
+
+  private  boolean isCheckedIconBottom() {
+    return checkedIconGravity == CHECKED_ICON_GRAVITY_BOTTOM_START || checkedIconGravity == CHECKED_ICON_GRAVITY_BOTTOM_END;
+  }
+
 }

--- a/lib/java/com/google/android/material/card/MaterialCardViewHelper.java
+++ b/lib/java/com/google/android/material/card/MaterialCardViewHelper.java
@@ -170,7 +170,7 @@ class MaterialCardViewHelper {
     setCheckedIcon(
         MaterialResources.getDrawable(
             materialCardView.getContext(), attributes, R.styleable.MaterialCardView_checkedIcon));
-    checkedIconGravity =attributes.getInteger(
+    checkedIconGravity = attributes.getInteger(
         R.styleable.MaterialCardView_checkedIconGravity, CHECKED_ICON_GRAVITY_TOP_END);
 
     rippleColor =
@@ -406,29 +406,18 @@ class MaterialCardViewHelper {
 
   void onMeasure(int measuredWidth, int measuredHeight) {
     if (clickableForegroundDrawable != null) {
-      int left = checkedIconMargin;
-      int bottom = measuredHeight - checkedIconMargin - checkedIconSize;
+      int left = isCheckedIconEnd() ? measuredWidth - checkedIconMargin - checkedIconSize : checkedIconMargin;
+      int bottom = isCheckedIconBottom() ? checkedIconMargin : measuredHeight - checkedIconMargin - checkedIconSize;
 
-      if (isCheckedIconEnd()) {
-        left = measuredWidth - checkedIconMargin - checkedIconSize;
-      }
-      if (isCheckedIconBottom()){
-        bottom = checkedIconMargin;
-      }
       boolean isPreLollipop = VERSION.SDK_INT < VERSION_CODES.LOLLIPOP;
       if (isPreLollipop || materialCardView.getUseCompatPadding()) {
         bottom -= (int) Math.ceil(2f * calculateVerticalBackgroundPadding());
         left -= (int) Math.ceil(2f * calculateHorizontalBackgroundPadding());
       }
 
-      int right = measuredWidth - checkedIconMargin - checkedIconSize;
-      if (isCheckedIconEnd()){
-        right = checkedIconMargin;
-      }
-      int top = checkedIconMargin;
-      if (isCheckedIconBottom()){
-        top = measuredHeight - checkedIconMargin - checkedIconSize;
-      }
+      int right = isCheckedIconEnd() ? checkedIconMargin : measuredWidth - checkedIconMargin - checkedIconSize;
+      int top = isCheckedIconBottom() ? measuredHeight - checkedIconMargin - checkedIconSize : checkedIconMargin;
+
       if (ViewCompat.getLayoutDirection(materialCardView) == ViewCompat.LAYOUT_DIRECTION_RTL) {
         // swap left and right
         int tmp = right;
@@ -692,5 +681,4 @@ class MaterialCardViewHelper {
   private  boolean isCheckedIconBottom() {
     return checkedIconGravity == CHECKED_ICON_GRAVITY_BOTTOM_START || checkedIconGravity == CHECKED_ICON_GRAVITY_BOTTOM_END;
   }
-
 }

--- a/lib/java/com/google/android/material/card/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/card/res/values/attrs.xml
@@ -32,6 +32,17 @@
     <attr name="checkedIcon"/>
     <!-- Tint color for the checked icon. -->
     <attr name="checkedIconTint"/>
+    <!-- Specifies how the checked icon should be positioned. -->
+    <attr name="checkedIconGravity">
+      <!-- Push icon to the top|start of the card. -->
+      <flag name="TOP_START" value="0x1"/>
+      <!--  Push icon to the bottom|start of the card. -->
+      <flag name="BOTTOM_START" value="0x2"/>
+      <!-- Push icon to the top|end of the card. -->
+      <flag name="TOP_END" value="0x3"/>
+      <!-- Push icon to the bottom|end of the card. -->
+      <flag name="BOTTOM_END" value="0x4"/>
+    </attr>
     <!-- Ripple color for the Card. -->
     <attr name="rippleColor"/>
     <!-- State when a Card is being dragged. -->


### PR DESCRIPTION
Currently the checkedIcon in the `MaterialCardView` is positioned on the top|end corner.
With this PR is possible to configure the `checkedIconGravity`.

<img width="269" alt="top_start" src="https://user-images.githubusercontent.com/2583078/91978343-39a5e380-ed24-11ea-8d7b-02e4fea6963c.png">
<img width="271" alt="bottom_start" src="https://user-images.githubusercontent.com/2583078/91978334-37438980-ed24-11ea-947e-4c2a54de594c.png">
<img width="272" alt="top_end" src="https://user-images.githubusercontent.com/2583078/91978338-3874b680-ed24-11ea-90a5-b8c8bd0ccd21.png">
<img width="270" alt="bottom_end" src="https://user-images.githubusercontent.com/2583078/91978340-390d4d00-ed24-11ea-90b9-32cb8675b05f.png">

It preserves the current default behavior.

