### PR TITLE
[TextInputLayout] Update box background color for outlined text input.

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -4105,7 +4105,7 @@ public class TextInputLayout extends LinearLayout {
     }
 
     // Update the text box's background color based on the current state.
-    if (boxBackgroundMode == BOX_BACKGROUND_FILLED) {
+    if (boxBackgroundMode == BOX_BACKGROUND_FILLED || boxBackgroundMode == BOX_BACKGROUND_OUTLINE) {
       if (!isEnabled()) {
         boxBackgroundColor = disabledFilledBackgroundColor;
       } else if (isHovered && !hasFocus) {


### PR DESCRIPTION
I would like to apply a background color when my outlined `TextInputLayout` is disabled.

Usage:

**styles.xml**
```xml
<style name="Widget.Vitamin.TextInputLayout" parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
    <item name="boxBackgroundColor">@color/vtmn_outlined_states</item>
    <!-- Other properties here -->
</style>
```

**vtmn_outlined_states.xml**
```xml
<?xml version="1.0" encoding="utf-8"?>
<selector xmlns:android="http://schemas.android.com/apk/res/android">
    <item android:color="@color/vtmn_grey_light_3" android:state_enabled="false" />
    <item android:color="@android:color/transparent" />
</selector>
```

Without this contribution, background of the text input isn't updated when it is disabled.

**Before this contribution**
![Screenshot_20210219-175549](https://user-images.githubusercontent.com/1913901/108535762-f3e1d500-72db-11eb-8cfb-04f2e699d166.jpg)

**After this contribution**
![Screenshot_20210219-175237](https://user-images.githubusercontent.com/1913901/108535341-833ab880-72db-11eb-8dad-49cbcbb897fe.jpg)

Closes #2069 