### PR TITLE
[NavigationRailView] Update inset handling for Navigation Rail & Bottom Nav

### DIFF
--- a/lib/java/com/google/android/material/bottomnavigation/BottomNavigationView.java
+++ b/lib/java/com/google/android/material/bottomnavigation/BottomNavigationView.java
@@ -33,8 +33,12 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.ContextCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import com.google.android.material.behavior.HideBottomViewOnScrollBehavior;
 import com.google.android.material.internal.ThemeEnforcement;
+import com.google.android.material.internal.ViewUtils;
+import com.google.android.material.internal.ViewUtils.RelativePadding;
 import com.google.android.material.navigation.NavigationBarMenuView;
 import com.google.android.material.navigation.NavigationBarView;
 import com.google.android.material.shape.MaterialShapeDrawable;
@@ -125,6 +129,33 @@ public class BottomNavigationView extends NavigationBarView {
     if (shouldDrawCompatibilityTopDivider()) {
       addCompatibilityTopDivider(context);
     }
+
+    applyWindowInsets();
+  }
+
+  private void applyWindowInsets() {
+    ViewUtils.doOnApplyWindowInsets(
+        this,
+        new ViewUtils.OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              View view,
+              @NonNull WindowInsetsCompat insets,
+              @NonNull RelativePadding initialPadding) {
+            // Apply the bottom, start, and end padding for a BottomNavigationView
+            // to dodge the system navigation bar
+            initialPadding.bottom += insets.getSystemWindowInsetBottom();
+
+            boolean isRtl = ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
+            int systemWindowInsetLeft = insets.getSystemWindowInsetLeft();
+            int systemWindowInsetRight = insets.getSystemWindowInsetRight();
+            initialPadding.start += isRtl ? systemWindowInsetRight : systemWindowInsetLeft;
+            initialPadding.end += isRtl ? systemWindowInsetLeft : systemWindowInsetRight;
+            initialPadding.applyToView(view);
+            return insets;
+          }
+        });
   }
 
   @Override

--- a/lib/java/com/google/android/material/navigation/NavigationBarView.java
+++ b/lib/java/com/google/android/material/navigation/NavigationBarView.java
@@ -44,7 +44,6 @@ import android.util.AttributeSet;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.View;
 import android.widget.FrameLayout;
 import androidx.annotation.AttrRes;
 import androidx.annotation.DimenRes;
@@ -60,8 +59,6 @@ import androidx.annotation.StyleRes;
 import androidx.customview.view.AbsSavedState;
 import com.google.android.material.badge.BadgeDrawable;
 import com.google.android.material.internal.ThemeEnforcement;
-import com.google.android.material.internal.ViewUtils;
-import com.google.android.material.internal.ViewUtils.RelativePadding;
 import com.google.android.material.resources.MaterialResources;
 import com.google.android.material.ripple.RippleUtils;
 import com.google.android.material.shape.MaterialShapeDrawable;
@@ -299,32 +296,6 @@ public abstract class NavigationBarView extends FrameLayout {
 
           @Override
           public void onMenuModeChange(MenuBuilder menu) {}
-        });
-
-    applyWindowInsets();
-  }
-
-  private void applyWindowInsets() {
-    ViewUtils.doOnApplyWindowInsets(
-        this,
-        new ViewUtils.OnApplyWindowInsetsListener() {
-          @NonNull
-          @Override
-          public androidx.core.view.WindowInsetsCompat onApplyWindowInsets(
-              View view,
-              @NonNull androidx.core.view.WindowInsetsCompat insets,
-              @NonNull RelativePadding initialPadding) {
-            // Window insets may add additional padding, e.g., to dodge the system navigation bar
-            initialPadding.bottom += insets.getSystemWindowInsetBottom();
-
-            boolean isRtl = ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
-            int systemWindowInsetLeft = insets.getSystemWindowInsetLeft();
-            int systemWindowInsetRight = insets.getSystemWindowInsetRight();
-            initialPadding.start += isRtl ? systemWindowInsetRight : systemWindowInsetLeft;
-            initialPadding.end += isRtl ? systemWindowInsetLeft : systemWindowInsetRight;
-            initialPadding.applyToView(view);
-            return insets;
-          }
         });
   }
 

--- a/lib/java/com/google/android/material/navigationrail/NavigationRailView.java
+++ b/lib/java/com/google/android/material/navigationrail/NavigationRailView.java
@@ -34,7 +34,12 @@ import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
 import com.google.android.material.internal.ThemeEnforcement;
+import com.google.android.material.internal.ViewUtils;
+import com.google.android.material.internal.ViewUtils.RelativePadding;
 import com.google.android.material.navigation.NavigationBarView;
 
 /**
@@ -134,6 +139,33 @@ public class NavigationRailView extends NavigationBarView {
     setMenuGravity(
         attributes.getInt(R.styleable.NavigationRailView_menuGravity, DEFAULT_MENU_GRAVITY));
     attributes.recycle();
+
+    applyWindowInsets();
+  }
+
+  private void applyWindowInsets() {
+    ViewUtils.doOnApplyWindowInsets(
+        this,
+        new ViewUtils.OnApplyWindowInsetsListener() {
+          @NonNull
+          @Override
+          public WindowInsetsCompat onApplyWindowInsets(
+              View view,
+              @NonNull WindowInsetsCompat insets,
+              @NonNull RelativePadding initialPadding) {
+            // Apply the top, bottom, and start padding for a start edge aligned
+            // NavigationRailView to dodge the system status and navigation bars
+            initialPadding.top += insets.getSystemWindowInsetTop();
+            initialPadding.bottom += insets.getSystemWindowInsetBottom();
+
+            boolean isRtl = ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
+            int systemWindowInsetLeft = insets.getSystemWindowInsetLeft();
+            int systemWindowInsetRight = insets.getSystemWindowInsetRight();
+            initialPadding.start += isRtl ? systemWindowInsetRight : systemWindowInsetLeft;
+            initialPadding.applyToView(view);
+            return insets;
+          }
+        });
   }
 
   @Override


### PR DESCRIPTION
Correctly apply only the top, bottom, and start padding to a `NavigationRailView`, moving the inset logic that was incorrectly moved to `NavigationBarView` back to `BottomNavigationView`.

Closes #2252

#### Don't forget:

- [X] Identify the component the PR relates to in brackets in the title.
- [X] Link to GitHub issues it solves.
- [X] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
