### PR TITLE
Fix travis CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - sdkmanager --list | head -15
   - mkdir "$ANDROID_HOME/licenses" || true
   - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo -e "\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license"
   - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
 
 before_script:


### PR DESCRIPTION
### Overview
This adds the missing SDK license that currently fails the CI build.

### Thanks for starting a pull request on Material Components!

#### Don't forget:

[✓ ] Identify the component the PR relates to in brackets in the title.
[ ✓] Link to GitHub issues it solves.
[ ✓] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
