### PR TITLE
[MaterialColors] MaterialColors returns the wrong value when color is TypedValued.TYPE_STRING

### DIFF
--- a/lib/java/com/google/android/material/resources/MaterialAttributes.java
+++ b/lib/java/com/google/android/material/resources/MaterialAttributes.java
@@ -71,7 +71,8 @@ public class MaterialAttributes {
               errorMessageComponent,
               context.getResources().getResourceName(attributeResId)));
     }
-    return typedValue.data;
+	if (tv.type == TypedValue.TYPE_STRING) return ContextCompat.getColor(context, typedValue.resourceId);
+    else return typedValue.data;
   }
 
   /**


### PR DESCRIPTION
> I came across this problem when implementing Dark Mode.

- Pic 1 is requesting a `android.R.attr.colorBackground`,I override it in my project theme, return `data` is ok.
<img width="757" alt="Pic1" src="https://user-images.githubusercontent.com/24718357/139388058-473f21d9-3716-414c-bd9e-9f6cc8833e24.png">

- Pic 2 is requesting a `android.R.attr.textColorPrimary` which I didn't override it, and I found the `TypedValue#Type` is `TYPE_STRING`, we can't just return `data`. 
<img width="789" alt="Pic2" src="https://user-images.githubusercontent.com/24718357/139388062-fb48d006-e0ff-4de7-85a3-ff4a7fd52e56.png">

I found this issue, and I solved it, but I don’t know the reason for this design.
