### PR TITLE
Replace all Android strings with library ones

### DIFF
--- a/lib/java/com/google/android/material/datepicker/res/values-af/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-af/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s-%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Gekose datum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Kanselleer"</string>
   <string name="mtrl_picker_text_input_date_hint">Datum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Begindatum</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Einddatum</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-am/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-am/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">የተመረጠው ቀን</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"እሺ"</string>
+  <string name="mtrl_picker_cancel">"ይቅር"</string>
   <string name="mtrl_picker_text_input_date_hint">ቀን</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">መጀመሪያ ቀን</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">የማብቂያ ቀን</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ar/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ar/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">التاريخ المحدَّد</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"حسنًا"</string>
+  <string name="mtrl_picker_cancel">"إلغاء"</string>
   <string name="mtrl_picker_text_input_date_hint">التاريخ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">تاريخ البدء</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">تاريخ الانتهاء</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-as/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-as/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Selected date</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ঠিক আছে"</string>
+  <string name="mtrl_picker_cancel">"বাতিল কৰক"</string>
   <string name="mtrl_picker_text_input_date_hint">Date</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Start date</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">End date</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-az/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-az/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s: %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Seçilmiş tarix</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Ləğv edin"</string>
   <string name="mtrl_picker_text_input_date_hint">Tarix</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Başlama tarixi</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Bitmə tarixi</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-b+es+419/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-b+es+419/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s-%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Fecha seleccionada</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Aceptar"</string>
+  <string name="mtrl_picker_cancel">"Cancelar"</string>
   <string name="mtrl_picker_text_input_date_hint">Fecha</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Fecha de inicio</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Fecha de finalización</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-b+sr+Latn/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-b+sr+Latn/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s–%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Izabrani datum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Potvrdi"</string>
+  <string name="mtrl_picker_cancel">"Otkaži"</string>
   <string name="mtrl_picker_text_input_date_hint">Datum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Datum početka</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Datum završetka</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-be/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-be/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Выбраная дата</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ОК"</string>
+  <string name="mtrl_picker_cancel">"Скасаваць"</string>
   <string name="mtrl_picker_text_input_date_hint">Дата</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Дата пачатку</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Дата заканчэння</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-bg/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-bg/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Избрана дата</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Отказ"</string>
   <string name="mtrl_picker_text_input_date_hint">Дата</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Начална дата</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Крайна дата</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-bn/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-bn/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">বেছে নেওয়া তারিখ</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ঠিক আছে"</string>
+  <string name="mtrl_picker_cancel">"বাতিল করুন"</string>
   <string name="mtrl_picker_text_input_date_hint">তারিখ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">শুরুর তারিখ</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">সমাপ্তির তারিখ</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-bs/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-bs/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Odabrani datum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Uredu"</string>
+  <string name="mtrl_picker_cancel">"Otkaži"</string>
   <string name="mtrl_picker_text_input_date_hint">Datum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Datum početka</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Datum završetka</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ca/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ca/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s - %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Data seleccionada</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"D\'acord"</string>
+  <string name="mtrl_picker_cancel">"Cancel·la"</string>
   <string name="mtrl_picker_text_input_date_hint">Data</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Data d\'inici</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Data de finalització</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-cs/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-cs/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Vybrané datum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Zrušit"</string>
   <string name="mtrl_picker_text_input_date_hint">Datum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Datum zahájení</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Datum ukončení</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-da/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-da/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Valgt dato</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Annuller"</string>
   <string name="mtrl_picker_text_input_date_hint">Dato</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Startdato</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Slutdato</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-de/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-de/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Ausgewähltes Datum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Abbrechen"</string>
   <string name="mtrl_picker_text_input_date_hint">Datum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Startdatum</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Enddatum</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-el/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-el/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Επιλεγμένη ημερομηνία</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Ακύρωση"</string>
   <string name="mtrl_picker_text_input_date_hint">Ημερομηνία</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Ημερομηνία έναρξης</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Ημερομηνία λήξης</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-en-rGB/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-en-rGB/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Selected date</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Cancel"</string>
   <string name="mtrl_picker_text_input_date_hint">Date</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Start date</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">End date</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-es-rUS/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-es-rUS/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s-%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Fecha seleccionada</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Aceptar"</string>
+  <string name="mtrl_picker_cancel">"Cancelar"</string>
   <string name="mtrl_picker_text_input_date_hint">Fecha</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Fecha de inicio</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Fecha de finalización</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-es/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-es/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Fecha seleccionada</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Aceptar"</string>
+  <string name="mtrl_picker_cancel">"Cancelar"</string>
   <string name="mtrl_picker_text_input_date_hint">Fecha</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Fecha de inicio</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Fecha de finalización</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-et/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-et/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s–%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Valitud kuupäev</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Tühista"</string>
   <string name="mtrl_picker_text_input_date_hint">Kuupäev</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Alguskuupäev</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Lõppkuupäev</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-eu/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-eu/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s-%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Hautatutako data</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Ados"</string>
+  <string name="mtrl_picker_cancel">"Utzi"</string>
   <string name="mtrl_picker_text_input_date_hint">Data</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Hasiera-data</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Amaiera-data</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-fa/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-fa/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">تاریخ انتخابی</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"تأیید"</string>
+  <string name="mtrl_picker_cancel">"لغو"</string>
   <string name="mtrl_picker_text_input_date_hint">تاریخ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">تاریخ شروع</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">تاریخ پایان</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-fi/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-fi/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Valittu päivämäärä</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Peru"</string>
   <string name="mtrl_picker_text_input_date_hint">Päivämäärä</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Alkamispäivä</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Päättymispäivä</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-fr-rCA/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-fr-rCA/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">Du %1$s au %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Date sélectionnée</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Annuler"</string>
   <string name="mtrl_picker_text_input_date_hint">Date</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Date de début</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Date de fin</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-fr/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-fr/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s - %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Date sélectionnée</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Annuler"</string>
   <string name="mtrl_picker_text_input_date_hint">Date</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Date de début</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Date de fin</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-gl/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-gl/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s - %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Data seleccionada</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Aceptar"</string>
+  <string name="mtrl_picker_cancel">"Cancelar"</string>
   <string name="mtrl_picker_text_input_date_hint">Data</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Data de inicio</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Data de finalización</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-gu/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-gu/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">પસંદ કરેલી તારીખ</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ઓકે"</string>
+  <string name="mtrl_picker_cancel">"રદ કરો"</string>
   <string name="mtrl_picker_text_input_date_hint">તારીખ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">શરૂ કરવાની તારીખ</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">સમાપ્તિની તારીખ</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-hi/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-hi/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">चुनी गई तारीख</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ठीक है"</string>
+  <string name="mtrl_picker_cancel">"रद्द करें"</string>
   <string name="mtrl_picker_text_input_date_hint">तारीख</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">शुरू होने की तारीख</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">खत्म होने की तारीख</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-hr/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-hr/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Odabrani datum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"U redu"</string>
+  <string name="mtrl_picker_cancel">"Odustani"</string>
   <string name="mtrl_picker_text_input_date_hint">Datum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Datum početka</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Datum završetka</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-hu/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-hu/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Kiválasztott dátum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Mégse"</string>
   <string name="mtrl_picker_text_input_date_hint">Dátum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Kezdés dátuma</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Befejezés dátuma</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-hy/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-hy/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Ընտրված ամսաթիվը</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Լավ"</string>
+  <string name="mtrl_picker_cancel">"Չեղարկել"</string>
   <string name="mtrl_picker_text_input_date_hint">Ամսաթիվ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Մեկնարկի ամսաթիվը</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Ավարտի ամսաթիվը</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-in/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-in/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Tanggal yang dipilih</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Oke"</string>
+  <string name="mtrl_picker_cancel">"Batal"</string>
   <string name="mtrl_picker_text_input_date_hint">Tanggal</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Tanggal mulai</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Tanggal akhir</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-is/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-is/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Valin dagsetning</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Í lagi"</string>
+  <string name="mtrl_picker_cancel">"Hætta við"</string>
   <string name="mtrl_picker_text_input_date_hint">Dagsetning</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Upphafsdagur</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Lokadagur</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-it/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-it/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s - %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Data selezionata</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Annulla"</string>
   <string name="mtrl_picker_text_input_date_hint">Data</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Data di inizio</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Data di fine</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-iw/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-iw/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">התאריך הנבחר</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"אישור"</string>
+  <string name="mtrl_picker_cancel">"ביטול"</string>
   <string name="mtrl_picker_text_input_date_hint">תאריך</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">תאריך התחלה</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">תאריך סיום</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ja/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ja/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s～%2$s</string>
   <string name="mtrl_picker_date_header_unselected">選択した日付</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"キャンセル"</string>
   <string name="mtrl_picker_text_input_date_hint">日付</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">開始日</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">終了日</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ka/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ka/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s - %2$s</string>
   <string name="mtrl_picker_date_header_unselected">არჩეული თარიღი</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"გაუქმება"</string>
   <string name="mtrl_picker_text_input_date_hint">თარიღი</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">დაწყების თარიღი</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">დასრულების თარიღი</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-kk/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-kk/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Таңдалған күн</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Жарайды"</string>
+  <string name="mtrl_picker_cancel">"Бас тарту"</string>
   <string name="mtrl_picker_text_input_date_hint">Күні</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Басталу күні</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Аяқталу күні</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-km/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-km/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">កាលបរិច្ឆេទដែលបាន​ជ្រើសរើស</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"យល់​ព្រម​"</string>
+  <string name="mtrl_picker_cancel">"បោះ​បង់​"</string>
   <string name="mtrl_picker_text_input_date_hint">កាលបរិច្ឆេទ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">កាល​បរិច្ឆេទ​ចាប់ផ្ដើម</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">កាល​បរិច្ឆេទ​បញ្ចប់</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-kn/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-kn/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">ದಿನಾಂಕವನ್ನು ಆಯ್ಕೆಮಾಡಲಾಗಿದೆ</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ಸರಿ"</string>
+  <string name="mtrl_picker_cancel">"ರದ್ದುಮಾಡಿ"</string>
   <string name="mtrl_picker_text_input_date_hint">ದಿನಾಂಕ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">ಪ್ರಾರಂಭ ದಿನಾಂಕ</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">ಮುಕ್ತಾಯ ದಿನಾಂಕ</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ko/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ko/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s~%2$s</string>
   <string name="mtrl_picker_date_header_unselected">선택한 날짜</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"확인"</string>
+  <string name="mtrl_picker_cancel">"취소"</string>
   <string name="mtrl_picker_text_input_date_hint">날짜</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">시작일</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">종료일</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ky/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ky/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Тандалган күн</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Жарайт"</string>
+  <string name="mtrl_picker_cancel">"Жокко чыгаруу"</string>
   <string name="mtrl_picker_text_input_date_hint">Күн</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Баштоо күнү</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Аяктоо күнү</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-lo/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-lo/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">ເລືອກວັນທີ</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ຕົກລົງ"</string>
+  <string name="mtrl_picker_cancel">"ຍົກເລີກ"</string>
   <string name="mtrl_picker_text_input_date_hint">ວັນທີ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">ວັນທີເລີ່ມ</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">ວັນທີສິ້ນສຸດ</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-lt/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-lt/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s–%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Pasirinkta data</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Gerai"</string>
+  <string name="mtrl_picker_cancel">"Atšaukti"</string>
   <string name="mtrl_picker_text_input_date_hint">Data</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Pradžios data</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Pabaigos data</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-lv/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-lv/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s–%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Atlasītais datums</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Labi"</string>
+  <string name="mtrl_picker_cancel">"Atcelt"</string>
   <string name="mtrl_picker_text_input_date_hint">Datums</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Sākuma datums</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Beigu datums</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-mk/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-mk/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s - %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Избран датум</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Во ред"</string>
+  <string name="mtrl_picker_cancel">"Откажи"</string>
   <string name="mtrl_picker_text_input_date_hint">Датум</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Почетен датум</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Краен датум</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ml/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ml/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">തിരഞ്ഞെടുത്ത തീയതി</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ശരി"</string>
+  <string name="mtrl_picker_cancel">"റദ്ദാക്കുക"</string>
   <string name="mtrl_picker_text_input_date_hint">തീയതി</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">ആരംഭിക്കുന്ന തീയതി</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">അവസാനിക്കുന്ന തീയതി</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-mn/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-mn/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Сонгосон огноо</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ОК"</string>
+  <string name="mtrl_picker_cancel">"Цуцлах"</string>
   <string name="mtrl_picker_text_input_date_hint">Огноо</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Эхлэх огноо</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Дуусах огноо</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-mr/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-mr/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">निवडलेली तारीख</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ठीक आहे"</string>
+  <string name="mtrl_picker_cancel">"रद्द करा"</string>
   <string name="mtrl_picker_text_input_date_hint">तारीख</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">सुरू होण्याची तारीख</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">संपण्याची तारीख</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ms/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ms/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Tarikh dipilih</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Batal"</string>
   <string name="mtrl_picker_text_input_date_hint">Tarikh</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Tarikh mula</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Tarikh tamat</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-my/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-my/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">ရွေးထားသည့် ရက်စွဲ</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"မလုပ်တော့"</string>
   <string name="mtrl_picker_text_input_date_hint">ရက်စွဲ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">စတင်ရက်</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">ပြီးဆုံးရက်</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-nb/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-nb/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s–%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Valgt dato</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Avbryt"</string>
   <string name="mtrl_picker_text_input_date_hint">Dato</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Startdato</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Sluttdato</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ne/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ne/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">चयन गरिएको मिति</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ठिक छ"</string>
+  <string name="mtrl_picker_cancel">"रद्द गर्नुहोस्"</string>
   <string name="mtrl_picker_text_input_date_hint">मिति</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">सुरु हुने मिति</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">अन्त्य हुने मिति</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-nl/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-nl/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Geselecteerde datum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Annuleren"</string>
   <string name="mtrl_picker_text_input_date_hint">Datum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Startdatum</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Einddatum</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-or/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-or/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Selected date</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ଠିକ୍‍ ଅଛି"</string>
+  <string name="mtrl_picker_cancel">"ବାତିଲ୍‍ କରନ୍ତୁ"</string>
   <string name="mtrl_picker_text_input_date_hint">Date</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Start date</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">End date</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-pa/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-pa/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">ਚੁਣੀ ਗਈ ਤਾਰੀਖ</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ਠੀਕ ਹੈ"</string>
+  <string name="mtrl_picker_cancel">"ਰੱਦ ਕਰੋ"</string>
   <string name="mtrl_picker_text_input_date_hint">ਤਾਰੀਖ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">ਸ਼ੁਰੂਆਤੀ ਤਾਰੀਖ</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">ਸਮਾਪਤੀ ਤਾਰੀਖ</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-pl/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-pl/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s–%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Wybrana data</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Anuluj"</string>
   <string name="mtrl_picker_text_input_date_hint">Data</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Data rozpoczęcia</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Data zakończenia</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-pt-rBR/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-pt-rBR/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Data selecionada</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Cancelar"</string>
   <string name="mtrl_picker_text_input_date_hint">Data</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Data de início</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Data de término</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-pt-rPT/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-pt-rPT/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Data selecionada</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Cancelar"</string>
   <string name="mtrl_picker_text_input_date_hint">Data</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Data de início</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Data de conclusão</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ro/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ro/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Data selectată</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Anulați"</string>
   <string name="mtrl_picker_text_input_date_hint">Dată</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Data de începere</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Data de încheiere</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ru/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ru/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Выбранная дата</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ОК"</string>
+  <string name="mtrl_picker_cancel">"Отмена"</string>
   <string name="mtrl_picker_text_input_date_hint">Дата</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Дата начала</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Дата окончания</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-si/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-si/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">තේරූ දිනය</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"හරි"</string>
+  <string name="mtrl_picker_cancel">"අවලංගු කරන්න"</string>
   <string name="mtrl_picker_text_input_date_hint">දිනය</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">ආරම්භක දිනය</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">නිමා වන දිනය</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-sk/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-sk/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Vybraný dátum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Zrušiť"</string>
   <string name="mtrl_picker_text_input_date_hint">Dátum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Dátum začatia</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Dátum ukončenia</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-sl/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-sl/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s–%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Izbrani datum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"V redu"</string>
+  <string name="mtrl_picker_cancel">"Prekliči"</string>
   <string name="mtrl_picker_text_input_date_hint">Datum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Začetni datum</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Končni datum</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-sq/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-sq/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s - %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Data e zgjedhur</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Në rregull"</string>
+  <string name="mtrl_picker_cancel">"Anulo"</string>
   <string name="mtrl_picker_text_input_date_hint">Data</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Data e fillimit</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Data e përfundimit</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-sr/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-sr/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s–%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Изабрани датум</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Потврди"</string>
+  <string name="mtrl_picker_cancel">"Откажи"</string>
   <string name="mtrl_picker_text_input_date_hint">Датум</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Датум почетка</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Датум завршетка</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-sv/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-sv/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s–%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Valt datum</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Avbryt"</string>
   <string name="mtrl_picker_text_input_date_hint">Datum</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Startdatum</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Slutdatum</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-sw/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-sw/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Tarehe uliyochagua</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Sawa"</string>
+  <string name="mtrl_picker_cancel">"Ghairi"</string>
   <string name="mtrl_picker_text_input_date_hint">Tarehe</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Tarehe ya kuanza</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Tarehe ya mwisho</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ta/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ta/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">தேர்ந்தெடுக்கப்பட்ட தேதி</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"சரி"</string>
+  <string name="mtrl_picker_cancel">"ரத்துசெய்"</string>
   <string name="mtrl_picker_text_input_date_hint">தேதி</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">தொடக்கத் தேதி</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">முடிவுத் தேதி</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-te/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-te/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">ఎంచుకున్న తేది</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"సరే"</string>
+  <string name="mtrl_picker_cancel">"రద్దు చేయి"</string>
   <string name="mtrl_picker_text_input_date_hint">తేదీ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">ప్రారంభ తేదీ</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">ముగింపు తేదీ</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-th/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-th/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">วันที่ที่เลือก</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ตกลง"</string>
+  <string name="mtrl_picker_cancel">"ยกเลิก"</string>
   <string name="mtrl_picker_text_input_date_hint">วันที่</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">วันที่เริ่มต้น</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">วันที่สิ้นสุด</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-tl/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-tl/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Piniling petsa</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Kanselahin"</string>
   <string name="mtrl_picker_text_input_date_hint">Petsa</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Petsa ng pagsisimula</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Petsa ng pagtatapos</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-tr/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-tr/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s-%2$s</string>
   <string name="mtrl_picker_date_header_unselected">Seçilen tarih</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"Tamam"</string>
+  <string name="mtrl_picker_cancel">"İptal"</string>
   <string name="mtrl_picker_text_input_date_hint">Tarih</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Başlangıç tarihi</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Bitiş tarihi</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-uk/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-uk/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Вибрана дата</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Скасувати"</string>
   <string name="mtrl_picker_text_input_date_hint">Дата</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Дата початку</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Дата завершення</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-ur/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-ur/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">منتخب کردہ تاریخ</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"ٹھیک ہے"</string>
+  <string name="mtrl_picker_cancel">"منسوخ کریں"</string>
   <string name="mtrl_picker_text_input_date_hint">تاریخ</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">تاریخ آغاز</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">تاریخ اختتام</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-uz/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-uz/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Tanlangan sana</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Bekor qilish"</string>
   <string name="mtrl_picker_text_input_date_hint">Sana</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Boshlanish sanasi</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Tugash sanasi</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-vi/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-vi/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Ngày đã chọn</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"OK"</string>
+  <string name="mtrl_picker_cancel">"Hủy"</string>
   <string name="mtrl_picker_text_input_date_hint">Ngày</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Ngày bắt đầu</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Ngày kết thúc</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-zh-rCN/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-zh-rCN/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s - %2$s</string>
   <string name="mtrl_picker_date_header_unselected">选定的日期</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"确定"</string>
+  <string name="mtrl_picker_cancel">"取消"</string>
   <string name="mtrl_picker_text_input_date_hint">日期</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">开始日期</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">结束日期</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-zh-rHK/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-zh-rHK/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">已選取日期</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"確定"</string>
+  <string name="mtrl_picker_cancel">"取消"</string>
   <string name="mtrl_picker_text_input_date_hint">日期</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">開始日期</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">結束日期</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-zh-rTW/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-zh-rTW/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">所選日期</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"確定"</string>
+  <string name="mtrl_picker_cancel">"取消"</string>
   <string name="mtrl_picker_text_input_date_hint">日期</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">開始日期</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">結束日期</string>

--- a/lib/java/com/google/android/material/datepicker/res/values-zu/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values-zu/strings.xml
@@ -23,7 +23,8 @@
   <string name="mtrl_picker_range_header_selected">%1$s – %2$s</string>
   <string name="mtrl_picker_date_header_unselected">Khetha idethi</string>
   <string name="mtrl_picker_date_header_selected">%1$s</string>
-  <string name="mtrl_picker_confirm">@android:string/ok</string>
+  <string name="mtrl_picker_confirm">"KULUNGILE"</string>
+  <string name="mtrl_picker_cancel">"Khansela"</string>
   <string name="mtrl_picker_text_input_date_hint">Idethi</string>
   <string name="mtrl_picker_text_input_date_range_start_hint">Idethi yokuqala</string>
   <string name="mtrl_picker_text_input_date_range_end_hint">Idethi yokuphela</string>

--- a/lib/java/com/google/android/material/datepicker/res/values/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values/strings.xml
@@ -24,7 +24,7 @@
   <string name="mtrl_picker_date_header_unselected" description="Placeholder for a single date [CHAR_LIMIT=60]">Selected date</string>
   <string name="mtrl_picker_date_header_selected" description="A single date [CHAR_LIMIT=60]">%1$s</string>
   <string name="mtrl_picker_confirm" description="Button text to indicate that the widget will save the user's selection [CHAR_LIMIT=16]">OK</string>
-  <string name="mtrl_picker_cancel" description="Button text to indicate that the widget will ignore the user's selection [CHAR_LIMIT=16]" translatable="false">@android:string/cancel</string>
+  <string name="mtrl_picker_cancel" description="Button text to indicate that the widget will ignore the user's selection [CHAR_LIMIT=16]">Cancel</string>
   <string name="mtrl_picker_text_input_date_hint" description="Label for a single date selected by the user [CHAR_LIMIT=60]">Date</string>
   <string name="mtrl_picker_text_input_date_range_start_hint" description="Label for the start date in a range selected by the user [CHAR_LIMIT=60]">Start date</string>
   <string name="mtrl_picker_text_input_date_range_end_hint" description="Label for the end date in a range selected by the user [CHAR_LIMIT=60]">End date</string>

--- a/lib/java/com/google/android/material/timepicker/res/layout/material_timepicker_dialog.xml
+++ b/lib/java/com/google/android/material/timepicker/res/layout/material_timepicker_dialog.xml
@@ -87,7 +87,7 @@
     android:layout_marginTop="2dp"
     android:layout_marginEnd="8dp"
     android:minWidth="72dp"
-    android:text="@android:string/cancel"
+    android:text="@string/mtrl_timepicker_cancel"
     app:layout_constraintEnd_toStartOf="@id/material_timepicker_ok_button"
     app:layout_constraintTop_toTopOf="@id/material_timepicker_mode_button" />
 

--- a/lib/java/com/google/android/material/timepicker/res/values-af/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-af/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minute</string>
   <string name="material_hour_selection">Kies uur</string>
   <string name="material_minute_selection">Kies minute</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Kanselleer"</string>
   <string name="material_clock_toggle_content_description">Kies vm. of nm.</string>
   <string name="material_timepicker_text_input_mode_description">Skakel oor na teksmodus vir die tydinvoer.</string>
   <string name="material_timepicker_clock_mode_description">Skakel oor na horlosiemodus vir die tydinvoer.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-am/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-am/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s ደቂቃዎች</string>
   <string name="material_hour_selection">ሰዓትን ይምረጡ</string>
   <string name="material_minute_selection">ደቂቃዎችን ይምረጡ</string>
+  <string name="mtrl_timepicker_confirm">"እሺ"</string>
+  <string name="mtrl_timepicker_cancel">"ይቅር"</string>
   <string name="material_clock_toggle_content_description">AM ወይም PM ይምረጡ</string>
   <string name="material_timepicker_text_input_mode_description">ለጊዜ ግቤቱ ወደ የጽሑፍ ግቤት ሁነታ ቀይር።</string>
   <string name="material_timepicker_clock_mode_description">ለጊዜ ግቤቱ ወደ የሰዓት ሁነታ ቀይር።</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ar/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ar/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s دقيقة</string>
   <string name="material_hour_selection">تحديد الساعة</string>
   <string name="material_minute_selection">تحديد الدقائق</string>
+  <string name="mtrl_timepicker_confirm">"حسنًا"</string>
+  <string name="mtrl_timepicker_cancel">"إلغاء"</string>
   <string name="material_clock_toggle_content_description">يُرجى اختيار صباحًا أو مساءً.</string>
   <string name="material_timepicker_text_input_mode_description">يُرجى التبديل إلى وضع إدخال النص لإدخال الوقت.</string>
   <string name="material_timepicker_clock_mode_description">يُرجى التبديل إلى وضع الساعة لإدخال الوقت.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-as/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-as/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutes</string>
   <string name="material_hour_selection">Select hour</string>
   <string name="material_minute_selection">মিনিট বাছনি কৰক</string>
+  <string name="mtrl_timepicker_confirm">"ঠিক আছে"</string>
+  <string name="mtrl_timepicker_cancel">"বাতিল কৰক"</string>
   <string name="material_clock_toggle_content_description">Select AM or PM</string>
   <string name="material_timepicker_text_input_mode_description">সময়ৰ ইনপুটৰ বাবে পাঠৰ ইনপুট ম\'ডলৈ যাওক।</string>
   <string name="material_timepicker_clock_mode_description">সময়ৰ ইনপুটৰ বাবে ঘড়ী ম\'ডলৈ যাওক।</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-az/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-az/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s dəqiqə</string>
   <string name="material_hour_selection">Saatı seçin</string>
   <string name="material_minute_selection">Dəqiqə seçin</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Ləğv edin"</string>
   <string name="material_clock_toggle_content_description">Gündüz və ya axşam seçin</string>
   <string name="material_timepicker_text_input_mode_description">Zamanı daxil etmək üçün mətnlə daxiletmə rejiminə keçin</string>
   <string name="material_timepicker_clock_mode_description">Zamanı daxil etmək üçün saat rejiminə keçin</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-b+es+419/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-b+es+419/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutos</string>
   <string name="material_hour_selection">Seleccione la hora.</string>
   <string name="material_minute_selection">Seleccionar minutos</string>
+  <string name="mtrl_timepicker_confirm">"Aceptar"</string>
+  <string name="mtrl_timepicker_cancel">"Cancelar"</string>
   <string name="material_clock_toggle_content_description">Selecciona a.m. o p.m.</string>
   <string name="material_timepicker_text_input_mode_description">Cambia al modo de entrada de texto para ingresar la hora.</string>
   <string name="material_timepicker_clock_mode_description">Cambia al modo de reloj para ingresar la hora.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-b+sr+Latn/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-b+sr+Latn/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s min</string>
   <string name="material_hour_selection">Izaberite sat</string>
   <string name="material_minute_selection">Izaberite minute</string>
+  <string name="mtrl_timepicker_confirm">"Potvrdi"</string>
+  <string name="mtrl_timepicker_cancel">"Otkaži"</string>
   <string name="material_clock_toggle_content_description">Izaberite pre podne ili po podne</string>
   <string name="material_timepicker_text_input_mode_description">Pređite u režim unosa teksta radi unosa vremena.</string>
   <string name="material_timepicker_clock_mode_description">Pređite u režim sata radi unosa vremena.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-be/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-be/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s хв</string>
   <string name="material_hour_selection">Выберыце гадзіну</string>
   <string name="material_minute_selection">Выберыце хвіліны</string>
+  <string name="mtrl_timepicker_confirm">"ОК"</string>
+  <string name="mtrl_timepicker_cancel">"Скасаваць"</string>
   <string name="material_clock_toggle_content_description">Выберыце AM (да паўдня) або PM (пасля паўдня)</string>
   <string name="material_timepicker_text_input_mode_description">Пераключыцца на рэжым тэксту пры ўводзе часу.</string>
   <string name="material_timepicker_clock_mode_description">Пераключыцца на рэжым гадзінніка пры ўводзе часу.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-bg/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-bg/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s минути</string>
   <string name="material_hour_selection">Изберете час</string>
   <string name="material_minute_selection">Избиране на минути</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Отказ"</string>
   <string name="material_clock_toggle_content_description">Изберете AM или PM</string>
   <string name="material_timepicker_text_input_mode_description">Превключете към режима за въвеждане на текст, за да въведете часа.</string>
   <string name="material_timepicker_clock_mode_description">Превключете към режима за часовник, за да въведете часа.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-bn/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-bn/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s মিনিট</string>
   <string name="material_hour_selection">ঘণ্টা বেছে নিন</string>
   <string name="material_minute_selection">মিনিট বেছে নিন</string>
+  <string name="mtrl_timepicker_confirm">"ঠিক আছে"</string>
+  <string name="mtrl_timepicker_cancel">"বাতিল করুন"</string>
   <string name="material_clock_toggle_content_description">AM অথবা PM বেছে নিন</string>
   <string name="material_timepicker_text_input_mode_description">সময় ইনপুট দেওয়ার জন্য পাঠ্য ইনপুট মোডে যান।</string>
   <string name="material_timepicker_clock_mode_description">সময় ইনপুট দেওয়ার জন্য ঘড়ি মোডে যান।</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-bs/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-bs/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s min</string>
   <string name="material_hour_selection">Odaberite sat</string>
   <string name="material_minute_selection">Odaberite minute</string>
+  <string name="mtrl_timepicker_confirm">"Uredu"</string>
+  <string name="mtrl_timepicker_cancel">"Otkaži"</string>
   <string name="material_clock_toggle_content_description">Odaberite prijepodne ili poslijepodne</string>
   <string name="material_timepicker_text_input_mode_description">Prebacite u način unosa teksta za unos vremena.</string>
   <string name="material_timepicker_clock_mode_description">Prebacite u način rada kao sat za unos vremena.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ca/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ca/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minuts</string>
   <string name="material_hour_selection">Seleccioneu l\'hora</string>
   <string name="material_minute_selection">Selecciona els minuts</string>
+  <string name="mtrl_timepicker_confirm">"D\'acord"</string>
+  <string name="mtrl_timepicker_cancel">"Cancel·la"</string>
   <string name="material_clock_toggle_content_description">Selecciona a. m. o p. m.</string>
   <string name="material_timepicker_text_input_mode_description">Canvia al mode d\'introducció de text per introduir l\'hora.</string>
   <string name="material_timepicker_clock_mode_description">Canvia al mode de rellotge per introduir l\'hora.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-cs/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-cs/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s min</string>
   <string name="material_hour_selection">Vyberte hodinu</string>
   <string name="material_minute_selection">Zvolte minuty</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Zrušit"</string>
   <string name="material_clock_toggle_content_description">Vyberte AM nebo PM</string>
   <string name="material_timepicker_text_input_mode_description">Chcete-li zadat čas, přepněte na režim textu.</string>
   <string name="material_timepicker_clock_mode_description">Chcete-li zadat čas, přepněte na režim hodin.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-da/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-da/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutter</string>
   <string name="material_hour_selection">Vælg time</string>
   <string name="material_minute_selection">Vælg minutter</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Annuller"</string>
   <string name="material_clock_toggle_content_description">Vælg AM eller PM</string>
   <string name="material_timepicker_text_input_mode_description">Skift til teksttilstand for at angive klokkeslæt.</string>
   <string name="material_timepicker_clock_mode_description">Skift til urtilstand for at angive klokkeslæt.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-de/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-de/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s Minuten</string>
   <string name="material_hour_selection">Stunde auswählen</string>
   <string name="material_minute_selection">Minuten auswählen</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Abbrechen"</string>
   <string name="material_clock_toggle_content_description">Vormittags oder Nachmittags auswählen</string>
   <string name="material_timepicker_text_input_mode_description">In den Texteingabemodus wechseln, um die Uhrzeit einzugeben.</string>
   <string name="material_timepicker_clock_mode_description">In den Uhrzeitmodus wechseln, um die Uhrzeit einzugeben.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-el/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-el/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s λεπτά</string>
   <string name="material_hour_selection">Επιλογή ώρας</string>
   <string name="material_minute_selection">Επιλογή λεπτών</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Ακύρωση"</string>
   <string name="material_clock_toggle_content_description">Επιλέξτε π.μ. ή μ.μ.</string>
   <string name="material_timepicker_text_input_mode_description">Κάντε εναλλαγή στη λειτουργία εισαγωγής κειμένου, για την εισαγωγή της ώρας.</string>
   <string name="material_timepicker_clock_mode_description">Κάντε εναλλαγή στη λειτουργία ρολογιού, για την εισαγωγή της ώρας.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-en-rGB/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-en-rGB/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutes</string>
   <string name="material_hour_selection">Select hour</string>
   <string name="material_minute_selection">Select minutes</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Cancel"</string>
   <string name="material_clock_toggle_content_description">Select a.m. or p.m.</string>
   <string name="material_timepicker_text_input_mode_description">Switch to text input mode for the time input.</string>
   <string name="material_timepicker_clock_mode_description">Switch to clock mode for the time input.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-es-rUS/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-es-rUS/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutos</string>
   <string name="material_hour_selection">Seleccione la hora.</string>
   <string name="material_minute_selection">Seleccionar minutos</string>
+  <string name="mtrl_timepicker_confirm">"Aceptar"</string>
+  <string name="mtrl_timepicker_cancel">"Cancelar"</string>
   <string name="material_clock_toggle_content_description">Selecciona a.m. o p.m.</string>
   <string name="material_timepicker_text_input_mode_description">Cambia al modo de entrada de texto para ingresar la hora.</string>
   <string name="material_timepicker_clock_mode_description">Cambia al modo de reloj para ingresar la hora.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-es/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-es/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutos</string>
   <string name="material_hour_selection">Seleccionar hora</string>
   <string name="material_minute_selection">Seleccionar minutos</string>
+  <string name="mtrl_timepicker_confirm">"Aceptar"</string>
+  <string name="mtrl_timepicker_cancel">"Cancelar"</string>
   <string name="material_clock_toggle_content_description">Selecciona AM o PM</string>
   <string name="material_timepicker_text_input_mode_description">Cambia al modo de introducción de texto para escribir la hora.</string>
   <string name="material_timepicker_clock_mode_description">Cambia al modo de reloj para escribir la hora.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-et/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-et/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutit</string>
   <string name="material_hour_selection">Valige tund</string>
   <string name="material_minute_selection">Minutite valimine</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Tühista"</string>
   <string name="material_clock_toggle_content_description">Valige AM või PM</string>
   <string name="material_timepicker_text_input_mode_description">Aktiveerige kellaaja sisestamiseks tekstisisestusrežiim.</string>
   <string name="material_timepicker_clock_mode_description">Aktiveerige kellaaja sisestamiseks kellarežiim.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-eu/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-eu/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutu</string>
   <string name="material_hour_selection">Hautatu ordua</string>
   <string name="material_minute_selection">Hautatu minutuak</string>
+  <string name="mtrl_timepicker_confirm">"Ados"</string>
+  <string name="mtrl_timepicker_cancel">"Utzi"</string>
   <string name="material_clock_toggle_content_description">Hautatu AM edo PM</string>
   <string name="material_timepicker_text_input_mode_description">Ordua idazteko, aldatu testua idazteko metodora.</string>
   <string name="material_timepicker_clock_mode_description">Aldatu erloju modura ordua zehazteko.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-fa/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-fa/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s دقیقه</string>
   <string name="material_hour_selection">انتخاب ساعت</string>
   <string name="material_minute_selection">انتخاب دقیقه</string>
+  <string name="mtrl_timepicker_confirm">"تأیید"</string>
+  <string name="mtrl_timepicker_cancel">"لغو"</string>
   <string name="material_clock_toggle_content_description">انتخاب .ق.ظ. یا ب.ظ.</string>
   <string name="material_timepicker_text_input_mode_description">برای وارد کردن زمان، به حالت ورودی نوشتاری تغییر وضعیت دهید.</string>
   <string name="material_timepicker_clock_mode_description">برای وارد کردن زمان، به حالت ساعت تغییر وضعیت دهید.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-fi/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-fi/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minuuttia</string>
   <string name="material_hour_selection">Valitse tunti</string>
   <string name="material_minute_selection">Valitse minuutit</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Peru"</string>
   <string name="material_clock_toggle_content_description">Valitse AP tai IP</string>
   <string name="material_timepicker_text_input_mode_description">Vaihda ajan syöttämiseen tekstitilassa.</string>
   <string name="material_timepicker_clock_mode_description">Vaihda ajan syöttämiseen kellotilassa.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-fr-rCA/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-fr-rCA/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutes</string>
   <string name="material_hour_selection">Sélectionner l\'heure</string>
   <string name="material_minute_selection">Sélectionnez les minutes</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Annuler"</string>
   <string name="material_clock_toggle_content_description">Sélectionner AM ou PM</string>
   <string name="material_timepicker_text_input_mode_description">Passer au mode Entrée de texte pour entrer l\'heure.</string>
   <string name="material_timepicker_clock_mode_description">Passer au mode Horloge pour entrer l\'heure.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-fr/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-fr/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s min</string>
   <string name="material_hour_selection">Sélectionnez une heure</string>
   <string name="material_minute_selection">Sélectionner des minutes</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Annuler"</string>
   <string name="material_clock_toggle_content_description">Sélectionner le format AM ou PM</string>
   <string name="material_timepicker_text_input_mode_description">Passer en mode saisie de texte pour la saisie de l\'heure.</string>
   <string name="material_timepicker_clock_mode_description">Passer en mode horloge pour la saisie de l\'heure.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-gl/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-gl/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutos</string>
   <string name="material_hour_selection">Seleccionar hora</string>
   <string name="material_minute_selection">Seleccionar minutos</string>
+  <string name="mtrl_timepicker_confirm">"Aceptar"</string>
+  <string name="mtrl_timepicker_cancel">"Cancelar"</string>
   <string name="material_clock_toggle_content_description">Seleccionar a.m. ou p.m.</string>
   <string name="material_timepicker_text_input_mode_description">Cambia ao modo de introdución de texto para introducir a hora.</string>
   <string name="material_timepicker_clock_mode_description">Cambiar ao modo de reloxo para introducir a hora.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-gu/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-gu/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s મિનિટ</string>
   <string name="material_hour_selection">સમય પસંદ કરો</string>
   <string name="material_minute_selection">મિનિટ પસંદ કરો</string>
+  <string name="mtrl_timepicker_confirm">"ઓકે"</string>
+  <string name="mtrl_timepicker_cancel">"રદ કરો"</string>
   <string name="material_clock_toggle_content_description">AM અથવા PM પસંદ કરો</string>
   <string name="material_timepicker_text_input_mode_description">સમય દાખલ કરવા માટે ટેક્સ્ટ ઇનપુટ મોડમાં સ્વિચ કરો.</string>
   <string name="material_timepicker_clock_mode_description">સમય દાખલ કરવા માટે ઘડિયાળ મોડમાં સ્વિચ કરો.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-hi/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-hi/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s मिनट</string>
   <string name="material_hour_selection">घंटा चुनें</string>
   <string name="material_minute_selection">मिनट चुनें</string>
+  <string name="mtrl_timepicker_confirm">"ठीक है"</string>
+  <string name="mtrl_timepicker_cancel">"रद्द करें"</string>
   <string name="material_clock_toggle_content_description">AM या PM चुनें</string>
   <string name="material_timepicker_text_input_mode_description">समय इनपुट के लिए लेख इनपुट मोड पर जाएं.</string>
   <string name="material_timepicker_clock_mode_description">समय इनपुट के लिए घड़ी मोड पर जाएं.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-hr/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-hr/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s min</string>
   <string name="material_hour_selection">Odaberite sat</string>
   <string name="material_minute_selection">Odaberite minute</string>
+  <string name="mtrl_timepicker_confirm">"U redu"</string>
+  <string name="mtrl_timepicker_cancel">"Odustani"</string>
   <string name="material_clock_toggle_content_description">Odaberite prijepodne ili poslijepodne</string>
   <string name="material_timepicker_text_input_mode_description">Prijeđite na način unosa teksta da biste unijeli vrijeme.</string>
   <string name="material_timepicker_clock_mode_description">Prijeđite na način rada sata da biste unijeli vrijeme.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-hu/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-hu/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s perc</string>
   <string name="material_hour_selection">Óra kiválasztása</string>
   <string name="material_minute_selection">Perc kiválasztása</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Mégse"</string>
   <string name="material_clock_toggle_content_description">Válassza ki, hogy délelőtt vagy délután</string>
   <string name="material_timepicker_text_input_mode_description">Időbevitelhez váltson szövegbeviteli módba.</string>
   <string name="material_timepicker_clock_mode_description">Időbevitelhez váltson óramódba.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-hy/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-hy/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s րոպե</string>
   <string name="material_hour_selection">Ընտրել ժամը</string>
   <string name="material_minute_selection">Ընտրեք րոպեն</string>
+  <string name="mtrl_timepicker_confirm">"Լավ"</string>
+  <string name="mtrl_timepicker_cancel">"Չեղարկել"</string>
   <string name="material_clock_toggle_content_description">Ընտրել AM կամ PM</string>
   <string name="material_timepicker_text_input_mode_description">Ժամը մուտքագրելու համար միացրեք տեքստի մուտքագրման ռեժիմը:</string>
   <string name="material_timepicker_clock_mode_description">Ժամը մուտքագրելու համար միացրեք ժամացույցի ռեժիմը:</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-in/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-in/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s menit</string>
   <string name="material_hour_selection">Pilih jam</string>
   <string name="material_minute_selection">Pilih menit</string>
+  <string name="mtrl_timepicker_confirm">"Oke"</string>
+  <string name="mtrl_timepicker_cancel">"Batal"</string>
   <string name="material_clock_toggle_content_description">Pilih AM atau PM</string>
   <string name="material_timepicker_text_input_mode_description">Beralih ke mode masukan teks untuk masukan waktu.</string>
   <string name="material_timepicker_clock_mode_description">Beralih ke mode jam untuk masukan waktu.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-is/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-is/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s mínútur</string>
   <string name="material_hour_selection">Velja tíma</string>
   <string name="material_minute_selection">Veldu mínútur</string>
+  <string name="mtrl_timepicker_confirm">"Í lagi"</string>
+  <string name="mtrl_timepicker_cancel">"Hætta við"</string>
   <string name="material_clock_toggle_content_description">Velja f.h. eða e.h.</string>
   <string name="material_timepicker_text_input_mode_description">Skipta yfir í textastillingu til að færa inn tíma.</string>
   <string name="material_timepicker_clock_mode_description">Skipta yfir í klukkustillingu til að færa inn tíma.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-it/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-it/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minuti</string>
   <string name="material_hour_selection">Seleziona l\'ora</string>
   <string name="material_minute_selection">Seleziona i minuti</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Annulla"</string>
   <string name="material_clock_toggle_content_description">Seleziona AM o PM</string>
   <string name="material_timepicker_text_input_mode_description">Passa alla modalità di immissione testo per inserire l\'ora.</string>
   <string name="material_timepicker_clock_mode_description">Passa alla modalità orologio per inserire l\'ora.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-iw/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-iw/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s דקות</string>
   <string name="material_hour_selection">בחר שעה</string>
   <string name="material_minute_selection">בחר דקות</string>
+  <string name="mtrl_timepicker_confirm">"אישור"</string>
+  <string name="mtrl_timepicker_cancel">"ביטול"</string>
   <string name="material_clock_toggle_content_description">יש לבחור ב-AM או ב-PM</string>
   <string name="material_timepicker_text_input_mode_description">העבר למצב קלט טקסט לצורך הזנת השעה</string>
   <string name="material_timepicker_clock_mode_description">העבר למצב שעון לצורך הזנת השעה</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ja/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ja/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s分</string>
   <string name="material_hour_selection">時刻を選択してください</string>
   <string name="material_minute_selection">分を選択</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"キャンセル"</string>
   <string name="material_clock_toggle_content_description">午前または午後を選択</string>
   <string name="material_timepicker_text_input_mode_description">時刻をテキストで入力するモードに切り替えます。</string>
   <string name="material_timepicker_clock_mode_description">時刻を時計で入力するモードに切り替えます。</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ka/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ka/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s წუთი</string>
   <string name="material_hour_selection">აირჩიეთ საათი</string>
   <string name="material_minute_selection">აირჩიეთ წუთები</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"გაუქმება"</string>
   <string name="material_clock_toggle_content_description">აირჩიეთ AM ან PM</string>
   <string name="material_timepicker_text_input_mode_description">დროის შეყვანისთვის ტექსტის შეყვანის რეჟიმზე გადართვა.</string>
   <string name="material_timepicker_clock_mode_description">დროის შეყვანისთვის საათის რეჟიმზე გადართვა.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-kk/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-kk/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s минут</string>
   <string name="material_hour_selection">Сағатты таңдау</string>
   <string name="material_minute_selection">Минут таңдау</string>
+  <string name="mtrl_timepicker_confirm">"Жарайды"</string>
+  <string name="mtrl_timepicker_cancel">"Бас тарту"</string>
   <string name="material_clock_toggle_content_description">\"AM\" немесе \"PM\" форматын таңдау</string>
   <string name="material_timepicker_text_input_mode_description">Уақытты енгізу үшін мәтін енгізу режиміне өтіңіз.</string>
   <string name="material_timepicker_clock_mode_description">Уақытты енгізу үшін сағат режиміне өтіңіз.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-km/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-km/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s នាទី</string>
   <string name="material_hour_selection">ជ្រើសរើសម៉ោង</string>
   <string name="material_minute_selection">ជ្រើស​នាទី</string>
+  <string name="mtrl_timepicker_confirm">"យល់​ព្រម​"</string>
+  <string name="mtrl_timepicker_cancel">"បោះ​បង់​"</string>
   <string name="material_clock_toggle_content_description">ជ្រើសរើស AM ឬ PM</string>
   <string name="material_timepicker_text_input_mode_description">ប្តូរ​ទៅ​មុខងារ​បញ្ចូល​អក្សរ​សម្រាប់​ការ​បញ្ចូល​ម៉ោង។</string>
   <string name="material_timepicker_clock_mode_description">ប្តូរ​ទៅ​មុខងារ​នាឡិកា​សម្រាប់​ការ​បញ្ចូល​ម៉ោង។</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-kn/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-kn/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s ನಿಮಿಷಗಳು</string>
   <string name="material_hour_selection">ಸಮಯವನ್ನು ಆಯ್ಕೆಮಾಡಿ</string>
   <string name="material_minute_selection">ನಿಮಿಷಗಳನ್ನು ಆಯ್ಕೆಮಾಡಿ</string>
+  <string name="mtrl_timepicker_confirm">"ಸರಿ"</string>
+  <string name="mtrl_timepicker_cancel">"ರದ್ದುಮಾಡಿ"</string>
   <string name="material_clock_toggle_content_description">ಬೆಳಿಗ್ಗೆ ಅಥವಾ ಮಧ್ಯಾಹ್ನ ಆಯ್ಕೆಮಾಡಿ</string>
   <string name="material_timepicker_text_input_mode_description">ಸಮಯವನ್ನು ನಮೂದಿಸಲು ಪಠ್ಯದ ನಮೂನೆಗೆ ಬದಲಿಸಿ.</string>
   <string name="material_timepicker_clock_mode_description">ಸಮಯವನ್ನು ನಮೂದಿಸಲು ಗಡಿಯಾರದ ನಮೂನೆಗೆ ಬದಲಿಸಿ.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ko/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ko/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s분</string>
   <string name="material_hour_selection">시간 선택</string>
   <string name="material_minute_selection">분 선택</string>
+  <string name="mtrl_timepicker_confirm">"확인"</string>
+  <string name="mtrl_timepicker_cancel">"취소"</string>
   <string name="material_clock_toggle_content_description">오전 또는 오후를 선택하세요.</string>
   <string name="material_timepicker_text_input_mode_description">시간 입력을 위해 텍스트 입력 모드로 전환합니다.</string>
   <string name="material_timepicker_clock_mode_description">시간 입력을 위해 시계 모드로 전환합니다.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ky/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ky/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s мүнөт</string>
   <string name="material_hour_selection">Саат тандоо</string>
   <string name="material_minute_selection">Мүнөттөрдү тандаңыз</string>
+  <string name="mtrl_timepicker_confirm">"Жарайт"</string>
+  <string name="mtrl_timepicker_cancel">"Жокко чыгаруу"</string>
   <string name="material_clock_toggle_content_description">Тандоо: AM же PM</string>
   <string name="material_timepicker_text_input_mode_description">Убакытты текст киргизүү режиминде киргизиңиз.</string>
   <string name="material_timepicker_clock_mode_description">Убакытты дубал саатынын режиминде киргизиңиз.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-lo/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-lo/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s ນາທີ</string>
   <string name="material_hour_selection">ເລືອກຊົ່ວໂມງ</string>
   <string name="material_minute_selection">ເລືອກນາ​ທີ</string>
+  <string name="mtrl_timepicker_confirm">"ຕົກລົງ"</string>
+  <string name="mtrl_timepicker_cancel">"ຍົກເລີກ"</string>
   <string name="material_clock_toggle_content_description">ເລືອກຕອນເຊົ້າ ຫຼື ຕອນແລງ</string>
   <string name="material_timepicker_text_input_mode_description">ສະຫຼັບໄປໃຊ້ໂໝດປ້ອນຂໍ້ຄວາມສຳລັບການປ້ອນເວລາ.</string>
   <string name="material_timepicker_clock_mode_description">ສະຫຼັບໄປໃຊ້ໂໝດໂມງສຳລັບການປ້ອນເວລາ.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-lt/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-lt/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s min.</string>
   <string name="material_hour_selection">Pasirinkite valandą</string>
   <string name="material_minute_selection">Pasirinkite minutes</string>
+  <string name="mtrl_timepicker_confirm">"Gerai"</string>
+  <string name="mtrl_timepicker_cancel">"Atšaukti"</string>
   <string name="material_clock_toggle_content_description">Pasirinkite „iki pietų“ arba „po pietų“</string>
   <string name="material_timepicker_text_input_mode_description">Laiko įvestį pateikti perjungus į teksto įvesties režimą.</string>
   <string name="material_timepicker_clock_mode_description">Laiko įvestį pateikti perjungus į laikrodžio režimą.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-lv/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-lv/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s min</string>
   <string name="material_hour_selection">Atlasiet stundu</string>
   <string name="material_minute_selection">Atlasiet minūtes.</string>
+  <string name="mtrl_timepicker_confirm">"Labi"</string>
+  <string name="mtrl_timepicker_cancel">"Atcelt"</string>
   <string name="material_clock_toggle_content_description">Atlasiet “AM” (priekšpusdienā) vai “PM” (pēcpusdienā).</string>
   <string name="material_timepicker_text_input_mode_description">Lai ievadītu laiku, ieslēdziet teksta ievades režīmu.</string>
   <string name="material_timepicker_clock_mode_description">Lai ievadītu laiku, ieslēdziet pulksteņa režīmu.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-mk/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-mk/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s минути</string>
   <string name="material_hour_selection">Изберете час</string>
   <string name="material_minute_selection">Избери минути</string>
+  <string name="mtrl_timepicker_confirm">"Во ред"</string>
+  <string name="mtrl_timepicker_cancel">"Откажи"</string>
   <string name="material_clock_toggle_content_description">Изберете претпладне или попладне</string>
   <string name="material_timepicker_text_input_mode_description">Префрлете се на режимот за внесување текст за да внесете време.</string>
   <string name="material_timepicker_clock_mode_description">Префрлете се на режимот за часовник за да внесете време.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ml/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ml/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s മിനിറ്റ്</string>
   <string name="material_hour_selection">മണിക്കൂർ തിരഞ്ഞെടുക്കുക</string>
   <string name="material_minute_selection">മിനിറ്റ് തിരഞ്ഞെടുക്കുക</string>
+  <string name="mtrl_timepicker_confirm">"ശരി"</string>
+  <string name="mtrl_timepicker_cancel">"റദ്ദാക്കുക"</string>
   <string name="material_clock_toggle_content_description">AM അല്ലെങ്കിൽ PM തിരഞ്ഞെടുക്കുക</string>
   <string name="material_timepicker_text_input_mode_description">സമയം നൽകുന്നതിന് ടെക്സ്റ്റ് ഇൻപുട്ട് ‌മോ‌ഡിലേക്ക് ‌മാറുക.</string>
   <string name="material_timepicker_clock_mode_description">‌സമയം നൽകുന്നതിന് ക്ലോക്ക് മോഡിലേക്ക് ‌മാറുക.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-mn/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-mn/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s минут</string>
   <string name="material_hour_selection">Цаг сонгох</string>
   <string name="material_minute_selection">Минут сонгоно уу</string>
+  <string name="mtrl_timepicker_confirm">"ОК"</string>
+  <string name="mtrl_timepicker_cancel">"Цуцлах"</string>
   <string name="material_clock_toggle_content_description">ҮӨ эсвэл ҮХ сонгоно уу</string>
   <string name="material_timepicker_text_input_mode_description">Цагийг оруулахын тулд текст оруулах горимд шилжүүлнэ үү.</string>
   <string name="material_timepicker_clock_mode_description">Цагийг оруулахын тулд цагийн горимд шилжүүлнэ үү.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-mr/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-mr/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s मिनिटे</string>
   <string name="material_hour_selection">वेळ निवडा</string>
   <string name="material_minute_selection">मिनिटे निवडा</string>
+  <string name="mtrl_timepicker_confirm">"ठीक आहे"</string>
+  <string name="mtrl_timepicker_cancel">"रद्द करा"</string>
   <string name="material_clock_toggle_content_description">AM किंवा PM निवडा</string>
   <string name="material_timepicker_text_input_mode_description">वेळ इनपुटसाठी मजकूर इनपुट मोडवर स्विच करा.</string>
   <string name="material_timepicker_clock_mode_description">वेळेच्या इनपुटसाठी घड्याळ मोडवर स्विच करा.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ms/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ms/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minit</string>
   <string name="material_hour_selection">Pilih jam</string>
   <string name="material_minute_selection">Pilih minit</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Batal"</string>
   <string name="material_clock_toggle_content_description">Pilih AM atau PM</string>
   <string name="material_timepicker_text_input_mode_description">Beralih ke mod input teks untuk input masa.</string>
   <string name="material_timepicker_clock_mode_description">Beralih ke mod jam untuk input masa.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-my/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-my/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s မိနစ်</string>
   <string name="material_hour_selection">နာရီ ရွေးရန်</string>
   <string name="material_minute_selection">မိနစ်များ ရွေးပါ</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"မလုပ်တော့"</string>
   <string name="material_clock_toggle_content_description">AM (သို့) PM ရွေးရန်</string>
   <string name="material_timepicker_text_input_mode_description">အချိန်ထည့်သွင်းရန် စာသားထည့်သွင်းမှုမုဒ်သို့ ပြောင်းပါ။</string>
   <string name="material_timepicker_clock_mode_description">အချိန်ထည့်သွင်းမှုအတွက် နာရီမုဒ်သို့ ပြောင်းပါ။</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-nb/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-nb/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutter</string>
   <string name="material_hour_selection">Velg time</string>
   <string name="material_minute_selection">Angi minutter</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Avbryt"</string>
   <string name="material_clock_toggle_content_description">Velg AM eller PM</string>
   <string name="material_timepicker_text_input_mode_description">Bytt til tekstinndatamodus for tidsinndata.</string>
   <string name="material_timepicker_clock_mode_description">Bytt til klokkemodus for tidsinndata.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ne/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ne/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s मिनेट</string>
   <string name="material_hour_selection">घन्टा चयन गर्नुहोस्</string>
   <string name="material_minute_selection">मिनेट चयन गर्नुहोस्</string>
+  <string name="mtrl_timepicker_confirm">"ठिक छ"</string>
+  <string name="mtrl_timepicker_cancel">"रद्द गर्नुहोस्"</string>
   <string name="material_clock_toggle_content_description">पूर्वाह्न वा अपराह्न चयन गर्नुहोस्</string>
   <string name="material_timepicker_text_input_mode_description">समय इनपुट गर्न पाठ इनपुट मोडमा स्विच गर्नुहोस्।</string>
   <string name="material_timepicker_clock_mode_description">समय इनपुट गर्न घडी मोडमा स्विच गर्नुहोस्।</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-nl/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-nl/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minuten</string>
   <string name="material_hour_selection">Selecteer uur</string>
   <string name="material_minute_selection">Minuten selecteren</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Annuleren"</string>
   <string name="material_clock_toggle_content_description">Selecteer a.m. of p.m.</string>
   <string name="material_timepicker_text_input_mode_description">Schakel naar de tekstinvoermodus om de tijd in te voeren.</string>
   <string name="material_timepicker_clock_mode_description">Schakel naar de klokmodus om de tijd in te voeren.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-or/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-or/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutes</string>
   <string name="material_hour_selection">Select hour</string>
   <string name="material_minute_selection">ମିନିଟ୍‍ ଚୟନ କରନ୍ତୁ</string>
+  <string name="mtrl_timepicker_confirm">"ଠିକ୍‍ ଅଛି"</string>
+  <string name="mtrl_timepicker_cancel">"ବାତିଲ୍‍ କରନ୍ତୁ"</string>
   <string name="material_clock_toggle_content_description">Select AM or PM</string>
   <string name="material_timepicker_text_input_mode_description">ସମୟ ଇନପୁଟ୍‍ ପାଇଁ ଟେକ୍ସଟ୍‍ ଇନପୁଟ୍‌କୁ ବଦଳାନ୍ତୁ।</string>
   <string name="material_timepicker_clock_mode_description">ସମୟ ଇନପୁଟ୍‍ ପାଇଁ ଘଣ୍ଟା ମୋଡ୍‌କୁ ବଦଳାନ୍ତୁ।</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-pa/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-pa/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s ਮਿੰਟ</string>
   <string name="material_hour_selection">ਸਮਾਂ ਚੁਣੋ</string>
   <string name="material_minute_selection">ਮਿੰਟ ਚੁਣੋ</string>
+  <string name="mtrl_timepicker_confirm">"ਠੀਕ ਹੈ"</string>
+  <string name="mtrl_timepicker_cancel">"ਰੱਦ ਕਰੋ"</string>
   <string name="material_clock_toggle_content_description">AM ਜਾਂ PM ਚੁਣੋ</string>
   <string name="material_timepicker_text_input_mode_description">ਸਮਾਂ ਇਨਪੁੱਟ ਕਰਨ ਲਈ ਲਿਖਤ ਇਨਪੁੱਟ ਮੋਡ \'ਤੇ ਸਵਿੱਚ ਕਰੋ।</string>
   <string name="material_timepicker_clock_mode_description">ਸਮਾਂ ਇਨਪੁੱਟ ਕਰਨ ਲਈ ਘੜੀ ਮੋਡ \'ਤੇ ਸਵਿੱਚ ਕਰੋ।</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-pl/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-pl/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minut</string>
   <string name="material_hour_selection">Wybierz godzinę</string>
   <string name="material_minute_selection">Wybierz minuty</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Anuluj"</string>
   <string name="material_clock_toggle_content_description">Wybierz: przed południem czy po południu</string>
   <string name="material_timepicker_text_input_mode_description">Aby wprowadzić czas, włącz tryb wprowadzania tekstu.</string>
   <string name="material_timepicker_clock_mode_description">Aby wprowadzić czas, włącz tryb zegara.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-pt-rBR/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-pt-rBR/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutos</string>
   <string name="material_hour_selection">Selecionar horário</string>
   <string name="material_minute_selection">Selecione os minutos</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Cancelar"</string>
   <string name="material_clock_toggle_content_description">Selecionar AM ou PM</string>
   <string name="material_timepicker_text_input_mode_description">Alterne para o modo de entrada de texto para informar o horário.</string>
   <string name="material_timepicker_clock_mode_description">Alterne para o modo de relógio para informar o horário.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-pt-rPT/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-pt-rPT/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minutos</string>
   <string name="material_hour_selection">Selecionar hora</string>
   <string name="material_minute_selection">Selecionar minutos</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Cancelar"</string>
   <string name="material_clock_toggle_content_description">Selecionar AM ou PM</string>
   <string name="material_timepicker_text_input_mode_description">Mude para o modo de introdução de texto para a introdução da hora.</string>
   <string name="material_timepicker_clock_mode_description">Mude para o modo de relógio para a introdução da hora.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ro/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ro/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minute</string>
   <string name="material_hour_selection">Selectați ora</string>
   <string name="material_minute_selection">Selectați minutele</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Anulați"</string>
   <string name="material_clock_toggle_content_description">Selectați ora</string>
   <string name="material_timepicker_text_input_mode_description">Pentru a introduce ora, comutați la modul de introducere a textului.</string>
   <string name="material_timepicker_clock_mode_description">Pentru a introduce ora, comutați la modul ceas.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ru/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ru/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s мин.</string>
   <string name="material_hour_selection">Выберите час</string>
   <string name="material_minute_selection">Выберите минуты</string>
+  <string name="mtrl_timepicker_confirm">"ОК"</string>
+  <string name="mtrl_timepicker_cancel">"Отмена"</string>
   <string name="material_clock_toggle_content_description">Выберите AM (до полудня) или PM (после полудня)</string>
   <string name="material_timepicker_text_input_mode_description">Чтобы ввести время, перейдите в режим ввода текста.</string>
   <string name="material_timepicker_clock_mode_description">Чтобы ввести время, перейдите в режим часов.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-si/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-si/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">මිනිත්තු %1$sයි</string>
   <string name="material_hour_selection">පැය තෝරන්න</string>
   <string name="material_minute_selection">මිනිත්තු තෝරන්න</string>
+  <string name="mtrl_timepicker_confirm">"හරි"</string>
+  <string name="mtrl_timepicker_cancel">"අවලංගු කරන්න"</string>
   <string name="material_clock_toggle_content_description">පෙරවරු හෝ පස්වරු තෝරන්න</string>
   <string name="material_timepicker_text_input_mode_description">වේලා ආදානය සඳහා ආදාන ප්‍රකාරය වෙත මාරු වෙන්න.</string>
   <string name="material_timepicker_clock_mode_description">වේලා ආදානය සඳහා ඔරලෝසු ප්‍රකාරය වෙත මාරු වෙන්න.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-sk/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-sk/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s min</string>
   <string name="material_hour_selection">Vybrať hodinu</string>
   <string name="material_minute_selection">Vyberte minúty</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Zrušiť"</string>
   <string name="material_clock_toggle_content_description">Vyberte AM alebo PM</string>
   <string name="material_timepicker_text_input_mode_description">Ak chcete zadať čas, prepnite na textový režim vstupu</string>
   <string name="material_timepicker_clock_mode_description">Ak chcete zadať čas, prepnite na režim hodín.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-sl/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-sl/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s min</string>
   <string name="material_hour_selection">Izberite uro</string>
   <string name="material_minute_selection">Izberite minute</string>
+  <string name="mtrl_timepicker_confirm">"V redu"</string>
+  <string name="mtrl_timepicker_cancel">"Prekliči"</string>
   <string name="material_clock_toggle_content_description">Izberite dopoldanski ali popoldanski čas.</string>
   <string name="material_timepicker_text_input_mode_description">Preklopite na način za vnašanje besedila, da vnesete čas.</string>
   <string name="material_timepicker_clock_mode_description">Preklopite na način ure, da vnesete čas.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-sq/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-sq/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minuta</string>
   <string name="material_hour_selection">Zgjidh orën</string>
   <string name="material_minute_selection">Përzgjidh minutat</string>
+  <string name="mtrl_timepicker_confirm">"Në rregull"</string>
+  <string name="mtrl_timepicker_cancel">"Anulo"</string>
   <string name="material_clock_toggle_content_description">Zgjidh paradite ose pasdite</string>
   <string name="material_timepicker_text_input_mode_description">Kalo te modaliteti i hyrjes së tekstit për hyrjen e kohës.</string>
   <string name="material_timepicker_clock_mode_description">Kalo te modaliteti i orës për hyrjen e kohës.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-sr/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-sr/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s мин</string>
   <string name="material_hour_selection">Изаберите сат</string>
   <string name="material_minute_selection">Изаберите минуте</string>
+  <string name="mtrl_timepicker_confirm">"Потврди"</string>
+  <string name="mtrl_timepicker_cancel">"Откажи"</string>
   <string name="material_clock_toggle_content_description">Изаберите пре подне или по подне</string>
   <string name="material_timepicker_text_input_mode_description">Пређите у режим уноса текста ради уноса времена.</string>
   <string name="material_timepicker_clock_mode_description">Пређите у режим сата ради уноса времена.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-sv/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-sv/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s minuter</string>
   <string name="material_hour_selection">Ange timme</string>
   <string name="material_minute_selection">Välj minuter</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Avbryt"</string>
   <string name="material_clock_toggle_content_description">Välj mellan FM och EM</string>
   <string name="material_timepicker_text_input_mode_description">Byt till textinmatningsläget och ange tid.</string>
   <string name="material_timepicker_clock_mode_description">Byt till klockläget och ange tid.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-sw/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-sw/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">Dakika %1$s</string>
   <string name="material_hour_selection">Chagua saa</string>
   <string name="material_minute_selection">Chagua dakika</string>
+  <string name="mtrl_timepicker_confirm">"Sawa"</string>
+  <string name="mtrl_timepicker_cancel">"Ghairi"</string>
   <string name="material_clock_toggle_content_description">Chagua AM au PM</string>
   <string name="material_timepicker_text_input_mode_description">Badilisha iwe katika hali ya maandishi wakati wa kuweka muda.</string>
   <string name="material_timepicker_clock_mode_description">Badilisha umbo liwe la saa ya mishale wakati wa kuweka muda.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ta/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ta/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s நிமிடங்கள்</string>
   <string name="material_hour_selection">மணிநேரத்தைத் தேர்ந்தெடுக்க உதவும்</string>
   <string name="material_minute_selection">நிமிடத்தைத் தேர்ந்தெடுக்கவும்</string>
+  <string name="mtrl_timepicker_confirm">"சரி"</string>
+  <string name="mtrl_timepicker_cancel">"ரத்துசெய்"</string>
   <string name="material_clock_toggle_content_description">AM அல்லது PMமைத் தேர்ந்தெடுக்க உதவும்</string>
   <string name="material_timepicker_text_input_mode_description">உரை உள்ளீட்டிற்காக, கடிகாரப் பயன்முறைக்கு மாற்றும்.</string>
   <string name="material_timepicker_clock_mode_description">நேர உள்ளீட்டிற்காக, கடிகாரப் பயன்முறைக்கு மாற்றும்.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-te/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-te/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s నిమిషాలు</string>
   <string name="material_hour_selection">గంటను ఎంచుకోండి</string>
   <string name="material_minute_selection">నిమిషాలను ఎంచుకోండి</string>
+  <string name="mtrl_timepicker_confirm">"సరే"</string>
+  <string name="mtrl_timepicker_cancel">"రద్దు చేయి"</string>
   <string name="material_clock_toggle_content_description">AM లేదా PMను ఎంచుకోండి</string>
   <string name="material_timepicker_text_input_mode_description">సమయాన్ని నమోదు చేయడం కోసం వచన నమోదు మోడ్‌కి మారండి.</string>
   <string name="material_timepicker_clock_mode_description">సమయాన్ని నమోదు చేయడం కోసం గడియారం మోడ్‌కు మారండి.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-th/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-th/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s นาที</string>
   <string name="material_hour_selection">เลือกชั่วโมง</string>
   <string name="material_minute_selection">เลือกนาที</string>
+  <string name="mtrl_timepicker_confirm">"ตกลง"</string>
+  <string name="mtrl_timepicker_cancel">"ยกเลิก"</string>
   <string name="material_clock_toggle_content_description">เลือก AM หรือ PM</string>
   <string name="material_timepicker_text_input_mode_description">สลับไปโหมดป้อนข้อความเพื่อป้อนเวลา</string>
   <string name="material_timepicker_clock_mode_description">สลับไปโหมดนาฬิกาเพื่อป้อนเวลา</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-tl/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-tl/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s (na) minuto</string>
   <string name="material_hour_selection">Pumili ng oras</string>
   <string name="material_minute_selection">Pumili ng mga minuto</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Kanselahin"</string>
   <string name="material_clock_toggle_content_description">Piliin ang AM o PM</string>
   <string name="material_timepicker_text_input_mode_description">Lumipat sa pamamaraan ng pag-input ng text para sa input na oras.</string>
   <string name="material_timepicker_clock_mode_description">Lumipat sa mode ng orasan para sa input na oras.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-tr/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-tr/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s dakika</string>
   <string name="material_hour_selection">Saat seçin</string>
   <string name="material_minute_selection">Dakikayı seçin</string>
+  <string name="mtrl_timepicker_confirm">"Tamam"</string>
+  <string name="mtrl_timepicker_cancel">"İptal"</string>
   <string name="material_clock_toggle_content_description">ÖÖ veya ÖS\'yi seçin</string>
   <string name="material_timepicker_text_input_mode_description">Zaman girişi için metin girişi moduna geçin.</string>
   <string name="material_timepicker_clock_mode_description">Zaman girişi için saat moduna geçin.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-uk/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-uk/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s хв</string>
   <string name="material_hour_selection">Вибрати годину</string>
   <string name="material_minute_selection">Виберіть хвилини</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Скасувати"</string>
   <string name="material_clock_toggle_content_description">Виберіть ДП чи ПП</string>
   <string name="material_timepicker_text_input_mode_description">Перейти в текстовий режим, щоб ввести час.</string>
   <string name="material_timepicker_clock_mode_description">Перейти в режим годинника, щоб ввести час.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-ur/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-ur/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s منٹ</string>
   <string name="material_hour_selection">گھنٹہ منتخب کریں</string>
   <string name="material_minute_selection">منٹ منتخب کریں</string>
+  <string name="mtrl_timepicker_confirm">"ٹھیک ہے"</string>
+  <string name="mtrl_timepicker_cancel">"منسوخ کریں"</string>
   <string name="material_clock_toggle_content_description">AM یا PM منتخب کریں</string>
   <string name="material_timepicker_text_input_mode_description">وقت ان پٹ کے لیے ٹیکسٹ ان پٹ وضع پر سوئچ کریں۔</string>
   <string name="material_timepicker_clock_mode_description">وقت ان پٹ کے لیے گھڑی و‏ضع پر سوئچ کریں۔</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-uz/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-uz/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s daqiqa</string>
   <string name="material_hour_selection">Soatni tanlang</string>
   <string name="material_minute_selection">Daqiqalarni tanlash</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Bekor qilish"</string>
   <string name="material_clock_toggle_content_description">Tushdan oldin yoki keyinligini tanlang</string>
   <string name="material_timepicker_text_input_mode_description">Vaqtni kiritish uchun matn kiritish rejimiga o‘ting.</string>
   <string name="material_timepicker_clock_mode_description">Vaqtni kiritish uchun soat rejimiga o‘ting.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-vi/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-vi/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s phút</string>
   <string name="material_hour_selection">Chọn giờ</string>
   <string name="material_minute_selection">Chọn phút</string>
+  <string name="mtrl_timepicker_confirm">"OK"</string>
+  <string name="mtrl_timepicker_cancel">"Hủy"</string>
   <string name="material_clock_toggle_content_description">Chọn SA hoặc CH</string>
   <string name="material_timepicker_text_input_mode_description">Chuyển sang chế độ nhập văn bản để nhập thời gian.</string>
   <string name="material_timepicker_clock_mode_description">Chuyển sang chế độ đồng hồ để nhập thời gian.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-zh-rCN/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-zh-rCN/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s 分</string>
   <string name="material_hour_selection">选择小时</string>
   <string name="material_minute_selection">选择分钟</string>
+  <string name="mtrl_timepicker_confirm">"确定"</string>
+  <string name="mtrl_timepicker_cancel">"取消"</string>
   <string name="material_clock_toggle_content_description">选择上午或下午</string>
   <string name="material_timepicker_text_input_mode_description">切换到文字输入模式来输入时间。</string>
   <string name="material_timepicker_clock_mode_description">切换到时钟模式来输入时间。</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-zh-rHK/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-zh-rHK/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s 分</string>
   <string name="material_hour_selection">選取時段</string>
   <string name="material_minute_selection">選取分鐘</string>
+  <string name="mtrl_timepicker_confirm">"確定"</string>
+  <string name="mtrl_timepicker_cancel">"取消"</string>
   <string name="material_clock_toggle_content_description">選擇上午或下午</string>
   <string name="material_timepicker_text_input_mode_description">切換至文字輸入模式即可輸入時間。</string>
   <string name="material_timepicker_clock_mode_description">切換至時鐘模式即可輸入時間。</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-zh-rTW/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-zh-rTW/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">%1$s 分</string>
   <string name="material_hour_selection">請選取時段</string>
   <string name="material_minute_selection">選取分鐘數</string>
+  <string name="mtrl_timepicker_confirm">"確定"</string>
+  <string name="mtrl_timepicker_cancel">"取消"</string>
   <string name="material_clock_toggle_content_description">選取上午或下午</string>
   <string name="material_timepicker_text_input_mode_description">切換至文字輸入模式來輸入時間。</string>
   <string name="material_timepicker_clock_mode_description">切換至時鐘模式來輸入時間。</string>

--- a/lib/java/com/google/android/material/timepicker/res/values-zu/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values-zu/strings.xml
@@ -24,6 +24,8 @@
   <string name="material_minute_suffix">amaminithi angu-%1$s</string>
   <string name="material_hour_selection">Khetha ihora</string>
   <string name="material_minute_selection">Khetha amaminithi</string>
+  <string name="mtrl_timepicker_confirm">"KULUNGILE"</string>
+  <string name="mtrl_timepicker_cancel">"Khansela"</string>
   <string name="material_clock_toggle_content_description">Khetha u-AM noma u-PM</string>
   <string name="material_timepicker_text_input_mode_description">Shintshela kumodi yokufaka umbhalo ngokufaka isikhathi.</string>
   <string name="material_timepicker_clock_mode_description">Shintshela kumodi yewashi ngokufakwa kwesikhathi.</string>

--- a/lib/java/com/google/android/material/timepicker/res/values/strings.xml
+++ b/lib/java/com/google/android/material/timepicker/res/values/strings.xml
@@ -28,9 +28,10 @@
 
   <string name="material_hour_selection" description="Description for button to switch to select the hour [CHAR_LIMIT=NONE]">Select hour</string>
   <string name="material_minute_selection" description="Description for button to switch to select the minute [CHAR_LIMIT=NONE]">Select minutes</string>
-  <string name="material_clock_toggle_content_description" description="Description for the toggle to choose between AM and PM [CHAR_LIMIT=NONE] ">Select AM or PM</string>
+  <string name="material_clock_toggle_content_description" description="Description for the toggle to choose between AM and PM [CHAR_LIMIT=NONE]">Select AM or PM</string>
 
   <string name="mtrl_timepicker_confirm" description="Button text to indicate that the widget will save the user's selection [CHAR_LIMIT=16]">OK</string>
+  <string name="mtrl_timepicker_cancel" description="Button text to indicate that the widget will ignore the user's selection [CHAR_LIMIT=16]">Cancel</string>
 
   <!-- Accessibility string used for describing the button in time picker that changes the dialog to text input mode. [CHAR LIMIT=NONE] -->
   <string name="material_timepicker_text_input_mode_description">Switch to text input mode for the time input.</string>


### PR DESCRIPTION
[Context](https://github.com/material-components/material-components-android/issues/1346#issuecomment-933791071):
> It did look like the Android framework string is missing on certain OEM devices. (Material is using android:string/ok for the button.) I guess we can fix it by replacing the string with proper values.
---
- Fixes https://github.com/material-components/material-components-android/issues/2655
- Fixes https://github.com/material-components/material-components-android/issues/2577
- Fixes https://github.com/material-components/material-components-android/issues/1602
- Fixes https://github.com/material-components/material-components-android/issues/1346