### PR TITLE
[DatePickerFragment] [MaterialCalendar] Fix NavigationButton icon alignment

### DIFF
--- a/lib/java/com/google/android/material/datepicker/res/values/styles.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values/styles.xml
@@ -169,6 +169,8 @@
   <style name="Base.Widget.MaterialComponents.MaterialCalendar.NavigationButton" parent="Widget.MaterialComponents.Button.TextButton.Dialog.Flush">
     <item name="android:textColor">@color/material_on_surface_emphasis_medium</item>
     <item name="iconTint">@color/material_on_surface_emphasis_medium</item>
+    <item name="android:paddingLeft">12dip</item>
+    <item name="android:paddingStart">12dip</item>
   </style>
 
   <style name="Widget.MaterialComponents.MaterialCalendar.YearNavigationButton" parent="Base.Widget.MaterialComponents.MaterialCalendar.NavigationButton"/>


### PR DESCRIPTION
Compensate parent style MaterialComponents.Button.TextButton defaut icon padding to have MaterialCalendar.Navigation icon centered
closes #2388

Before :
![device-2021-09-26-123807](https://user-images.githubusercontent.com/1625652/134804485-96e82637-1a28-492a-849e-e4a81781e449.png)


After 
![device-2021-09-26-124329](https://user-images.githubusercontent.com/1625652/134804487-dbf13e91-64fa-41c6-8567-8824d1fc6e29.png)
:
