### PR TITLE
[MaterialShapeDrawable] Implement getAlpha()

### DIFF
--- a/lib/java/com/google/android/material/shape/MaterialShapeDrawable.java
+++ b/lib/java/com/google/android/material/shape/MaterialShapeDrawable.java
@@ -456,6 +456,11 @@ public class MaterialShapeDrawable extends Drawable implements TintAwareDrawable
   }
 
   @Override
+  public int getAlpha() {
+    return drawableState.alpha;
+  }
+
+  @Override
   public void setAlpha(@IntRange(from = 0, to = 255) int alpha) {
     if (drawableState.alpha != alpha) {
       drawableState.alpha = alpha;

--- a/lib/javatests/com/google/android/material/shape/MaterialShapeDrawableTest.java
+++ b/lib/javatests/com/google/android/material/shape/MaterialShapeDrawableTest.java
@@ -34,6 +34,7 @@ public class MaterialShapeDrawableTest {
   private static final float ELEVATION = 4;
   private static final float TRANSLATION_Z = 2;
   private static final float Z = ELEVATION + TRANSLATION_Z;
+  private static final int ALPHA = 127;
 
   private final Context context = ApplicationProvider.getApplicationContext();
 
@@ -131,5 +132,12 @@ public class MaterialShapeDrawableTest {
     assertThat(drawable.getElevation()).isEqualTo(ELEVATION);
     assertThat(drawable.getFillColor().getDefaultColor()).isEqualTo(colorSurface);
     assertThat(drawable.isElevationOverlayInitialized()).isTrue();
+  }
+
+  @Test
+  public void whenSetAlpha_returnsAlpha() {
+    materialShapeDrawable.setAlpha(ALPHA);
+
+    assertThat(materialShapeDrawable.getAlpha()).isEqualTo(ALPHA);
   }
 }


### PR DESCRIPTION
Closes #1796

Implement `MaterialShapeDrawable.getAlpha()` and return `drawableState.alpha`

- [x] Identify the component the PR relates to in brackets in the title.
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

