### PR TITLE
[RangeSlider] Updating attribute name "values"

### DIFF
--- a/lib/java/com/google/android/material/slider/RangeSlider.java
+++ b/lib/java/com/google/android/material/slider/RangeSlider.java
@@ -45,7 +45,7 @@ import java.util.List;
  * <p>{@code app:minSeparation}: <b>Optional.</b> The minimum distance between two thumbs that would
  * otherwise overlap.
  *
- * @attr ref com.google.android.material.R.styleable#RangeSlider_values
+ * @attr ref com.google.android.material.R.styleable#RangeSlider_initialValues
  * @attr ref com.google.android.material.R.styleable#RangeSlider_minSeparation
  */
 public class RangeSlider extends BaseSlider<RangeSlider, OnChangeListener, OnSliderTouchListener> {
@@ -66,8 +66,8 @@ public class RangeSlider extends BaseSlider<RangeSlider, OnChangeListener, OnSli
     TypedArray a =
         ThemeEnforcement.obtainStyledAttributes(
             context, attrs, R.styleable.RangeSlider, defStyleAttr, DEF_STYLE_RES);
-    if (a.hasValue(R.styleable.RangeSlider_values)) {
-      int valuesId = a.getResourceId(R.styleable.RangeSlider_values, 0);
+    if (a.hasValue(R.styleable.RangeSlider_initialValues)) {
+      int valuesId = a.getResourceId(R.styleable.RangeSlider_initialValues, 0);
       TypedArray values = a.getResources().obtainTypedArray(valuesId);
       setValues(convertToFloat(values));
     }

--- a/lib/java/com/google/android/material/slider/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/slider/res/values/attrs.xml
@@ -68,7 +68,7 @@
   </declare-styleable>
 
   <declare-styleable name="RangeSlider">
-    <attr name="values" format="reference" />
+    <attr name="initialValues" format="reference" />
 
     <!-- If there is more than one thumb, and the slider is
          not discrete the thumbs will be separated by this dimen -->


### PR DESCRIPTION
Renaming the "values" attribute to "initialValues", a more descriptive name and it is not easy to conflict with another attribute name.

The motivation of this change is described in this issue https://github.com/material-components/material-components-android/issues/2199

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
