### PR TITLE
[MaterialButtonToggleGroup] Checked button UI issue

### DIFF
--- a/lib/java/com/google/android/material/button/MaterialButtonToggleGroup.java
+++ b/lib/java/com/google/android/material/button/MaterialButtonToggleGroup.java
@@ -332,6 +332,7 @@ public class MaterialButtonToggleGroup extends LinearLayout {
     }
 
     checkForced(id);
+    invalidate();
   }
 
   /**
@@ -348,6 +349,7 @@ public class MaterialButtonToggleGroup extends LinearLayout {
     updateCheckedStates(id, false);
     checkedId = View.NO_ID;
     dispatchOnButtonChecked(id, false);
+    invalidate();
   }
 
   /**


### PR DESCRIPTION
closes https://github.com/material-components/material-components-android/issues/2133

Calling `invalidate()` will call `updateChildOrder()` which will fix the issue.