### PR TITLE
[FloatingActionButton] Updated documentation for RTL support

### DIFF
--- a/docs/components/FloatingActionButton.md
+++ b/docs/components/FloatingActionButton.md
@@ -130,7 +130,7 @@ In the layout:
       android:id="@+id/floating_action_button"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_gravity="bottom|right"
+      android:layout_gravity="bottom|end"
       android:layout_margin="16dp"
       android:contentDescription="@string/fab_content_desc"
       app:srcCompat="@drawable/ic_plus_24"/>
@@ -281,7 +281,7 @@ In the layout:
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_margin="16dp"
-    android:layout_gravity="bottom|right"
+    android:layout_gravity="bottom|end"
     android:contentDescription="@string/extended_fab_content_desc"
     android:text="@string/extended_fab_label"
     app:icon="@drawable/ic_plus_24px"/>


### PR DESCRIPTION
Per https://material.io/components/buttons-floating-action-button

Icons should be placed to the left of text labels for left-to-right languages.
Icons should be placed to the right for right-to-left languages.

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [ ] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
