### PR TITLE
[ShapeableImageView] Support contentPadding

### DIFF
--- a/catalog/java/io/material/catalog/imageview/ShapeableImageViewMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/imageview/ShapeableImageViewMainDemoFragment.java
@@ -45,9 +45,7 @@ public class ShapeableImageViewMainDemoFragment extends DemoFragment {
         layoutInflater.inflate(R.layout.catalog_imageview, viewGroup, false /* attachToRoot */);
     MaterialButtonToggleGroup toggleGroup = view.findViewById(R.id.togglegroup);
     ShapeableImageView imageView = view.findViewById(R.id.image_view);
-
     ShapeableImageView iconView = view.findViewById(R.id.icon_view);
-    iconView.setContentPadding(20, 20, 20, 20);
 
     SparseArray<ShapeAppearanceModel> shapes = new SparseArray<>();
     shapes.put(

--- a/catalog/java/io/material/catalog/imageview/ShapeableImageViewMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/imageview/ShapeableImageViewMainDemoFragment.java
@@ -46,6 +46,9 @@ public class ShapeableImageViewMainDemoFragment extends DemoFragment {
     MaterialButtonToggleGroup toggleGroup = view.findViewById(R.id.togglegroup);
     ShapeableImageView imageView = view.findViewById(R.id.image_view);
 
+    ShapeableImageView iconView = view.findViewById(R.id.icon_view);
+    iconView.setContentPadding(20, 20, 20, 20);
+
     SparseArray<ShapeAppearanceModel> shapes = new SparseArray<>();
     shapes.put(
         R.id.button_diamond,
@@ -66,10 +69,14 @@ public class ShapeableImageViewMainDemoFragment extends DemoFragment {
             return;
           }
 
+          ShapeAppearanceModel shape = shapes.get(checkedId);
+
           // Randomly makes dog wink.
           imageView.setImageResource(
               random.nextBoolean() ? R.drawable.dog_image : R.drawable.dog_image_wink);
-          imageView.setShapeAppearanceModel(shapes.get(checkedId));
+          imageView.setShapeAppearanceModel(shape);
+
+          iconView.setShapeAppearanceModel(shape);
         });
 
     return view;

--- a/catalog/java/io/material/catalog/imageview/res/layout/catalog_imageview.xml
+++ b/catalog/java/io/material/catalog/imageview/res/layout/catalog_imageview.xml
@@ -107,4 +107,16 @@
 
   </LinearLayout>
 
+  <com.google.android.material.imageview.ShapeableImageView
+    android:id="@+id/icon_view"
+    android:layout_margin="10dp"
+    android:layout_gravity="center"
+    android:layout_width="40dp"
+    android:layout_height="40dp"
+    android:background="?colorSecondary"
+    android:elevation="2dp"
+    app:shapeAppearance="?shapeAppearanceSmallComponent"
+    app:srcCompat="@drawable/ic_pets_24dp"
+    app:tint="?colorOnSecondary" />
+
 </LinearLayout>

--- a/catalog/java/io/material/catalog/imageview/res/layout/catalog_imageview.xml
+++ b/catalog/java/io/material/catalog/imageview/res/layout/catalog_imageview.xml
@@ -22,6 +22,7 @@
   android:id="@+id/main_viewGroup"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
+  android:layoutDirection="inherit"
   android:padding="@dimen/cat_imageview_padding"
   android:orientation="vertical">
 
@@ -115,6 +116,7 @@
     android:layout_height="40dp"
     android:background="?colorSecondary"
     android:elevation="2dp"
+    app:contentPadding="8dp"
     app:shapeAppearance="?shapeAppearanceSmallComponent"
     app:srcCompat="@drawable/ic_pets_24dp"
     app:tint="?colorOnSecondary" />

--- a/catalog/java/io/material/catalog/windowpreferences/res/drawable/ic_pets_24dp.xml
+++ b/catalog/java/io/material/catalog/windowpreferences/res/drawable/ic_pets_24dp.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M4.5,9.5m-2.5,0a2.5,2.5 0,1 1,5 0a2.5,2.5 0,1 1,-5 0"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9,5.5m-2.5,0a2.5,2.5 0,1 1,5 0a2.5,2.5 0,1 1,-5 0"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15,5.5m-2.5,0a2.5,2.5 0,1 1,5 0a2.5,2.5 0,1 1,-5 0"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19.5,9.5m-2.5,0a2.5,2.5 0,1 1,5 0a2.5,2.5 0,1 1,-5 0"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M17.34,14.86c-0.87,-1.02 -1.6,-1.89 -2.48,-2.91 -0.46,-0.54 -1.05,-1.08 -1.75,-1.32 -0.11,-0.04 -0.22,-0.07 -0.33,-0.09 -0.25,-0.04 -0.52,-0.04 -0.78,-0.04s-0.53,0 -0.79,0.05c-0.11,0.02 -0.22,0.05 -0.33,0.09 -0.7,0.24 -1.28,0.78 -1.75,1.32 -0.87,1.02 -1.6,1.89 -2.48,2.91 -1.31,1.31 -2.92,2.76 -2.62,4.79 0.29,1.02 1.02,2.03 2.33,2.32 0.73,0.15 3.06,-0.44 5.54,-0.44h0.18c2.48,0 4.81,0.58 5.54,0.44 1.31,-0.29 2.04,-1.31 2.33,-2.32 0.31,-2.04 -1.3,-3.49 -2.61,-4.8z"/>
+</vector>

--- a/lib/java/com/google/android/material/imageview/ShapeableImageView.java
+++ b/lib/java/com/google/android/material/imageview/ShapeableImageView.java
@@ -37,8 +37,6 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
-import androidx.appcompat.content.res.AppCompatResources;
-import androidx.appcompat.widget.AppCompatImageView;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewOutlineProvider;
@@ -47,6 +45,9 @@ import androidx.annotation.DimenRes;
 import androidx.annotation.Dimension;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.appcompat.widget.AppCompatImageView;
 import com.google.android.material.resources.MaterialResources;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.ShapeAppearanceModel;
@@ -72,6 +73,11 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   private ShapeAppearanceModel shapeAppearanceModel;
   @Dimension private float strokeWidth;
   private Path maskPath;
+
+  @Dimension private int leftContentPadding;
+  @Dimension private int topContentPadding;
+  @Dimension private int rightContentPadding;
+  @Dimension private int bottomContentPadding;
 
   public ShapeableImageView(Context context) {
     this(context, null, 0);
@@ -136,6 +142,225 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
     super.onSizeChanged(width, height, oldWidth, oldHeight);
     updateShapeMask(width, height);
+  }
+
+  /**
+   * Set additional padding on the image that is not applied to the background.
+   *
+   * @param left   the padding on the left of the image in pixels
+   * @param top    the padding on the top of the image in pixels
+   * @param right  the padding on the right of the image in pixels
+   * @param bottom the padding on the bottom of the image in pixels
+   */
+  public void setContentPadding(
+      @Dimension int left, @Dimension int top, @Dimension int right, @Dimension int bottom) {
+    // Super padding is equal to background padding + content padding. Adjust the content padding
+    //  portion of the super padding here:
+    super.setPadding(
+        super.getPaddingLeft() - leftContentPadding + left,
+        super.getPaddingTop() - topContentPadding + top,
+        super.getPaddingRight() - rightContentPadding + right,
+        super.getPaddingBottom() - bottomContentPadding + bottom);
+
+    leftContentPadding = left;
+    topContentPadding = top;
+    rightContentPadding = right;
+    bottomContentPadding = bottom;
+  }
+
+  /**
+   * Set additional relative padding on the image that is not applied to the background.
+   *
+   * @param start  the padding on the start of the image in pixels
+   * @param top    the padding on the top of the image in pixels
+   * @param end    the padding on the end of the image in pixels
+   * @param bottom the padding on the bottom of the image in pixels
+   */
+  @RequiresApi(17)
+  public void setContentPaddingRelative(
+      @Dimension int start, @Dimension int top, @Dimension int end, @Dimension int bottom) {
+    // Super padding is equal to background padding + content padding. Adjust the content padding
+    //  portion of the super padding here:
+    super.setPaddingRelative(
+        super.getPaddingStart() - getContentPaddingStart() + start,
+        super.getPaddingTop() - topContentPadding + top,
+        super.getPaddingEnd() - getContentPaddingEnd() + end,
+        super.getPaddingBottom() - bottomContentPadding + bottom);
+
+    leftContentPadding = isRtl() ? end : start;
+    topContentPadding = top;
+    rightContentPadding = isRtl() ? start : end;
+    bottomContentPadding = bottom;
+  }
+
+  /**
+   * The additional padding on the bottom of the image, which is not applied to the background.
+   *
+   * @return the bottom padding on the image
+   */
+  @Dimension
+  public int getContentPaddingBottom() {
+    return bottomContentPadding;
+  }
+
+  /**
+   * The additional relative padding on the end of the image, which is not applied to the
+   * background.
+   *
+   * @return the end padding on the image
+   */
+  @Dimension
+  public final int getContentPaddingEnd() {
+    return isRtl() ? getContentPaddingLeft() : getContentPaddingRight();
+  }
+
+  /**
+   * The additional padding on the left of the image, which is not applied to the background.
+   *
+   * @return the left padding on the image
+   */
+  @Dimension
+  public int getContentPaddingLeft() {
+    return leftContentPadding;
+  }
+
+  /**
+   * The additional padding on the right of the image, which is not applied to the background.
+   *
+   * @return the right padding on the image
+   */
+  @Dimension
+  public int getContentPaddingRight() {
+    return rightContentPadding;
+  }
+
+  /**
+   * The additional relative padding on the start of the image, which is not applied to the
+   * background.
+   *
+   * @return the start padding on the image
+   */
+  @Dimension
+  public final int getContentPaddingStart() {
+    return isRtl() ? getContentPaddingRight() : getContentPaddingLeft();
+  }
+
+  /**
+   * The additional padding on the top of the image, which is not applied to the background.
+   *
+   * @return the top padding on the image
+   */
+  @Dimension
+  public int getContentPaddingTop() {
+    return topContentPadding;
+  }
+
+  private boolean isRtl() {
+    return VERSION.SDK_INT >= 17 && getLayoutDirection() == LAYOUT_DIRECTION_RTL;
+  }
+
+  /**
+   * Set the padding. This is applied to both the background and the image, and does not affect the
+   * content padding differentiating the image from the background.
+   *
+   * @param left the left padding in pixels
+   * @param top the top padding in pixels
+   * @param right the right padding in pixels
+   * @param bottom the bottom padding in pixels
+   */
+  @Override
+  public void setPadding(
+      @Dimension int left, @Dimension int top, @Dimension int right, @Dimension int bottom) {
+    super.setPadding(
+        left + getContentPaddingLeft(),
+        top + getContentPaddingTop(),
+        right + getContentPaddingRight(),
+        bottom + getContentPaddingBottom());
+  }
+
+  /**
+   * Set the relative padding. This is applied to both the background and the image, and does not
+   * affect the content padding differentiating the image from the background.
+   *
+   * @param start the start padding in pixels
+   * @param top the top padding in pixels
+   * @param end the end padding in pixels
+   * @param bottom the bottom padding in pixels
+   */
+  @Override
+  public void setPaddingRelative(
+      @Dimension int start, @Dimension int top, @Dimension int end, @Dimension int bottom) {
+    super.setPaddingRelative(
+        start + getContentPaddingStart(),
+        top + getContentPaddingTop(),
+        end + getContentPaddingEnd(),
+        bottom + getContentPaddingBottom());
+  }
+
+  /**
+   * The padding on the bottom of the View, applied to both the image and the background.
+   *
+   * @return the bottom padding
+   */
+  @Override
+  @Dimension
+  public int getPaddingBottom() {
+    return super.getPaddingBottom() - getContentPaddingBottom();
+  }
+
+  /**
+   * The relative padding on the end of the View, applied to both the image and the background.
+   *
+   * @return the end padding
+   */
+  @Override
+  @Dimension
+  public int getPaddingEnd() {
+    return super.getPaddingEnd() - getContentPaddingEnd();
+  }
+
+  /**
+   * The padding on the left of the View, applied to both the image and the background.
+   *
+   * @return the left padding
+   */
+  @Override
+  @Dimension
+  public int getPaddingLeft() {
+    return super.getPaddingLeft() - getContentPaddingLeft();
+  }
+
+  /**
+   * The padding on the right of the View, applied to both the image and the background.
+   *
+   * @return the right padding
+   */
+  @Override
+  @Dimension
+  public int getPaddingRight() {
+    return super.getPaddingRight() - getContentPaddingRight();
+  }
+
+  /**
+   * The relative padding on the start of the View, applied to both the image and the background.
+   *
+   * @return the start padding
+   */
+  @Override
+  @Dimension
+  public int getPaddingStart() {
+    return super.getPaddingStart() - getContentPaddingStart();
+  }
+
+  /**
+   * The padding on the top of the View, applied to both the image and the background.
+   *
+   * @return the top padding
+   */
+  @Override
+  @Dimension
+  public int getPaddingTop() {
+    return super.getPaddingTop() - getContentPaddingTop();
   }
 
   @Override

--- a/lib/java/com/google/android/material/imageview/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/imageview/res/values/attrs.xml
@@ -27,5 +27,16 @@
          attributes declared in the shapeAppearance. Attribute declaration is in the shape package.
          -->
     <attr name="shapeAppearanceOverlay" />
+
+    <!-- Attributes for padding the image, since android:padding is applied to the background
+         for ShapeableImageView
+         -->
+    <attr name="contentPadding" />
+    <attr name="contentPaddingBottom" />
+    <attr name="contentPaddingEnd" format="dimension" />
+    <attr name="contentPaddingLeft" />
+    <attr name="contentPaddingRight" />
+    <attr name="contentPaddingStart" format="dimension" />
+    <attr name="contentPaddingTop" />
   </declare-styleable>
 </resources>


### PR DESCRIPTION
Closes #1489. Adds `contentPadding` APIs to ShapeableImageView. This is achieved by communicating the sum of padding and contentPadding as a single value to the superclass (AppCompatImageView), but tracking them separately in this class. This maintains the existing behavior of ShapeableImageView padding, which pads the background, but takes advantage of the fact that AppCompatImageView does _not_ pad the background.

Frankly the internal logic is a nightmare, and hard to wrap my head around even after writing it. But it's the only way I can get it to work while maintaining behavioral compatibility, and it seems to work as expected with some manual testing.

I'm happy to add tests but I can't figure out how they work in this project. Is there something special I need to do to get the IDE to recognize the test sources?