### PR TITLE
[BottomSheetDialogFragment] Added constructor with layout ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
 
   androidXVersions = [
     annotation            : '1.2.0',
-    appCompat             : '1.1.0',
+    appCompat             : '1.4.0',
     cardView              : '1.0.0',
     constraintlayout      : '2.0.1',
     coordinatorlayout     : '1.1.0',
@@ -197,8 +197,8 @@ subprojects {
         // This disables the builds tools automatic vector -> PNG generation
         defaultConfig.generatedDensities = []
 
-        compileOptions.sourceCompatibility JavaVersion.VERSION_1_7
-        compileOptions.targetCompatibility JavaVersion.VERSION_1_7
+        compileOptions.sourceCompatibility JavaVersion.VERSION_1_8
+        compileOptions.targetCompatibility JavaVersion.VERSION_1_8
 
         aaptOptions.additionalParameters "--no-version-vectors"
 

--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetDialogFragment.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetDialogFragment.java
@@ -18,6 +18,7 @@ package com.google.android.material.bottomsheet;
 
 import android.app.Dialog;
 import android.os.Bundle;
+import androidx.annotation.LayoutRes;
 import androidx.appcompat.app.AppCompatDialogFragment;
 import android.view.View;
 import androidx.annotation.NonNull;
@@ -34,6 +35,16 @@ public class BottomSheetDialogFragment extends AppCompatDialogFragment {
    * BottomSheet is hidden and onStateChanged() is called.
    */
   private boolean waitingForDismissAllowingStateLoss;
+
+  /** {@inheritDoc} **/
+  public BottomSheetDialogFragment() {
+    super();
+  }
+
+  /** {@inheritDoc} **/
+  public BottomSheetDialogFragment(@LayoutRes int contentLayoutId) {
+    super(contentLayoutId);
+  }
 
   @NonNull
   @Override


### PR DESCRIPTION
### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [X] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [X] Link to GitHub issues it solves. `closes #1105 `
- [X] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.

Fixes https://github.com/material-components/material-components-android/issues/1105

This PR adds a constructor to `BottomSheetDialogFragment` that takes a layout ID.
Basically this PR exposes the constructor available in `AppCompatDialogFragment` since `AppCompat` version 1.4.0.

"Added AppCompatDialogFragment constructor that takes a layout ID ([Icbf22](https://android-review.googlesource.com/#/q/Icbf22da2f79aa902756a8e2e319efa5a0d92bdde), [b/188119987](https://issuetracker.google.com/issues/188119987))"

`AppCompat` version 1.4.0 targeting Java 8 language level, so it requires `material-components-android` to update the java version also to 1.8.
For more details on the `AppCompat` 1.4.0, here is the link https://developer.android.com/jetpack/androidx/releases/appcompat#1.4.0
`Library is now targeting Java 8 language level`