### PR TITLE
[Snackbar] Fix last remaining NPE from #917

### DIFF
--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -773,7 +773,9 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
 
       // Set view to INVISIBLE so it doesn't flash on the screen before the inset adjustment is
       // handled and the enter animation is started
-      view.setVisibility(View.INVISIBLE);
+      if (view.getParent() != null) {
+        view.setVisibility(View.INVISIBLE);
+      }
       targetParent.addView(this.view);
     }
 


### PR DESCRIPTION
The commit in PR https://github.com/material-components/material-components-android/pull/1887 fixed all NPEs from issue #917. But the commit https://github.com/material-components/material-components-android/commit/ebd322314719fb65bdfa7299274ed4662a29d88c did only apply 3 of the 4 changes. Ommiting the first change seems logical when looking at the code, so I understand @leticiarossi why you did not apply the first null-check.
But: Without the null-check the NPE mentioned in #917 still occours. We also could not believe it, this is why we made in the last days several releases and testing it “in the field” via jitpack. As result:

1. When releasing with https://github.com/vonox7/material-components-android/commit/331d064eb02cb4ff1a2b84f274b8d2c98848e9d4, no NPEs happened any more.
2. When releasing with https://github.com/material-components/material-components-android/commit/c6deb0639763409b132f79dd7039158e69dc6ffb most of the NPEs were fixed, but not all of them. An example crash is:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.View.invalidate(boolean)' on a null object reference
       at android.view.View.setFlags(View.java:15732)
       at android.view.View.setVisibility(View.java:10800)
       at com.google.android.material.snackbar.BaseTransientBottomBar$10.run(BaseTransientBottomBar.java:896)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:214)
       at android.app.ActivityThread.main(ActivityThread.java:7050)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:494)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:965)
```
3. When releasing again with https://github.com/vonox7/material-components-android/commit/331d064eb02cb4ff1a2b84f274b8d2c98848e9d4, no NPEs happened any more.
4. We could not believe it, so we reverted the single other change that happened in BaseTransientBottomBar in a release with https://github.com/zigavehovec/material-components-android/commit/f2e475675e74e5195e85d0f30770f4469ac7b685: The same crashes as in release from step 2 happened.
5. We did now a final release with https://github.com/zigavehovec/material-components-android/commit/d9057289bdaae87ffbf9f729b587ffd695feb8f0. No NPEs happen any more.

I must confess that I am not 100% sure why exactly this check fixes the NPE, but i can report that without this null-check a lot of crashes occour, and with this check the material-components-android library doesn’t crash any more on our use-cases. Therefore I ask politely to also add this NPE-check to the library so that it won’t crash any more on Android 8 and Android 9 devices.