### PR TITLE
[Document] Remove outdated notes about android-maven-gradle-plugin

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -33,10 +33,6 @@ the Design Library dependency as you would normally, using the version
 specified as `mdcLibraryVersion` in the library's top-level `build.gradle`
 file.
 
-Note: Do not update Gradle beyond 4.10 as the
-[android-maven-gradle-plugin](https://github.com/dcendents/android-maven-gradle-plugin)
-dependency cannot be used for Gradle 5.x.
-
 ## Useful Links
 
 -   [Getting Started](getting-started.md)


### PR DESCRIPTION
We have already migrated to Gradle 6.1 and  the android-maven-gradle-plugin has been replaced by Maven Publish plugin.
https://developer.android.com/studio/build/maven-publish-plugin

This pull request removes the outdated message on the building guidance document.