### PR TITLE
[MaterialDatePicker] closes #1676

### DIFF
--- a/lib/java/com/google/android/material/datepicker/MonthAdapter.java
+++ b/lib/java/com/google/android/material/datepicker/MonthAdapter.java
@@ -88,16 +88,11 @@ class MonthAdapter extends BaseAdapter {
   }
 
   /**
-   * Returns the number of days in a month plus the amount required to off-set for the first day to
-   * the correct position within the week.
-   *
-   * <p>{@see MonthAdapter#firstPositionInMonth}.
-   *
-   * @return The maximum valid position index
+   * @return The maximum number of cells for a month with 6 rows
    */
   @Override
   public int getCount() {
-    return month.daysInMonth + firstPositionInMonth();
+    return 42;
   }
 
   @NonNull


### PR DESCRIPTION
Lets Month Adapter consistently render a full 6x7 grid, and prevents the impact of a smaller grid rendered for the first visible month on adjacent months.
