### PR TITLE
[MaterialTimePicker] Make default theme overlay public

### DIFF
--- a/lib/java/com/google/android/material/timepicker/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/timepicker/res-public/values/public.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2020 The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +25,8 @@
   <public name="clockFaceBackgroundColor" type="attr" />
   <public name="clockHandColor" type="attr" />
   <public name="clockNumberTextColor" type="attr" />
+
+  <public name="ThemeOverlay.MaterialComponents.MaterialTimePicker" type="style" />
 
   <public name="Widget.MaterialComponents.TimePicker" type="style" />
   <public name="Widget.MaterialComponents.TimePicker.Button" type="style" />


### PR DESCRIPTION
If we want to override certain theme attributes of material time picker dialog like text appearances or colors while also retaining the default styles set in the default theme, it might be better to allow inheriting from the default theme overlay of the material time picker dialog so that users can safely override attributes without missing any default styles provided from the library.

If there is an alternative way of doing this, please feel free to close this PR. 

closes #1891 
