### PR TITLE
[Resources] Remove unused public.xml resources

### DIFF
--- a/lib/java/com/google/android/material/button/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/button/res-public/values/public.xml
@@ -15,8 +15,6 @@
   ~ limitations under the License.
 -->
 <resources>
-  <public name="additionalPaddingStartForIcon" type="attr"/>
-  <public name="additionalPaddingEndForIcon" type="attr"/>
   <public name="checkedButton" type="attr"/>
   <public name="cornerRadius" type="attr"/>
   <public name="icon" type="attr"/>

--- a/lib/java/com/google/android/material/textfield/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/textfield/res-public/values/public.xml
@@ -28,17 +28,10 @@
   <public name="boxBackgroundColor" type="attr"/>
   <public name="boxBackgroundMode" type="attr"/>
   <public name="boxCollapsedPaddingTop" type="attr"/>
-  <public name="boxCollapsedPaddingBottom" type="attr"/>
   <public name="boxCornerRadiusTopStart" type="attr"/>
   <public name="boxCornerRadiusTopEnd" type="attr"/>
   <public name="boxCornerRadiusBottomStart" type="attr"/>
   <public name="boxCornerRadiusBottomEnd" type="attr"/>
-  <public name="boxExpandedPaddingTop" type="attr"/>
-  <public name="boxExpandedPaddingBottom" type="attr"/>
-  <public name="boxPaddingStart" type="attr"/>
-  <public name="boxPaddingTop" type="attr"/>
-  <public name="boxPaddingEnd" type="attr"/>
-  <public name="boxPaddingBottom" type="attr"/>
   <public name="boxStrokeColor" type="attr"/>
   <public name="boxStrokeErrorColor" type="attr"/>
   <public name="boxStrokeWidth" type="attr"/>

--- a/lib/java/com/google/android/material/tooltip/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/tooltip/res-public/values/public.xml
@@ -16,7 +16,6 @@
 -->
 <resources>
   <public name="tooltipStyle" type="attr"/>
-  <public name="backgroundTint" type="color" />
   <public name="ShapeAppearance.MaterialComponents.Tooltip" type="style"/>
   <public name="TextAppearance.MaterialComponents.Tooltip" type="style"/>
   <public name="Widget.MaterialComponents.Tooltip" type="style"/>


### PR DESCRIPTION
### These public resources have no definitions, and can be removed.

Fixes errors similar to the one below when compiling the Material components from source in the AOSP Build system:
>> error: no definition for declared symbol 'com.google.android.material:attr/boxPaddingTop'.