### PR TITLE
[ShapeableImageView] Call invalidateOutline when shape is changed

### DIFF
--- a/catalog/java/io/material/catalog/imageview/res/layout/catalog_imageview.xml
+++ b/catalog/java/io/material/catalog/imageview/res/layout/catalog_imageview.xml
@@ -22,6 +22,7 @@
   android:id="@+id/main_viewGroup"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
+  android:clipChildren="false"
   android:padding="@dimen/cat_imageview_padding"
   android:orientation="vertical">
 
@@ -66,7 +67,7 @@
     app:strokeColor="?attr/colorSecondary"
     app:shapeAppearance="?attr/shapeAppearanceMediumComponent"
     app:strokeWidth="1dp"
-    app:elevation="5dp"
+    android:elevation="5dp"
     android:padding="8dp"
     app:srcCompat="@drawable/dog_image" />
 
@@ -84,8 +85,8 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:adjustViewBounds="true"
+      android:elevation="5dp"
       android:scaleType="fitXY"
-      app:elevation="5dp"
       app:shapeAppearance="@style/ShapeAppearanceImageLeft"
       app:srcCompat="@drawable/cat_image"
       app:strokeColor="?attr/colorSecondary"
@@ -98,8 +99,8 @@
       android:layout_height="match_parent"
       android:layout_weight="1"
       android:adjustViewBounds="true"
+      android:elevation="5dp"
       android:scaleType="fitXY"
-      app:elevation="5dp"
       app:shapeAppearance="@style/ShapeAppearanceImageRight"
       app:srcCompat="@drawable/cateyes_image"
       app:strokeColor="?attr/colorSecondary"

--- a/lib/java/com/google/android/material/imageview/ShapeableImageView.java
+++ b/lib/java/com/google/android/material/imageview/ShapeableImageView.java
@@ -146,6 +146,9 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
     }
     updateShapeMask(getWidth(), getHeight());
     invalidate();
+    if (VERSION.SDK_INT >= 21) {
+      invalidateOutline();
+    }
   }
 
   @NonNull


### PR DESCRIPTION
I discovered this while using the included Catalog app to look into #1489. But this PR does *not* that issue.

Previously, ShapeableImageView was not updating its shadow outline provider when its shape was changed at runtime. This would lead to shadows around the original shape while the view had the appearance of the new shape.

This could not be observed in the Catalog app, because the Catalog app was incorrectly using `app:elevation`, an invalid attribute; rather than `android:elevation`. So the views in the Catalog had no elevation at all and thus the odd elevation behavior was not visible.

This PR fixes the issue by calling `invalidateOutline` at the end of `setShapeAppearanceModel`, and applies `android:elevation` in the Catalog app to view the result.