### PR TITLE
[ShapeableImageView] Fix padding bugs

### DIFF
--- a/lib/java/com/google/android/material/imageview/ShapeableImageView.java
+++ b/lib/java/com/google/android/material/imageview/ShapeableImageView.java
@@ -37,8 +37,6 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
-import androidx.appcompat.content.res.AppCompatResources;
-import androidx.appcompat.widget.AppCompatImageView;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewOutlineProvider;
@@ -48,6 +46,8 @@ import androidx.annotation.Dimension;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.appcompat.widget.AppCompatImageView;
 import com.google.android.material.resources.MaterialResources;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.ShapeAppearanceModel;
@@ -169,28 +169,25 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
       return;
     }
 
-    if (VERSION.SDK_INT > 19 && !isLayoutDirectionResolved()) {
-      return;
+    if ((VERSION.SDK_INT < 19 || isLayoutDirectionResolved())
+        && !hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      // Finally, update the super padding to be the combined `android:padding` and
+      //  `app:contentPadding`, in keeping with ShapeableImageView's crazy internal padding contract:
+      if (VERSION.SDK_INT >= 21 && (isPaddingRelative() || isContentPaddingRelative())) {
+        setPaddingRelative(
+            super.getPaddingStart(),
+            super.getPaddingTop(),
+            super.getPaddingEnd(),
+            super.getPaddingBottom());
+      } else {
+        setPadding(
+            super.getPaddingLeft(),
+            super.getPaddingTop(),
+            super.getPaddingRight(),
+            super.getPaddingBottom());
+      }
+      hasAdjustedPaddingAfterLayoutDirectionResolved = true;
     }
-
-    hasAdjustedPaddingAfterLayoutDirectionResolved = true;
-
-    // Update the super padding to be the combined `android:padding` and
-    // `app:contentPadding`, keeping with ShapeableImageView's internal padding contract:
-    if (VERSION.SDK_INT >= 21 && (isPaddingRelative() || isContentPaddingRelative())) {
-      setPaddingRelative(
-          super.getPaddingStart(),
-          super.getPaddingTop(),
-          super.getPaddingEnd(),
-          super.getPaddingBottom());
-      return;
-    }
-
-    setPadding(
-        super.getPaddingLeft(),
-        super.getPaddingTop(),
-        super.getPaddingRight(),
-        super.getPaddingBottom());
   }
 
   @Override

--- a/lib/java/com/google/android/material/imageview/ShapeableImageView.java
+++ b/lib/java/com/google/android/material/imageview/ShapeableImageView.java
@@ -169,13 +169,12 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
       return;
     }
 
-    if ((VERSION.SDK_INT < 19 || isLayoutDirectionResolved())
-        && !hasAdjustedPaddingAfterLayoutDirectionResolved) {
+    if (VERSION.SDK_INT < 19 || isLayoutDirectionResolved()) {
       hasAdjustedPaddingAfterLayoutDirectionResolved = true;
 
       // Finally, update the super padding to be the combined `android:padding` and
       //  `app:contentPadding`, in keeping with ShapeableImageView's crazy internal padding contract:
-      if (VERSION.SDK_INT >= 21 && (isPaddingRelative() || isContentPaddingRelative())) {
+      if (VERSION.SDK_INT >= 17 && (isPaddingRelative() || isContentPaddingRelative())) {
         setPaddingRelative(
             super.getPaddingStart(),
             super.getPaddingTop(),
@@ -378,6 +377,8 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
           top + getContentPaddingTop(),
           right + getContentPaddingRight(),
           bottom + getContentPaddingBottom());
+    } else {
+      super.setPadding(left, top, right, bottom);
     }
   }
 
@@ -399,6 +400,8 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
           top + getContentPaddingTop(),
           end + getContentPaddingEnd(),
           bottom + getContentPaddingBottom());
+    } else {
+      super.setPaddingRelative(start, top, end, bottom);
     }
   }
 
@@ -410,7 +413,11 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @Override
   @Dimension
   public int getPaddingBottom() {
-    return super.getPaddingBottom() - getContentPaddingBottom();
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      return super.getPaddingBottom() - getContentPaddingBottom();
+    } else {
+      return super.getPaddingBottom();
+    }
   }
 
   /**
@@ -421,7 +428,11 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @Override
   @Dimension
   public int getPaddingEnd() {
-    return super.getPaddingEnd() - getContentPaddingEnd();
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      return super.getPaddingEnd() - getContentPaddingEnd();
+    } else {
+      return super.getPaddingEnd();
+    }
   }
 
   /**
@@ -432,7 +443,11 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @Override
   @Dimension
   public int getPaddingLeft() {
-    return super.getPaddingLeft() - getContentPaddingLeft();
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      return super.getPaddingLeft() - getContentPaddingLeft();
+    } else {
+      return super.getPaddingLeft();
+    }
   }
 
   /**
@@ -443,7 +458,11 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @Override
   @Dimension
   public int getPaddingRight() {
-    return super.getPaddingRight() - getContentPaddingRight();
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      return super.getPaddingRight() - getContentPaddingRight();
+    } else {
+      return super.getPaddingRight();
+    }
   }
 
   /**
@@ -454,7 +473,11 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @Override
   @Dimension
   public int getPaddingStart() {
-    return super.getPaddingStart() - getContentPaddingStart();
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      return super.getPaddingStart() - getContentPaddingStart();
+    } else {
+      return super.getPaddingStart();
+    }
   }
 
   /**
@@ -465,7 +488,11 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @Override
   @Dimension
   public int getPaddingTop() {
-    return super.getPaddingTop() - getContentPaddingTop();
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      return super.getPaddingTop() - getContentPaddingTop();
+    } else {
+      return super.getPaddingTop();
+    }
   }
 
   @Override

--- a/lib/java/com/google/android/material/imageview/ShapeableImageView.java
+++ b/lib/java/com/google/android/material/imageview/ShapeableImageView.java
@@ -171,6 +171,8 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
 
     if ((VERSION.SDK_INT < 19 || isLayoutDirectionResolved())
         && !hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      hasAdjustedPaddingAfterLayoutDirectionResolved = true;
+
       // Finally, update the super padding to be the combined `android:padding` and
       //  `app:contentPadding`, in keeping with ShapeableImageView's crazy internal padding contract:
       if (VERSION.SDK_INT >= 21 && (isPaddingRelative() || isContentPaddingRelative())) {
@@ -186,7 +188,6 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
             super.getPaddingRight(),
             super.getPaddingBottom());
       }
-      hasAdjustedPaddingAfterLayoutDirectionResolved = true;
     }
   }
 
@@ -216,13 +217,17 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
     startContentPadding = UNDEFINED_PADDING;
     endContentPadding = UNDEFINED_PADDING;
 
-    // Super padding is equal to background padding + content padding. Adjust the content padding
-    //  portion of the super padding here:
-    super.setPadding(
-        super.getPaddingLeft() - leftContentPadding + left,
-        super.getPaddingTop() - topContentPadding + top,
-        super.getPaddingRight() - rightContentPadding + right,
-        super.getPaddingBottom() - bottomContentPadding + bottom);
+    // If onMeasure hasn't adjusted padding yet, wait for it to be set to avoid double-applying the
+    //  content padding in onMeasure:
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      // Super padding is equal to background padding + content padding. Adjust the content padding
+      //  portion of the super padding here:
+      super.setPadding(
+          super.getPaddingLeft() - leftContentPadding + left,
+          super.getPaddingTop() - topContentPadding + top,
+          super.getPaddingRight() - rightContentPadding + right,
+          super.getPaddingBottom() - bottomContentPadding + bottom);
+    }
 
     leftContentPadding = left;
     topContentPadding = top;
@@ -241,14 +246,20 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @RequiresApi(17)
   public void setContentPaddingRelative(
       @Dimension int start, @Dimension int top, @Dimension int end, @Dimension int bottom) {
-    // Super padding is equal to background padding + content padding. Adjust the content padding
-    //  portion of the super padding here:
-    super.setPaddingRelative(
-        super.getPaddingStart() - getContentPaddingStart() + start,
-        super.getPaddingTop() - topContentPadding + top,
-        super.getPaddingEnd() - getContentPaddingEnd() + end,
-        super.getPaddingBottom() - bottomContentPadding + bottom);
+    // If onMeasure hasn't adjusted padding yet, wait for it to be set to avoid double-applying the
+    //  content padding in onMeasure:
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      // Super padding is equal to background padding + content padding. Adjust the content padding
+      //  portion of the super padding here:
+      super.setPaddingRelative(
+          super.getPaddingStart() - getContentPaddingStart() + start,
+          super.getPaddingTop() - topContentPadding + top,
+          super.getPaddingEnd() - getContentPaddingEnd() + end,
+          super.getPaddingBottom() - bottomContentPadding + bottom);
+    }
 
+    startContentPadding = start;
+    endContentPadding = end;
     leftContentPadding = isRtl() ? end : start;
     topContentPadding = top;
     rightContentPadding = isRtl() ? start : end;
@@ -361,11 +372,13 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @Override
   public void setPadding(
       @Dimension int left, @Dimension int top, @Dimension int right, @Dimension int bottom) {
-    super.setPadding(
-        left + getContentPaddingLeft(),
-        top + getContentPaddingTop(),
-        right + getContentPaddingRight(),
-        bottom + getContentPaddingBottom());
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      super.setPadding(
+          left + getContentPaddingLeft(),
+          top + getContentPaddingTop(),
+          right + getContentPaddingRight(),
+          bottom + getContentPaddingBottom());
+    }
   }
 
   /**
@@ -380,11 +393,13 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   @Override
   public void setPaddingRelative(
       @Dimension int start, @Dimension int top, @Dimension int end, @Dimension int bottom) {
-    super.setPaddingRelative(
-        start + getContentPaddingStart(),
-        top + getContentPaddingTop(),
-        end + getContentPaddingEnd(),
-        bottom + getContentPaddingBottom());
+    if (hasAdjustedPaddingAfterLayoutDirectionResolved) {
+      super.setPaddingRelative(
+          start + getContentPaddingStart(),
+          top + getContentPaddingTop(),
+          end + getContentPaddingEnd(),
+          bottom + getContentPaddingBottom());
+    }
   }
 
   /**

--- a/lib/javatests/com/google/android/material/imageview/AndroidManifest.xml
+++ b/lib/javatests/com/google/android/material/imageview/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2019 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  package="com.google.android.material.imageview">
+
+  <uses-sdk
+    tools:overrideLibrary="androidx.test.core"/>
+
+  <application/>
+</manifest>

--- a/lib/javatests/com/google/android/material/imageview/ShapeableImageViewTest.java
+++ b/lib/javatests/com/google/android/material/imageview/ShapeableImageViewTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.material.imageview;
+
+import com.google.android.material.R;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import android.content.Context;
+import android.os.Build;
+import android.view.View;
+import androidx.test.core.app.ApplicationProvider;
+import com.google.android.material.shape.CornerFamily;
+import com.google.android.material.shape.CornerTreatment;
+import com.google.android.material.shape.CutCornerTreatment;
+import com.google.android.material.shape.ShapeAppearanceModel;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Tests for {@link com.google.android.material.imageview.ShapeableImageView}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ShapeableImageViewTest {
+
+  private static final float SMALL_CORNER_SIZE = 20f;
+  private static final float LARGE_CORNER_SIZE = 40f;
+  private static final int CUT_CORNER_FAMILY = CornerFamily.CUT;
+  private static final Class<CutCornerTreatment> CUT_CORNER_FAMILY_CLASS = CutCornerTreatment.class;
+
+  // Valid measureSpec values copied from a debugging session:
+  private static final int WIDTH_MEASURE_SPEC = 0x4000_03da;
+  private static final int HEIGHT_MEASURE_SPEC = 0x0000_0593;
+
+  private final Context context = ApplicationProvider.getApplicationContext();
+
+  @Before
+  public void themeApplicationContext() {
+    context.setTheme(R.style.Theme_MaterialComponents_Light_NoActionBar_Bridge);
+  }
+
+  @Test
+  public void testSetShapeAppearanceModel() {
+    ShapeableImageView imageView = new ShapeableImageView(context);
+    ShapeAppearanceModel appliedShapeAppearanceModel =
+        ShapeAppearanceModel.builder()
+            .setAllCorners(CUT_CORNER_FAMILY, SMALL_CORNER_SIZE)
+            .build();
+
+    imageView.setShapeAppearanceModel(appliedShapeAppearanceModel);
+
+    ShapeAppearanceModel actualShapeAppearanceModel = imageView.getShapeAppearanceModel();
+
+    assertThatCornerSizesMatch(appliedShapeAppearanceModel, actualShapeAppearanceModel);
+    assertThatCornerFamilyMatches(CUT_CORNER_FAMILY_CLASS, actualShapeAppearanceModel);
+  }
+
+  private void assertThatCornerSizesMatch(
+      ShapeAppearanceModel expected, ShapeAppearanceModel actual) {
+    assertThat(actual.getTopLeftCornerSize())
+        .isEqualTo(expected.getTopLeftCornerSize());
+    assertThat(actual.getTopRightCornerSize())
+        .isEqualTo(expected.getTopRightCornerSize());
+    assertThat(actual.getBottomRightCornerSize())
+        .isEqualTo(expected.getBottomRightCornerSize());
+    assertThat(actual.getBottomLeftCornerSize())
+        .isEqualTo(expected.getBottomLeftCornerSize());
+  }
+
+  private void assertThatCornerFamilyMatches(
+      Class<? extends CornerTreatment> expectedCornerFamily,
+      ShapeAppearanceModel shapeAppearanceModel) {
+    assertThat(shapeAppearanceModel.getTopLeftCorner()).isInstanceOf(expectedCornerFamily);
+    assertThat(shapeAppearanceModel.getTopRightCorner()).isInstanceOf(expectedCornerFamily);
+    assertThat(shapeAppearanceModel.getBottomRightCorner()).isInstanceOf(expectedCornerFamily);
+    assertThat(shapeAppearanceModel.getBottomLeftCorner()).isInstanceOf(expectedCornerFamily);
+  }
+
+  @Config(sdk = {16, 18, 19, 21, 30})
+  @Test
+  public void setContentPaddingBeforeMeasure() {
+    ShapeableImageView imageView = new ShapeableImageView(context);
+
+    imageView.setContentPadding(1, 2, 3, 4);
+
+    assertThat(imageView.getContentPaddingLeft()).isEqualTo(1);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getContentPaddingRight()).isEqualTo(3);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(4);
+    assertThat(imageView.getPaddingLeft()).isEqualTo(0);
+    assertThat(imageView.getPaddingTop()).isEqualTo(0);
+    assertThat(imageView.getPaddingRight()).isEqualTo(0);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(0);
+
+    forceResolveLayoutDirection(imageView);
+    imageView.onMeasure(WIDTH_MEASURE_SPEC, HEIGHT_MEASURE_SPEC);
+
+    assertThat(imageView.getContentPaddingLeft()).isEqualTo(1);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getContentPaddingRight()).isEqualTo(3);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(4);
+    assertThat(imageView.getPaddingLeft()).isEqualTo(0);
+    assertThat(imageView.getPaddingTop()).isEqualTo(0);
+    assertThat(imageView.getPaddingRight()).isEqualTo(0);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(0);
+  }
+
+  @Config(sdk = {16, 18, 19, 21, 30})
+  @Test
+  public void setPaddingBeforeMeasure() {
+    ShapeableImageView imageView = new ShapeableImageView(context);
+
+    imageView.setPadding(1, 2, 3, 4);
+
+    assertThat(imageView.getContentPaddingLeft()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingRight()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(0);
+    assertThat(imageView.getPaddingLeft()).isEqualTo(1);
+    assertThat(imageView.getPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getPaddingRight()).isEqualTo(3);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(4);
+
+    forceResolveLayoutDirection(imageView);
+    imageView.onMeasure(WIDTH_MEASURE_SPEC, HEIGHT_MEASURE_SPEC);
+
+    assertThat(imageView.getContentPaddingLeft()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingRight()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(0);
+    assertThat(imageView.getPaddingLeft()).isEqualTo(1);
+    assertThat(imageView.getPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getPaddingRight()).isEqualTo(3);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(4);
+  }
+
+  @Config(sdk = {16, 18, 19, 21, 30})
+  @Test
+  public void setPaddingAndContentPaddingBeforeMeasure() {
+    ShapeableImageView imageView = new ShapeableImageView(context);
+
+    imageView.setPadding(1, 2, 3, 4);
+    imageView.setContentPadding(5, 6, 7, 8);
+
+    assertThat(imageView.getContentPaddingLeft()).isEqualTo(5);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(6);
+    assertThat(imageView.getContentPaddingRight()).isEqualTo(7);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(8);
+    assertThat(imageView.getPaddingLeft()).isEqualTo(1);
+    assertThat(imageView.getPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getPaddingRight()).isEqualTo(3);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(4);
+
+    forceResolveLayoutDirection(imageView);
+    imageView.onMeasure(WIDTH_MEASURE_SPEC, HEIGHT_MEASURE_SPEC);
+
+    assertThat(imageView.getContentPaddingLeft()).isEqualTo(5);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(6);
+    assertThat(imageView.getContentPaddingRight()).isEqualTo(7);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(8);
+    assertThat(imageView.getPaddingLeft()).isEqualTo(1);
+    assertThat(imageView.getPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getPaddingRight()).isEqualTo(3);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(4);
+  }
+
+  @Config(sdk = {16, 18, 19, 21, 30})
+  @Test
+  public void setContentPaddingRelativeBeforeMeasure() {
+    ShapeableImageView imageView = new ShapeableImageView(context);
+
+    imageView.setContentPaddingRelative(1, 2, 3, 4);
+
+    assertThat(imageView.getContentPaddingStart()).isEqualTo(1);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getContentPaddingEnd()).isEqualTo(3);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(4);
+    assertThat(imageView.getPaddingStart()).isEqualTo(0);
+    assertThat(imageView.getPaddingTop()).isEqualTo(0);
+    assertThat(imageView.getPaddingEnd()).isEqualTo(0);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(0);
+
+    forceResolveLayoutDirection(imageView);
+    imageView.onMeasure(WIDTH_MEASURE_SPEC, HEIGHT_MEASURE_SPEC);
+
+    assertThat(imageView.getContentPaddingStart()).isEqualTo(1);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getContentPaddingEnd()).isEqualTo(3);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(4);
+    assertThat(imageView.getPaddingStart()).isEqualTo(0);
+    assertThat(imageView.getPaddingTop()).isEqualTo(0);
+    assertThat(imageView.getPaddingEnd()).isEqualTo(0);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(0);
+  }
+
+  @Config(sdk = {16, 18, 19, 21, 30})
+  @Test
+  public void setPaddingRelativeBeforeMeasure() {
+    ShapeableImageView imageView = new ShapeableImageView(context);
+
+    imageView.setPaddingRelative(1, 2, 3, 4);
+
+    assertThat(imageView.getContentPaddingStart()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingEnd()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(0);
+    assertThat(imageView.getPaddingStart()).isEqualTo(1);
+    assertThat(imageView.getPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getPaddingEnd()).isEqualTo(3);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(4);
+
+    forceResolveLayoutDirection(imageView);
+    imageView.onMeasure(WIDTH_MEASURE_SPEC, HEIGHT_MEASURE_SPEC);
+
+    assertThat(imageView.getContentPaddingStart()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingEnd()).isEqualTo(0);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(0);
+    assertThat(imageView.getPaddingStart()).isEqualTo(1);
+    assertThat(imageView.getPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getPaddingEnd()).isEqualTo(3);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(4);
+  }
+
+  @Config(sdk = {16, 18, 19, 21, 30})
+  @Test
+  public void setPaddingAndContentPaddingRelativeBeforeMeasure() {
+    ShapeableImageView imageView = new ShapeableImageView(context);
+
+    imageView.setPaddingRelative(1, 2, 3, 4);
+    imageView.setContentPaddingRelative(5, 6, 7, 8);
+
+    assertThat(imageView.getContentPaddingStart()).isEqualTo(5);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(6);
+    assertThat(imageView.getContentPaddingEnd()).isEqualTo(7);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(8);
+    assertThat(imageView.getPaddingStart()).isEqualTo(1);
+    assertThat(imageView.getPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getPaddingEnd()).isEqualTo(3);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(4);
+
+    forceResolveLayoutDirection(imageView);
+    imageView.onMeasure(WIDTH_MEASURE_SPEC, HEIGHT_MEASURE_SPEC);
+
+    assertThat(imageView.getContentPaddingStart()).isEqualTo(5);
+    assertThat(imageView.getContentPaddingTop()).isEqualTo(6);
+    assertThat(imageView.getContentPaddingEnd()).isEqualTo(7);
+    assertThat(imageView.getContentPaddingBottom()).isEqualTo(8);
+    assertThat(imageView.getPaddingStart()).isEqualTo(1);
+    assertThat(imageView.getPaddingTop()).isEqualTo(2);
+    assertThat(imageView.getPaddingEnd()).isEqualTo(3);
+    assertThat(imageView.getPaddingBottom()).isEqualTo(4);
+  }
+
+  /**
+   * Normally called by the system, we must call this because onMeasure's behavior relies on it. It
+   * is a hidden API, so must be called with reflection.
+   */
+  private void forceResolveLayoutDirection(View view) {
+    if (Build.VERSION.SDK_INT < 19) {
+      return;
+    }
+
+    try {
+      Method method = view.getClass().getMethod("resolveLayoutDirection");
+      method.invoke(view);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      fail("Could not force resolve layout direction: " + e.getMessage());
+    }
+
+    assertThat(view.isLayoutDirectionResolved()).isTrue();
+  }
+}


### PR DESCRIPTION
### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

Fixes #2063.

Ensures that content padding values are not propagated to their respective `super` padding values until after `onMeasure` has completed with `isLayoutDirectionResolved() == true` at least once. This was already the case inside `onMeasure`, but not the case in `setContentPadding` and `getPadding*` methods.

The internal logic required to make this work is hard to reason about, so I added `ShapeableImageViewTest` to test that both types of padding work as expected on multiple Android SDKs.