### PR TITLE
[DialogDemoLandingFragment] Fix the problem that the menu icon does not match

### DIFF
--- a/catalog/java/io/material/catalog/datepicker/DatePickerDemoLandingFragment.java
+++ b/catalog/java/io/material/catalog/datepicker/DatePickerDemoLandingFragment.java
@@ -62,7 +62,7 @@ public class DatePickerDemoLandingFragment extends DemoLandingFragment {
     @Provides
     @ActivityScope
     static FeatureDemo provideFeatureDemo() {
-      return new FeatureDemo(R.string.cat_picker_demo_title, R.drawable.ic_dialog) {
+      return new FeatureDemo(R.string.cat_picker_demo_title, R.drawable.ic_placeholder) {
         @Override
         public Fragment createFragment() {
           return new DatePickerDemoLandingFragment();


### PR DESCRIPTION
The `DatePicker` menu uses the icon of the `Dialog` menu, since no matching icon resource was found, use `ic_placeholder` instead

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[DialogDemoLandingFragment] Fix the problem that the menu icon does not match`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
