### PR TITLE
 [TextInputLayout] Fixed clear icon being displayed

### DIFF
--- a/lib/java/com/google/android/material/textfield/ClearTextEndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/ClearTextEndIconDelegate.java
@@ -56,7 +56,7 @@ class ClearTextEndIconDelegate extends EndIconDelegate {
           if (textInputLayout.getSuffixText() != null) {
             return;
           }
-          animateIcon(hasText(s));
+          animateIcon(textInputLayout.hasFocus() && hasText(s));
         }
       };
   private final OnFocusChangeListener onFocusChangeListener =


### PR DESCRIPTION
This fixes #2024

With this change, using `setText` on an EditText won't display the clear text end icon unless the TextInputLayout has focus