### PR TITLE
[TextInputLayout] Fixed clear text icon hide on double click

### DIFF
--- a/lib/java/com/google/android/material/textfield/ClearTextEndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/ClearTextEndIconDelegate.java
@@ -135,13 +135,13 @@ class ClearTextEndIconDelegate extends EndIconDelegate {
 
   private void animateIcon(boolean show) {
     boolean shouldSkipAnimation = textInputLayout.isEndIconVisible() == show;
-    if (show) {
+    if (show && !iconInAnim.isRunning()) {
       iconOutAnim.cancel();
       iconInAnim.start();
       if (shouldSkipAnimation) {
         iconInAnim.end();
       }
-    } else {
+    } else if (!show) {
       iconInAnim.cancel();
       iconOutAnim.start();
       if (shouldSkipAnimation) {


### PR DESCRIPTION
Do not cancel the `iconInAnim` on showing the clear text end icon if the animation is running.
Issue is reproducible in catalog.
closes https://github.com/material-components/material-components-android/issues/721
