### PR TITLE
[BottomSheet] make FloatRange for setHalfExpandedRatio() exclusive

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -908,7 +908,8 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
    * @attr ref
    *     com.google.android.material.R.styleable#BottomSheetBehavior_Layout_behavior_halfExpandedRatio
    */
-  public void setHalfExpandedRatio(@FloatRange(from = 0.0f, to = 1.0f) float ratio) {
+  public void setHalfExpandedRatio(
+      @FloatRange(from = 0.0f, to = 1.0f, fromInclusive = false, toInclusive = false) float ratio) {
 
     if ((ratio <= 0) || (ratio >= 1)) {
       throw new IllegalArgumentException("ratio must be a float value between 0 and 1");


### PR DESCRIPTION
Method body contains this check:

```java
if ((ratio <= 0) || (ratio >= 1)) {
  throw new IllegalArgumentException("ratio must be a float value between 0 and 1");
}
```

... so `FloatRange` should not be inclusive.

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Sign the CLA bot. You can do this once the pull request is opened.