### PR TITLE
[MaterialDatePicker] Fixed the filled range with RTL layout

### DIFF
--- a/lib/java/com/google/android/material/datepicker/MaterialCalendarGridView.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialCalendarGridView.java
@@ -16,6 +16,7 @@
 package com.google.android.material.datepicker;
 
 import com.google.android.material.R;
+import com.google.android.material.internal.ViewUtils;
 
 import static java.lang.Math.min;
 
@@ -135,7 +136,7 @@ final class MaterialCalendarGridView extends GridView {
       if (skipMonth(firstOfMonth, lastOfMonth, startItem, endItem)) {
         continue;
       }
-
+      boolean isRtl = ViewUtils.isLayoutRtl(this);
       int firstHighlightPosition;
       int rangeHighlightStart;
       if (startItem < firstOfMonth) {
@@ -143,7 +144,8 @@ final class MaterialCalendarGridView extends GridView {
         rangeHighlightStart =
             monthAdapter.isFirstInRow(firstHighlightPosition)
                 ? 0
-                : getChildAt(firstHighlightPosition - 1).getRight();
+                : !isRtl? getChildAt(firstHighlightPosition - 1).getRight():
+                    getChildAt(firstHighlightPosition - 1).getLeft();
       } else {
         dayCompute.setTimeInMillis(startItem);
         firstHighlightPosition = monthAdapter.dayToPosition(dayCompute.get(Calendar.DAY_OF_MONTH));
@@ -157,7 +159,8 @@ final class MaterialCalendarGridView extends GridView {
         rangeHighlightEnd =
             monthAdapter.isLastInRow(lastHighlightPosition)
                 ? getWidth()
-                : getChildAt(lastHighlightPosition).getRight();
+                : !isRtl? getChildAt(lastHighlightPosition).getRight():
+                    getChildAt(lastHighlightPosition).getLeft();
       } else {
         dayCompute.setTimeInMillis(endItem);
         lastHighlightPosition = monthAdapter.dayToPosition(dayCompute.get(Calendar.DAY_OF_MONTH));
@@ -172,8 +175,15 @@ final class MaterialCalendarGridView extends GridView {
         View firstView = getChildAt(firstPositionInRow);
         int top = firstView.getTop() + calendarStyle.day.getTopInset();
         int bottom = firstView.getBottom() - calendarStyle.day.getBottomInset();
-        int left = firstPositionInRow > firstHighlightPosition ? 0 : rangeHighlightStart;
-        int right = lastHighlightPosition > lastPositionInRow ? getWidth() : rangeHighlightEnd;
+        int left;
+        int right;
+        if (!isRtl){
+          left = firstPositionInRow > firstHighlightPosition ? 0 : rangeHighlightStart;
+          right = lastHighlightPosition > lastPositionInRow ? getWidth() : rangeHighlightEnd;
+        } else {
+          left = lastHighlightPosition > lastPositionInRow ? 0 : rangeHighlightEnd;
+          right = firstPositionInRow > firstHighlightPosition ? getWidth() : rangeHighlightStart;
+        }
         canvas.drawRect(left, top, right, bottom, calendarStyle.rangeFill);
       }
     }


### PR DESCRIPTION
It closes #1716. 

Currently with a RTL layout:

![93028395-001e8380-f614-11ea-8b79-59f681e1f0c5](https://user-images.githubusercontent.com/2583078/93265918-97690f80-f7a9-11ea-8940-06dbd54457dc.jpg)
 
With this PR (tested forcing the RTL layout direction in Developer options):

<img width="291" alt="Schermata 2020-09-15 alle 22 27 42" src="https://user-images.githubusercontent.com/2583078/93266190-ffb7f100-f7a9-11ea-9286-d6124fcb92c4.png">
<img width="288" alt="Schermata 2020-09-15 alle 22 27 54" src="https://user-images.githubusercontent.com/2583078/93266198-00e91e00-f7aa-11ea-9c22-6f4f59fb6fa1.png">
<img width="289" alt="Schermata 2020-09-15 alle 22 28 05" src="https://user-images.githubusercontent.com/2583078/93266201-021a4b00-f7aa-11ea-90ba-136c0e145d65.png">
