### PR TITLE
[Color] Fix HarmonizedColorsOptions.Builder#setColorAttributes is marked as nullable

### DIFF
--- a/lib/java/com/google/android/material/color/HarmonizedColorsOptions.java
+++ b/lib/java/com/google/android/material/color/HarmonizedColorsOptions.java
@@ -102,7 +102,7 @@ public class HarmonizedColorsOptions {
      *
      * @param colorAttributes The {@link HarmonizedColorAttributes} that needs to be harmonized.
      */
-    @Nullable
+    @NonNull
     public Builder setColorAttributes(@Nullable HarmonizedColorAttributes colorAttributes) {
       this.colorAttributes = colorAttributes;
       return this;


### PR DESCRIPTION
https://github.com/material-components/material-components-android/blob/788866e4483621e2222f649e617ee95f7aa9caa6/lib/java/com/google/android/material/color/HarmonizedColorsOptions.java#L105-L109

Fix #2650