### PR TITLE
[Slider] addOnChangeListener should take NonNull value

### DIFF
--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -831,7 +831,7 @@ abstract class BaseSlider<
    *
    * @param listener The callback to run when the slider changes
    */
-  public void addOnChangeListener(@Nullable L listener) {
+  public void addOnChangeListener(@NonNull L listener) {
     changeListeners.add(listener);
   }
 


### PR DESCRIPTION
all the logic around managing the `changeListeners` assumes they are nonnull, so it doesn't make sense to allow `addOnChangeListener` to take a null listener.

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
