### PR TITLE
[Snackbar] Changed dimens according to spec

### DIFF
--- a/lib/java/com/google/android/material/button/res/values/dimens.xml
+++ b/lib/java/com/google/android/material/button/res/values/dimens.xml
@@ -49,4 +49,6 @@
 
   <item name="mtrl_btn_letter_spacing" format="float" type="dimen">0.07</item>
 
+  <dimen name="mtrl_btn_snackbar_margin_horizontal">8dp</dimen>
+
 </resources>

--- a/lib/java/com/google/android/material/button/res/values/styles.xml
+++ b/lib/java/com/google/android/material/button/res/values/styles.xml
@@ -84,6 +84,8 @@
   <!-- Button style to show in the Snackbar component. -->
   <style name="Widget.MaterialComponents.Button.TextButton.Snackbar">
     <item name="android:textColor">?attr/colorPrimary</item>
+    <item name="android:layout_marginLeft">@dimen/mtrl_btn_snackbar_margin_horizontal</item>
+    <item name="android:layout_marginRight">@dimen/mtrl_btn_snackbar_margin_horizontal</item>
   </style>
 
   <style name="Widget.MaterialComponents.Button.OutlinedButton" parent="Widget.MaterialComponents.Button.TextButton">

--- a/lib/java/com/google/android/material/snackbar/res/layout/mtrl_layout_snackbar_include.xml
+++ b/lib/java/com/google/android/material/snackbar/res/layout/mtrl_layout_snackbar_include.xml
@@ -35,8 +35,6 @@
     style="?attr/snackbarButtonStyle"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/design_snackbar_extra_spacing_horizontal"
-    android:layout_marginLeft="@dimen/design_snackbar_extra_spacing_horizontal"
     android:layout_gravity="center_vertical|right|end"
     android:minWidth="48dp"
     android:visibility="gone"/>

--- a/lib/java/com/google/android/material/snackbar/res/values/dimens.xml
+++ b/lib/java/com/google/android/material/snackbar/res/values/dimens.xml
@@ -22,6 +22,7 @@
   <dimen name="design_snackbar_background_corner_radius">0dp</dimen>
 
   <dimen name="design_snackbar_padding_horizontal">12dp</dimen>
+  <dimen name="mtrl_snackbar_padding_horizontal">16dp</dimen>
 
   <!-- Extra spacing between the action and message views -->
   <dimen name="design_snackbar_extra_spacing_horizontal">0dp</dimen>

--- a/lib/java/com/google/android/material/snackbar/res/values/styles.xml
+++ b/lib/java/com/google/android/material/snackbar/res/values/styles.xml
@@ -38,6 +38,8 @@
          will be used, which supports the Material color theming attributes. -->
     <item name="android:background">@null</item>
     <item name="android:layout_margin">@dimen/mtrl_snackbar_margin</item>
+    <item name="android:paddingLeft">0dp</item>
+    <item name="android:paddingRight">0dp</item>
     <item name="animationMode">fade</item>
     <item name="backgroundOverlayColorAlpha">@dimen/mtrl_snackbar_background_overlay_color_alpha</item>
     <item name="actionTextColorAlpha">@dimen/mtrl_snackbar_action_text_color_alpha</item>
@@ -57,8 +59,8 @@
     <item name="android:textColor">?attr/colorSurface</item>
     <item name="android:paddingTop">@dimen/design_snackbar_padding_vertical</item>
     <item name="android:paddingBottom">@dimen/design_snackbar_padding_vertical</item>
-    <item name="android:paddingLeft">@dimen/design_snackbar_padding_horizontal</item>
-    <item name="android:paddingRight">@dimen/design_snackbar_padding_horizontal</item>
+    <item name="android:paddingLeft">@dimen/mtrl_snackbar_padding_horizontal</item>
+    <item name="android:paddingRight">@dimen/mtrl_snackbar_padding_horizontal</item>
   </style>
 
 </resources>


### PR DESCRIPTION
According to the spec:

<img width="508" alt="Schermata 2020-09-12 alle 00 54 39" src="https://user-images.githubusercontent.com/2583078/92979317-8e6afc00-f492-11ea-97a6-5f1c3525ad99.png">

Currently:

- The text has a padding of `12dp` from the `SnackbarContentLayout`  inherited from `Widget.Design.Snackbar` + `12dp` from `Widget.MaterialComponents.Snackbar.TextView`.
- The action button has a padding of `12dp` from the `SnackbarContentLayout`.

<img width="440" alt="Schermata 2020-09-12 alle 00 41 31" src="https://user-images.githubusercontent.com/2583078/92979297-83b06700-f492-11ea-9390-270b57ef8e2c.png">

With this PR:

<img width="314" alt="Schermata 2020-09-12 alle 00 26 32" src="https://user-images.githubusercontent.com/2583078/92979302-84e19400-f492-11ea-99c3-1466ae621e88.png">

It can be tested with the demo catalog.