### PR TITLE
[TimePicker] Added title options to builder

### DIFF
--- a/catalog/java/io/material/catalog/timepicker/TimePickerMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/timepicker/TimePickerMainDemoFragment.java
@@ -56,6 +56,8 @@ public class TimePickerMainDemoFragment extends DemoFragment {
     MaterialButtonToggleGroup timeFormatToggle = view.findViewById(R.id.time_format_toggle);
     clockFormat = TimeFormat.CLOCK_12H;
     timeFormatToggle.check(R.id.time_format_12h);
+    MaterialButtonToggleGroup timeTitleToggle = view.findViewById(R.id.time_title_toggle);
+    timeTitleToggle.check(R.id.time_title_standard);
 
     timeFormatToggle.addOnButtonCheckedListener(
         (group, checkedId, isChecked) -> {
@@ -74,12 +76,16 @@ public class TimePickerMainDemoFragment extends DemoFragment {
         return;
       }
 
-      MaterialTimePicker materialTimePicker = new MaterialTimePicker.Builder()
+      MaterialTimePicker.Builder builder = new MaterialTimePicker.Builder()
           .setTimeFormat(clockFormat)
           .setHour(hour)
-          .setMinute(minute)
-          .build();
+          .setMinute(minute);
 
+      if (timeTitleToggle.getCheckedButtonId() == R.id.time_title_custom) {
+        builder.setTitleText(R.string.cat_time_picker_demo_title_custom);
+      }
+
+      MaterialTimePicker materialTimePicker = builder.build();
       materialTimePicker.show(requireFragmentManager(), "fragment_tag");
 
       materialTimePicker.addOnPositiveButtonClickListener(dialog -> {

--- a/catalog/java/io/material/catalog/timepicker/res/layout/time_picker_main_demo.xml
+++ b/catalog/java/io/material/catalog/timepicker/res/layout/time_picker_main_demo.xml
@@ -45,39 +45,103 @@
       app:layout_constraintStart_toEndOf="@id/timepicker_button"
       app:layout_constraintTop_toTopOf="@id/timepicker_button" />
 
-    <com.google.android.material.button.MaterialButtonToggleGroup
-      android:id="@+id/time_format_toggle"
-      android:layout_width="wrap_content"
+    <LinearLayout
+      android:id="@+id/time_timeformat_container"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_margin="16dp"
       android:orientation="horizontal"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
-      app:selectionRequired="true"
-      app:singleSelection="true">
-      <Button
-        android:id="@+id/time_format_12h"
-        style="?attr/materialButtonOutlinedStyle"
+      app:layout_constraintTop_toTopOf="parent">
+
+      <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/time_format_12" />
+        android:layout_gravity="center_vertical"
+        android:text="@string/cat_time_picker_timeformat"/>
 
-      <Button
-        android:id="@+id/time_format_24h"
-        style="?attr/materialButtonOutlinedStyle"
+      <com.google.android.material.button.MaterialButtonToggleGroup
+        android:id="@+id/time_format_toggle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/time_format_24" />
+        android:layout_marginLeft="4dp"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:selectionRequired="true"
+        app:singleSelection="true">
 
-      <Button
-        android:id="@+id/time_format_system"
-        style="?attr/materialButtonOutlinedStyle"
+        <Button
+          android:id="@+id/time_format_12h"
+          style="?attr/materialButtonOutlinedStyle"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/time_format_12" />
+
+        <Button
+          android:id="@+id/time_format_24h"
+          style="?attr/materialButtonOutlinedStyle"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/time_format_24" />
+
+        <Button
+          android:id="@+id/time_format_system"
+          style="?attr/materialButtonOutlinedStyle"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/time_format_system" />
+
+      </com.google.android.material.button.MaterialButtonToggleGroup>
+
+    </LinearLayout>
+
+    <LinearLayout
+      android:id="@+id/time_title_container"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="16dp"
+      android:orientation="horizontal"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/time_timeformat_container">
+
+      <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/time_format_system" />
+        android:layout_gravity="center_vertical"
+        android:text="@string/cat_time_picker_title" />
 
-    </com.google.android.material.button.MaterialButtonToggleGroup>
+      <com.google.android.material.button.MaterialButtonToggleGroup
+        android:id="@+id/time_title_toggle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="4dp"
+        android:orientation="horizontal"
+        app:selectionRequired="true"
+        app:singleSelection="true">
+
+        <Button
+          android:id="@+id/time_title_standard"
+          style="?attr/materialButtonOutlinedStyle"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/cat_time_picker_title_standard" />
+
+        <Button
+          android:id="@+id/time_title_custom"
+          style="?attr/materialButtonOutlinedStyle"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/cat_time_picker_title_custom" />
+
+
+      </com.google.android.material.button.MaterialButtonToggleGroup>
+
+    </LinearLayout>
+    >
 
     <com.google.android.material.switchmaterial.SwitchMaterial
       android:id="@+id/framework_switch"
@@ -87,7 +151,7 @@
       android:text="@string/use_framework_dialog"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/time_format_toggle" />
+      app:layout_constraintTop_toBottomOf="@+id/time_title_container" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/catalog/java/io/material/catalog/timepicker/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/timepicker/res/values/strings.xml
@@ -32,5 +32,14 @@
   <string name="time_format_12">12H</string>
   <!-- Label for an option to choose the same time format as the system [CHAR LIMIT=16] -->
   <string name="time_format_system">System</string>
-
+  <!-- Label for an option to choose the time format -->
+  <string name="cat_time_picker_timeformat">Time format</string>
+  <!-- Label for an option to choose the title -->
+  <string name="cat_time_picker_title">Picker Title</string>
+  <!-- Indicates that the picker will start with a standard title [CHAR LIMIT=25] -->
+  <string name="cat_time_picker_title_standard">Standard</string>
+  <!-- Indicates that the picker will start with a custom title [CHAR LIMIT=25] -->
+  <string name="cat_time_picker_title_custom">Custom</string>
+  <!-- Custom title for the picker -->
+  <string name="cat_time_picker_demo_title_custom">Custom title</string>
 </resources>

--- a/lib/java/com/google/android/material/timepicker/MaterialTimePicker.java
+++ b/lib/java/com/google/android/material/timepicker/MaterialTimePicker.java
@@ -25,6 +25,7 @@ import android.content.DialogInterface.OnCancelListener;
 import android.content.DialogInterface.OnDismissListener;
 import android.content.res.ColorStateList;
 import android.os.Bundle;
+import androidx.annotation.StringRes;
 import androidx.fragment.app.DialogFragment;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
@@ -33,6 +34,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
@@ -73,8 +75,12 @@ public final class MaterialTimePicker extends DialogFragment {
 
   static final String TIME_MODEL_EXTRA = "TIME_PICKER_TIME_MODEL";
   static final String INPUT_MODE_EXTRA = "TIME_PICKER_INPUT_MODE";
+  static final String TITLE_TEXT_RES_ID_EXTRA = "TIME_PICKER_TITLE_TEXT_RES_ID_KEY";
+  static final String TITLE_TEXT_EXTRA = "TIME_PICKER_TITLE_TEXT_KEY";
 
   private MaterialButton modeButton;
+  @StringRes private int titleTextResId;
+  private CharSequence titleText;
 
   @InputMode private int inputMode = INPUT_MODE_CLOCK;
 
@@ -86,6 +92,8 @@ public final class MaterialTimePicker extends DialogFragment {
     Bundle args = new Bundle();
     args.putParcelable(TIME_MODEL_EXTRA, options.time);
     args.putInt(INPUT_MODE_EXTRA, options.inputMode);
+    args.putInt(TITLE_TEXT_RES_ID_EXTRA, options.titleTextResId);
+    args.putCharSequence(TITLE_TEXT_EXTRA, options.titleText);
     fragment.setArguments(args);
     return fragment;
   }
@@ -138,6 +146,8 @@ public final class MaterialTimePicker extends DialogFragment {
     super.onSaveInstanceState(bundle);
     bundle.putParcelable(TIME_MODEL_EXTRA, time);
     bundle.putInt(INPUT_MODE_EXTRA, inputMode);
+    bundle.putInt(TITLE_TEXT_RES_ID_EXTRA, titleTextResId);
+    bundle.putCharSequence(TITLE_TEXT_EXTRA, titleText);
   }
 
   private void restoreState(@Nullable Bundle bundle) {
@@ -150,6 +160,8 @@ public final class MaterialTimePicker extends DialogFragment {
       time = new TimeModel();
     }
     inputMode = bundle.getInt(INPUT_MODE_EXTRA, INPUT_MODE_CLOCK);
+    titleTextResId = bundle.getInt(TITLE_TEXT_RES_ID_EXTRA);
+    titleText = bundle.getCharSequence(TITLE_TEXT_EXTRA);
   }
 
   @NonNull
@@ -164,6 +176,13 @@ public final class MaterialTimePicker extends DialogFragment {
     textInputView = root.findViewById(R.id.material_textinput_timepicker);
     modeButton = root.findViewById(R.id.material_timepicker_mode_button);
     updateInputMode(modeButton);
+    TextView titleTextView = root.findViewById(R.id.header_title);
+    if (titleText != null) {
+      titleTextView.setText(titleText);
+    } else {
+      titleTextView.setText(titleTextResId);
+    }
+
     MaterialButton okButton = root.findViewById(R.id.material_timepicker_ok_button);
     okButton.setOnClickListener(
         new OnClickListener() {
@@ -365,6 +384,8 @@ public final class MaterialTimePicker extends DialogFragment {
     private TimeModel time = new TimeModel();
 
     private int inputMode;
+    private int titleTextResId = 0;
+    private CharSequence titleText = null;
 
     /** Sets the input mode to start with. */
     @NonNull
@@ -397,9 +418,32 @@ public final class MaterialTimePicker extends DialogFragment {
       return this;
     }
 
+    /**
+     * Sets the text used to guide the user at the top of the picker.
+     */
+    @NonNull
+    public Builder setTitleText(@StringRes int titleTextResId) {
+      this.titleTextResId = titleTextResId;
+      this.titleText = null;
+      return this;
+    }
+
+    /**
+     * Sets the text used to guide the user at the top of the picker.
+     */
+    @NonNull
+    public Builder setTitleText(@Nullable CharSequence charSequence) {
+      this.titleText = charSequence;
+      this.titleTextResId = 0;
+      return this;
+    }
+
     /** Creates a {@link MaterialTimePicker} with the provided options. */
     @NonNull
     public MaterialTimePicker build() {
+      if (titleTextResId == 0) {
+        titleTextResId = R.string.material_timepicker_select_time;
+      }
       return MaterialTimePicker.newInstance(this);
     }
   }

--- a/lib/java/com/google/android/material/timepicker/res/layout/material_timepicker_dialog.xml
+++ b/lib/java/com/google/android/material/timepicker/res/layout/material_timepicker_dialog.xml
@@ -31,7 +31,6 @@
     android:layout_marginTop="16dp"
     android:importantForAccessibility="no"
     android:layout_marginStart="24dp"
-    android:text="@string/material_timepicker_select_time"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
This PR adds to the `MaterialTimePicker.Builder` the options to add a custom title similar to the `MaterialDatePicker`.
I've updated the demo catalog with this option.

<img width="319" alt="Schermata 2020-09-12 alle 19 52 16" src="https://user-images.githubusercontent.com/2583078/93001722-772f1b80-f531-11ea-8640-2163a1433b9e.png">

<img width="253" alt="Schermata 2020-09-12 alle 19 44 53" src="https://user-images.githubusercontent.com/2583078/93001710-6d0d1d00-f531-11ea-898f-91d9aac0e51a.png">