### PR TITLE
[MaterialTimePicker] Fix typo in `TextAppearance.MaterialComponents.TimePicker.Title`

### DIFF
--- a/lib/java/com/google/android/material/timepicker/res/values/styles.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values/styles.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
      Copyright 2020 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +16,7 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="NewApi">
 
-  <style name="Widget.MaterialComponents.TimePicker" parent="" >
+  <style name="Widget.MaterialComponents.TimePicker" parent="">
     <item name="shapeAppearance">?shapeAppearanceMediumComponent</item>
     <item name="keyboardIcon">@drawable/ic_keyboard_black_24dp</item>
     <item name="clockIcon">@drawable/ic_clock_black_24dp</item>
@@ -85,7 +84,7 @@
   </style>
 
   <style name="TextAppearance.MaterialComponents.TimePicker.Title" parent="TextAppearance.MaterialComponents.Overline">
-    <item name="android:textColor">@/color/material_on_surface_emphasis_medium</item>
+    <item name="android:textColor">@color/material_on_surface_emphasis_medium</item>
   </style>
 
   <style name="Widget.MaterialComponents.TimePicker.Clock" parent="">


### PR DESCRIPTION
There was a typo when setting the text color in `TextAppearance.MaterialComponents.TimePicker.Title`