### PR TITLE
[MaterialDatePicker] Changed the header toggle to a MaterialButton

### DIFF
--- a/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
@@ -50,6 +50,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.dialog.InsetDialogOnTouchListener;
 import com.google.android.material.internal.CheckableImageButton;
 import com.google.android.material.resources.MaterialAttributes;
@@ -125,7 +126,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
   @InputMode private int inputMode;
 
   private TextView headerSelectionText;
-  private CheckableImageButton headerToggleButton;
+  private MaterialButton headerToggleButton;
   @Nullable private MaterialShapeDrawable background;
   private Button confirmButton;
 
@@ -360,7 +361,7 @@ public final class MaterialDatePicker<S> extends DialogFragment {
 
   private void initHeaderToggle(Context context) {
     headerToggleButton.setTag(TOGGLE_BUTTON_TAG);
-    headerToggleButton.setImageDrawable(createHeaderToggleDrawable(context));
+    headerToggleButton.setIcon(createHeaderToggleDrawable(context));
     headerToggleButton.setChecked(inputMode != INPUT_MODE_CALENDAR);
 
     // By default, CheckableImageButton adds a delegate that reads checked state.
@@ -374,14 +375,13 @@ public final class MaterialDatePicker<S> extends DialogFragment {
             // Update confirm button in case in progress selection has been reset
             confirmButton.setEnabled(dateSelector.isSelectionComplete());
 
-            headerToggleButton.toggle();
             updateToggleContentDescription(headerToggleButton);
             startPickerFragment();
           }
         });
   }
 
-  private void updateToggleContentDescription(@NonNull CheckableImageButton toggle) {
+  private void updateToggleContentDescription(@NonNull MaterialButton toggle) {
     String contentDescription =
         headerToggleButton.isChecked()
             ? toggle.getContext().getString(R.string.mtrl_picker_toggle_to_calendar_input_mode)

--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_toggle.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_toggle.xml
@@ -15,12 +15,18 @@
      limitations under the License.
 -->
 
-<com.google.android.material.internal.CheckableImageButton
+<com.google.android.material.button.MaterialButton
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/mtrl_picker_header_toggle"
     style="?attr/materialCalendarHeaderToggleButton"
+    android:checkable="true"
     android:layout_width="@dimen/mtrl_min_touch_target_size"
     android:layout_height="@dimen/mtrl_min_touch_target_size"
     android:layout_marginBottom="@dimen/mtrl_calendar_header_toggle_margin_bottom"
     android:layout_marginTop="@dimen/mtrl_calendar_header_toggle_margin_top"
+    android:insetTop="0dp"
+    android:insetBottom="0dp"
+    android:padding="12dp"
+    app:rippleColor="@color/mtrl_btn_ripple_color"
     android:layout_gravity="bottom|end"/>

--- a/lib/java/com/google/android/material/datepicker/res/values/styles.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values/styles.xml
@@ -91,9 +91,8 @@
     <item name="rippleColor">@color/mtrl_btn_ripple_color</item>
   </style>
 
-  <style name="Widget.MaterialComponents.MaterialCalendar.HeaderToggleButton" parent="Widget.AppCompat.ImageButton">
-    <item name="android:background">?attr/actionBarItemBackground</item>
-    <item name="android:tint">?attr/colorOnPrimary</item>
+  <style name="Widget.MaterialComponents.MaterialCalendar.HeaderToggleButton" parent="Widget.MaterialComponents.Button.TextButton">
+    <item name="iconTint">?attr/colorOnPrimary</item>
   </style>
 
   <style name="Widget.MaterialComponents.MaterialCalendar.DayTextView" parent="Widget.AppCompat.TextView">


### PR DESCRIPTION
Currently the header toggle is an `ImageButton` with a rounded ripple.

<img width="316" alt="Schermata 2020-09-12 alle 18 16 54" src="https://user-images.githubusercontent.com/2583078/92999802-2bc24080-f524-11ea-881a-26bfeecb92bc.png">

With this PR the header toggle is a `MaterialButton` with the same behavior of the cancel button on top in the header with a ripple based on the shape definition.

<img width="320" alt="Schermata 2020-09-12 alle 10 34 08" src="https://user-images.githubusercontent.com/2583078/92999805-3086f480-f524-11ea-8768-31f2a7e2220a.png">

<img width="316" alt="Schermata 2020-09-12 alle 18 23 45" src="https://user-images.githubusercontent.com/2583078/92999933-1f8ab300-f525-11ea-8b05-1130e4218b74.png">


<img width="316" alt="Schermata 2020-09-12 alle 18 25 36" src="https://user-images.githubusercontent.com/2583078/92999965-5e206d80-f525-11ea-8ea9-50d4dce06931.png">




It can be tested with the demo catalog.