### PR TITLE
[TextInputLayout] Fixed wrong position of the counter when helper or error text are removed

### DIFF
--- a/lib/java/com/google/android/material/textfield/IndicatorViewController.java
+++ b/lib/java/com/google/android/material/textfield/IndicatorViewController.java
@@ -420,7 +420,6 @@ final class IndicatorViewController {
 
     if (isCaptionView(index) && captionArea != null) {
       captionViewsAdded--;
-      setViewGroupGoneIfEmpty(captionArea, captionViewsAdded);
       captionArea.removeView(indicator);
     } else {
       indicatorArea.removeView(indicator);


### PR DESCRIPTION
It closes #1719 

When the `helperText` or the `errorText` are removed and the counter is visible, the counter view has a wrong position.

<img width="309" alt="Schermata 2020-09-15 alle 08 09 59" src="https://user-images.githubusercontent.com/2583078/93174716-bb3b3f80-f72e-11ea-9546-58f7e25b2dd8.png">

It can be replicated in many ways:

            <com.google.android.material.textfield.TextInputLayout
                android:id="@+id/til"
                app:counterEnabled="true"
                app:counterMaxLength="6"
               ...>

with:

        val textInputLayout: TextInputLayout = findViewById(R.id.til)
        textInputLayout.setEndIconOnClickListener{
            textInputLayout.isHelperTextEnabled = false
        }
        textInputLayout.isHelperTextEnabled = true

or

        val textInputLayout: TextInputLayout = findViewById(R.id.til)
        textInputLayout.isErrorEnabled = true
        textInputLayout.isErrorEnabled= false