### PR TITLE
[MaterialTimePicker] Fixed ClassCastException with a Bridge Theme

### DIFF
--- a/lib/java/com/google/android/material/timepicker/MaterialTimePicker.java
+++ b/lib/java/com/google/android/material/timepicker/MaterialTimePicker.java
@@ -33,6 +33,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.annotation.DrawableRes;
@@ -194,7 +195,7 @@ public final class MaterialTimePicker extends DialogFragment {
     }
 
     updateInputMode(modeButton);
-    MaterialButton okButton = root.findViewById(R.id.material_timepicker_ok_button);
+    Button okButton = root.findViewById(R.id.material_timepicker_ok_button);
     okButton.setOnClickListener(
         new OnClickListener() {
           @Override
@@ -206,7 +207,7 @@ public final class MaterialTimePicker extends DialogFragment {
           }
         });
 
-    MaterialButton cancelButton = root.findViewById(R.id.material_timepicker_cancel_button);
+    Button cancelButton = root.findViewById(R.id.material_timepicker_cancel_button);
     cancelButton.setOnClickListener(
         new OnClickListener() {
           @Override


### PR DESCRIPTION
It closes #1735.

The issue can be reproduced using a Bridge theme.
