### PR TITLE
[i18n][Catalog] Use regular strings instead of @android:string/* which can have translation issues

### DIFF
--- a/catalog/java/io/material/catalog/menu/MenuMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/menu/MenuMainDemoFragment.java
@@ -149,7 +149,7 @@ public class MenuMainDemoFragment extends DemoFragment {
   public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
     TextView contextMenuTextView = (TextView) v;
     Context context = getContext();
-    menu.add(android.R.string.copy)
+    menu.add(R.string.context_menu_copy)
         .setOnMenuItemClickListener(
             item -> {
               ClipboardManager clipboard =

--- a/catalog/java/io/material/catalog/menu/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/menu/res/values/strings.xml
@@ -34,7 +34,9 @@
     This TextView opens a context menu when long pressed.
     \n\nIt provides actions that affect the selected content or context frame.
   </string>
-  <string name="context_menu_highlight" description="text for a menu option to highlight text [CHAR_LIMIT=20].">Highlight</string>
+
+  <string name="context_menu_copy" description="Text for a menu option to copy text [CHAR_LIMIT=20].">Copy</string>
+  <string name="context_menu_highlight" description="Text for a menu option to highlight text [CHAR_LIMIT=20].">Highlight</string>
 
   <string-array name="cat_list_popup_window_content" translatable="false">
     <item>Item 1</item>


### PR DESCRIPTION
Follow-up of https://github.com/material-components/material-components-android/pull/2656