### PR TITLE
[Snapshots] Add note about required scope for accessing snapshot repo

### DIFF
--- a/docs/using-snapshot-version.md
+++ b/docs/using-snapshot-version.md
@@ -46,6 +46,24 @@ If you prefer to depend on a specific snapshot version, you can add
 all versions
 [here](https://github.com/material-components/material-components-android/packages/81484/versions)).
 
+You can also find the list of versions through the [GraphQL explorer](https://developer.github.com/v4/explorer/) with the following query:
+
+```graphql
+{
+  node(id: "MDE0OlBhY2thZ2VWZXJzaW9uMjMyNDc2OQ==") {
+    ... on PackageVersion {
+      id
+      version
+      files(last: 12, orderBy: {field: CREATED_AT, direction: ASC}) {
+        nodes {
+          name
+        }
+      }
+    }
+  }
+}
+```
+
 Alternatively, you could use
 [JitPack](https://jitpack.io/#material-components/material-components-android)
 to generate library releases based on specific commits.

--- a/docs/using-snapshot-version.md
+++ b/docs/using-snapshot-version.md
@@ -14,7 +14,7 @@ that are published daily via
 [GitHub Packages](https://help.github.com/en/packages/publishing-and-managing-packages/about-github-packages).
 
 To do so, you need to
-[create a GitHub access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token),
+[create a GitHub access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token) with the `read:packages` scope,
 and add the following to your `build.gradle` Maven repositories:
 
 ```groovy


### PR DESCRIPTION
It was unclear which scopes were required for the Personal Access Token to be used to access the snapshots maven repository. I figured it out after finally seeing a failure in the command line and trying to access the page in the browser, at which point the error told me which scope was required.

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
