### PR TITLE
[Documentation] Fix theme attr name to floatingActionButtonStyle

### DIFF
--- a/docs/components/BottomAppBar.md
+++ b/docs/components/BottomAppBar.md
@@ -332,7 +332,7 @@ bottom app bars and FABs but does not affect other components):
 <style name="Theme.App" parent="Theme.MaterialComponents.*">
     ...
     <item name="bottomAppBarStyle">@style/Widget.App.BottomAppBar</item>
-    <item name="fabStyle">@style/Widget.App.FloatingActionButton</item>
+    <item name="floatingActionButtonStyle">@style/Widget.App.FloatingActionButton</item>
 </style>
 
 <style name="Widget.App.BottomAppBar" parent="Widget.MaterialComponents.BottomAppBar.Colored">


### PR DESCRIPTION
The attribute name fabStyle seems to be obsolete. The correct attribute name is floatingActionButtonStyle.

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [ ] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
