### PR TITLE
[MaterialButton] Added IconOnly style

### DIFF
--- a/catalog/java/io/material/catalog/button/res/layout/cat_buttons_fragment.xml
+++ b/catalog/java/io/material/catalog/button/res/layout/cat_buttons_fragment.xml
@@ -158,6 +158,70 @@
         app:icon="@drawable/ic_dialogs_24px"
         app:iconGravity="textTop" />
 
+      <TextView
+        android:textStyle="bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:text="@string/cat_btn_icon_only_text"
+        android:textSize="16sp"/>
+
+      <Button
+        style="@style/Widget.MaterialComponents.Button.IconOnly"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/cat_btn_icon_only_text"
+        app:icon="@drawable/ic_add_24px"
+         />
+
+      <TextView
+        android:textStyle="bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:text="@string/cat_unelevated_btn_icon_only_text"
+        android:textSize="16sp"/>
+
+      <Button
+        style="@style/Widget.MaterialComponents.Button.UnelevatedButton.IconOnly"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/cat_unelevated_btn_icon_only_text"
+        app:icon="@drawable/ic_add_24px"
+        />
+
+      <TextView
+        android:textStyle="bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:text="@string/cat_text_btn_icon_only_text"
+        android:textSize="16sp"/>
+
+      <Button
+        style="@style/Widget.MaterialComponents.Button.TextButton.IconOnly"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/cat_text_btn_icon_only_text"
+        app:icon="@drawable/ic_add_24px"
+        />
+
+      <TextView
+        android:textStyle="bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:text="@string/cat_outlined_btn_icon_only_text"
+        android:textSize="16sp"/>
+
+      <Button
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton.IconOnly"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/cat_outlined_btn_icon_only_text"
+        app:icon="@drawable/ic_add_24px"
+        />
+
       <com.google.android.material.switchmaterial.SwitchMaterial
           android:id="@+id/cat_button_enabled_switch"
           android:layout_width="wrap_content"

--- a/catalog/java/io/material/catalog/button/res/layout/cat_buttons_toggle_group_fragment.xml
+++ b/catalog/java/io/material/catalog/button/res/layout/cat_buttons_toggle_group_fragment.xml
@@ -101,46 +101,38 @@
         android:id="@+id/icon_only_group"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
+
       <Button
-          style="?attr/materialButtonOutlinedStyle"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:minWidth="@dimen/mtrl_min_touch_target_size"
-          android:contentDescription="@string/cat_icon_button_label_paint_bucket"
-          app:icon="@drawable/ic_colors_24px"
-          app:iconPadding="0dp"/>
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton.IconOnly"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/cat_icon_button_label_paint_bucket"
+        app:icon="@drawable/ic_colors_24px" />
       <Button
-          style="?attr/materialButtonOutlinedStyle"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:minWidth="@dimen/mtrl_min_touch_target_size"
-          android:contentDescription="@string/cat_icon_button_label_plus"
-          app:icon="@drawable/ic_fab_24px"
-          app:iconPadding="0dp"/>
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton.IconOnly"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/cat_icon_button_label_plus"
+        app:icon="@drawable/ic_fab_24px"
+        app:iconPadding="0dp"/>
       <Button
-          style="?attr/materialButtonOutlinedStyle"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:minWidth="@dimen/mtrl_min_touch_target_size"
-          android:contentDescription="@string/cat_icon_button_label_components"
-          app:icon="@drawable/ic_components_24px"
-          app:iconPadding="0dp"/>
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton.IconOnly"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/cat_icon_button_label_components"
+        app:icon="@drawable/ic_components_24px" />
       <Button
-          style="?attr/materialButtonOutlinedStyle"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:minWidth="@dimen/mtrl_min_touch_target_size"
-          android:contentDescription="@string/cat_icon_button_label_accelerator"
-          app:icon="@drawable/ic_accelerator_24px"
-          app:iconPadding="0dp"/>
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton.IconOnly"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/cat_icon_button_label_accelerator"
+        app:icon="@drawable/ic_accelerator_24px" />
       <Button
-          style="?attr/materialButtonOutlinedStyle"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:minWidth="@dimen/mtrl_min_touch_target_size"
-          android:contentDescription="@string/cat_icon_button_label_dialog"
-          app:icon="@drawable/ic_dialogs_24px"
-          app:iconPadding="0dp"/>
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton.IconOnly"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/cat_icon_button_label_dialog"
+        app:icon="@drawable/ic_dialogs_24px" />
     </com.google.android.material.button.MaterialButtonToggleGroup>
 
     <com.google.android.material.switchmaterial.SwitchMaterial

--- a/catalog/java/io/material/catalog/button/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/button/res/values/strings.xml
@@ -42,6 +42,11 @@
   <string name="cat_button_clicked">Button clicked</string>
   <string name="cat_snackbar_action_button_text">Done</string>
 
+  <string name="cat_btn_icon_only_text">Icon only Material button</string>
+  <string name="cat_unelevated_btn_icon_only_text">Icon only Unelevated button</string>
+  <string name="cat_text_btn_icon_only_text">Icon only Text button</string>
+  <string name="cat_outlined_btn_icon_only_text">Icon only utlined button</string>
+
   <string name="cat_single_select">Single-select</string>
   <string name="cat_multi_select">Multi-select</string>
   <string name="cat_icon_only">Icon only</string>

--- a/lib/java/com/google/android/material/button/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/button/res-public/values/public.xml
@@ -34,5 +34,9 @@
   <public name="Widget.MaterialComponents.Button.OutlinedButton" type="style"/>
   <public name="Widget.MaterialComponents.Button.TextButton.Dialog" type="style"/>
   <public name="Widget.MaterialComponents.Button.TextButton.Dialog.Flush" type="style"/>
+  <public name="Widget.MaterialComponents.Button.IconOnly" type="style"/>
+  <public name="Widget.MaterialComponents.Button.UnelevatedButton.IconOnly" type="style"/>
+  <public name="Widget.MaterialComponents.Button.TextButton.IconOnly" type="style"/>
+  <public name="Widget.MaterialComponents.Button.OutlinedButton.IconOnly" type="style"/>
 </resources>
 

--- a/lib/java/com/google/android/material/button/res/values/dimens.xml
+++ b/lib/java/com/google/android/material/button/res/values/dimens.xml
@@ -25,7 +25,10 @@
   <dimen name="mtrl_btn_text_btn_padding_left">8dp</dimen>
   <dimen name="mtrl_btn_text_btn_padding_right">8dp</dimen>
   <dimen name="mtrl_btn_icon_btn_padding_left">12dp</dimen>
+  <dimen name="mtrl_btn_icon_only_padding_left">12dp</dimen>
 
+  <dimen name="mtrl_btn_icon_only_min_width">48dp</dimen>
+  <dimen name="mtrl_btn_icon_only_min_height">48dp</dimen>
   <dimen name="mtrl_btn_corner_radius">4dp</dimen>
 
   <dimen name="mtrl_btn_pressed_z">6dp</dimen>

--- a/lib/java/com/google/android/material/button/res/values/styles.xml
+++ b/lib/java/com/google/android/material/button/res/values/styles.xml
@@ -119,4 +119,32 @@
     <!-- Icon text button has the same padding as a regular text button -->
   </style>
 
+  <style name="Widget.MaterialComponents.Button.IconOnly">
+    <item name="iconPadding">0dp</item>
+    <item name="android:insetTop">0dp</item>
+    <item name="android:insetBottom">0dp</item>
+    <item name="android:paddingLeft">@dimen/mtrl_btn_icon_only_padding_left</item>
+    <item name="android:paddingRight">@dimen/mtrl_btn_icon_only_padding_left</item>
+    <item name="android:minWidth">@dimen/mtrl_btn_icon_only_min_width</item>
+    <item name="android:minHeight">@dimen/mtrl_btn_icon_only_min_height</item>
+    <item name="iconGravity">textStart</item>
+  </style>
+
+  <style name="Widget.MaterialComponents.Button.UnelevatedButton.IconOnly" parent="Widget.MaterialComponents.Button.IconOnly">
+    <item name="android:stateListAnimator" tools:ignore="NewApi">@animator/mtrl_btn_unelevated_state_list_anim</item>
+    <item name="elevation">0dp</item>
+  </style>
+
+  <style name="Widget.MaterialComponents.Button.TextButton.IconOnly" parent="Widget.MaterialComponents.Button.UnelevatedButton.IconOnly">
+    <item name="android:textColor">@color/mtrl_text_btn_text_color_selector</item>
+    <item name="iconTint">@color/mtrl_text_btn_text_color_selector</item>
+    <item name="backgroundTint">@color/mtrl_btn_text_btn_bg_color_selector</item>
+    <item name="rippleColor">@color/mtrl_btn_text_btn_ripple_color</item>
+  </style>
+
+  <style name="Widget.MaterialComponents.Button.OutlinedButton.IconOnly" parent="Widget.MaterialComponents.Button.TextButton.IconOnly">
+    <item name="strokeColor">@color/mtrl_btn_stroke_color_selector</item>
+    <item name="strokeWidth">@dimen/mtrl_btn_stroke_size</item>
+  </style>
+
 </resources>


### PR DESCRIPTION
It covers the point 2. of #1283.

Added
- `Widget.MaterialComponents.Button.IconOnly`
- `Widget.MaterialComponents.Button.UnelevatedButton.IconOnly`
- `Widget.MaterialComponents.Button.OutlinedButton.IconOnly`
- `Widget.MaterialComponents.Button.TextButton.IconOnly`

Updated the catalog demo:
<img width="255" alt="Schermata 2020-09-06 alle 20 00 03" src="https://user-images.githubusercontent.com/2583078/92332182-fd53e980-f07b-11ea-9d09-ed26537a943b.png">
<img width="240" alt="Schermata 2020-09-06 alle 20 00 20" src="https://user-images.githubusercontent.com/2583078/92332181-fc22bc80-f07b-11ea-9546-2eb902b59ba1.png">
