### PR TITLE
[Slider] Invalidate after new ColorStateList and return early if same

### DIFF
--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -1178,7 +1178,12 @@ abstract class BaseSlider<
    * @attr ref com.google.android.material.R.styleable#Slider_thumbColor
    */
   public void setThumbTintList(@NonNull ColorStateList thumbColor) {
+    if (thumbColor.equals(thumbDrawable.getFillColor())) {
+      return;
+    }
+
     thumbDrawable.setFillColor(thumbColor);
+    invalidate();
   }
 
   /**


### PR DESCRIPTION
When using the Slider component:
* Trigger invalidate() call after a new ColorStateList is applied 
* Exit early if the the fill color (ColorStateList) is the same as the currently set fill color, to avoid extra draws.

There's no issue currently filed for this, but when using the `Slider.setThumbTintList` in a project i'm working on, I noticed that the fill color doesn't **always** update when setting it - this should fix it!
