### PR TITLE
[Snackbar] Fixes remaining NPEs from #917

### DIFF
--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -773,7 +773,9 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
 
       // Set view to INVISIBLE so it doesn't flash on the screen before the inset adjustment is
       // handled and the enter animation is started
-      view.setVisibility(View.INVISIBLE);
+      if (view.getParent() != null) {
+        view.setVisibility(View.INVISIBLE);
+      }
       targetParent.addView(this.view);
     }
 
@@ -799,7 +801,9 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
       animateViewIn();
     } else {
       // Else if animations are disabled, just make view VISIBLE and call back now
-      view.setVisibility(View.VISIBLE);
+      if (view.getParent() != null) {
+        view.setVisibility(View.VISIBLE);
+      }
       onViewShown();
     }
   }
@@ -833,7 +837,9 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
         new SwipeDismissBehavior.OnDismissListener() {
           @Override
           public void onDismiss(@NonNull View view) {
-            view.setVisibility(View.GONE);
+            if (view.getParent() != null) {
+              view.setVisibility(View.GONE);
+            }
             dispatchDismiss(BaseCallback.DISMISS_EVENT_SWIPE);
           }
 
@@ -888,7 +894,9 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
               return;
             }
             // Make view VISIBLE now that we are about to start the enter animation
-            view.setVisibility(View.VISIBLE);
+            if (view.getParent() != null) {
+              view.setVisibility(View.VISIBLE);
+            }
             if (view.getAnimationMode() == ANIMATION_MODE_FADE) {
               startFadeInAnimation();
             } else {


### PR DESCRIPTION
There could happen NPEs when dismissing Snackbars that have not been attached to the view yet or fading in Snackbars that have already been dismissed. https://github.com/material-components/material-components-android/issues/917#issuecomment-576577838 describes this issue, which can be reproduced on Android 7.0, Android 8.0.0, Android 9.0. 

To test this PR, I created snackbars that were dismissed within 0-200ms and within 0-200ms created again. Without this PR, the app crashes (on e.g. an Android 8.0.0 emulator) within some seconds. With this PR, the app can run for at least 20 minutes without a crash.

Therefor the following exception does not happen any more:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.View.invalidate(boolean)' on a null object reference
    at android.view.View.setFlags(View.java:13338)
    at android.view.View.setVisibility(View.java:9382)
    at com.google.android.material.snackbar.BaseTransientBottomBar$9.run(BaseTransientBottomBar.java:848)
    at android.os.Handler.handleCallback(Handler.java:789)
    at android.os.Handler.dispatchMessage(Handler.java:98)
    at android.os.Looper.loop(Looper.java:164)
    at android.app.ActivityThread.main(ActivityThread.java:6541)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```