### PR TITLE
[AppBarLayout] Add liftOnScrollTargetView public setter

### DIFF
--- a/lib/java/com/google/android/material/appbar/AppBarLayout.java
+++ b/lib/java/com/google/android/material/appbar/AppBarLayout.java
@@ -973,6 +973,16 @@ public class AppBarLayout extends LinearLayout implements CoordinatorLayout.Atta
   }
 
   /**
+   * Sets the view that the {@link AppBarLayout} should use to determine whether it should be
+   * lifted and left the {@link AppBarLayout} if it should be.
+   */
+  public void setLiftOnScrollTargetView(View liftOnScrollTargetView) {
+    this.liftOnScrollTargetViewId = liftOnScrollTargetView.getId();
+    this.liftOnScrollTargetView = new WeakReference<>(liftOnScrollTargetView);
+    shouldLift(null);
+  }
+
+  /**
    * Returns the id of the view that the {@link AppBarLayout} should use to determine whether it
    * should be lifted.
    */


### PR DESCRIPTION
Add a public setter on weak ref `liftOnScrollTargetView` so we can have a better control on the scrolling view finding. Today we can only set an id which might be part a reused layout leading to unexpected behavior, especially when using a view pager with many fragment using the same layout (simple recycler). Moreover, when using view binding, it is easier and cleaner to provide the view directly.
The current solution is to use reflection to directly set the `liftOnScrollTargetView` and bypass `liftOnScrollTargetViewId`.