### PR TITLE
[MaterialTimePicker] Fix AM/PM toggle

### DIFF
--- a/lib/java/com/google/android/material/timepicker/TimePickerView.java
+++ b/lib/java/com/google/android/material/timepicker/TimePickerView.java
@@ -108,8 +108,8 @@ class TimePickerView extends ConstraintLayout implements TimePickerControls {
         return;
       }
 
-      int period = checkedId == R.id.material_clock_period_pm_button ? PM : AM;
       if (onPeriodChangeListener != null) {
+        int period = checkedId == R.id.material_clock_period_pm_button ? PM : AM;
         onPeriodChangeListener.onPeriodChange(period);
       }
     });


### PR DESCRIPTION
Presumably, one of the edits from [here](https://github.com/material-components/material-components-android/pull/2791) did not get into `master`, so I submitted it in a new PR.