### PR TITLE
[Color] Enable dynamic color for S_V2 regardless of manufacturer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ allprojects {
 }
 
 ext {
-  compileSdkVersion = 31
+  compileSdkVersion = 32
   minSdkVersion = 14
-  targetSdkVersion = 31
+  targetSdkVersion = 32
 
   androidXVersions = [
     annotation            : '1.2.0',

--- a/lib/java/com/google/android/material/color/DynamicColors.java
+++ b/lib/java/com/google/android/material/color/DynamicColors.java
@@ -340,7 +340,7 @@ public class DynamicColors {
     if (VERSION.SDK_INT < VERSION_CODES.S) {
       return false;
     }
-    if (BuildCompat.isAtLeastT()) {
+    if (VERSION.SDK_INT >= VERSION_CODES.S_V2) {
       return true;
     }
     DeviceSupportCondition deviceSupportCondition =


### PR DESCRIPTION
Since S_V2, aka sdk version 32, dynamic color is a part of aosp

https://android.googlesource.com/platform/frameworks/base/+log/refs/tags/android-12.1.0_r1/packages/SystemUI/monet

related: #2677 

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
