### PR TITLE
[BaseTransientBottomBar] Check for nullable AccessibilityService

### DIFF
--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -1098,7 +1098,7 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
 
   /** Returns true if we should animate the Snackbar view in/out. */
   boolean shouldAnimate() {
-    if (accessibilityManager == null) {
+    if (accessibilityManager == null || !accessibilityManager.isEnabled()) {
       return true;
     }
     int feedbackFlags = AccessibilityServiceInfo.FEEDBACK_SPOKEN;

--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -1098,6 +1098,9 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
 
   /** Returns true if we should animate the Snackbar view in/out. */
   boolean shouldAnimate() {
+    if (accessibilityManager == null) {
+      return true;
+    }
     int feedbackFlags = AccessibilityServiceInfo.FEEDBACK_SPOKEN;
     List<AccessibilityServiceInfo> serviceList =
         accessibilityManager.getEnabledAccessibilityServiceList(feedbackFlags);


### PR DESCRIPTION
If `accessibilityManager` is null because `Context.ACCESSIBILITY_SERVICE` is unavailable, skip the check and perform the animation every time, because the user is not caring about accessibility (probably the service is in a disabled state).

Fix #1885 
