### PR TITLE
[Sliders] Make `BaseOnChangeListener` public

### DIFF
--- a/lib/java/com/google/android/material/slider/BaseOnChangeListener.java
+++ b/lib/java/com/google/android/material/slider/BaseOnChangeListener.java
@@ -17,15 +17,10 @@
 package com.google.android.material.slider;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.RestrictTo;
-import androidx.annotation.RestrictTo.Scope;
 
 /**
  * Interface definition for a callback invoked when a slider's value is changed.
- *
- * @hide
  */
-@RestrictTo(Scope.LIBRARY_GROUP)
 public interface BaseOnChangeListener<S> {
 
   /** Called when the value of the slider changes. */


### PR DESCRIPTION
`Slider.OnChangeListener` and `Slider.OnSliderTouchListener` both extend it and are public APIs. This must be public too, otherwise access to those subtypes are actually a lint error in AGP 7.1+
