### PR TITLE
[MaterialDividerItemDecoration] Fix divider count

### DIFF
--- a/lib/java/com/google/android/material/divider/MaterialDividerItemDecoration.java
+++ b/lib/java/com/google/android/material/divider/MaterialDividerItemDecoration.java
@@ -317,18 +317,16 @@ public class MaterialDividerItemDecoration extends ItemDecoration {
     left += isRtl ? insetEnd : insetStart;
     right -= isRtl ? insetStart : insetEnd;
 
-    int itemCount = parent.getAdapter() == null ? 0 : parent.getAdapter().getItemCount();
-    int dividerCount = lastItemDecorated ? itemCount : itemCount - 1;
+    int childCount = parent.getChildCount();
+    int dividerCount = lastItemDecorated ? childCount : childCount - 1;
     for (int i = 0; i < dividerCount; i++) {
       View child = parent.getChildAt(i);
-      if (child != null) {
-        parent.getDecoratedBoundsWithMargins(child, tempRect);
-        // Take into consideration any translationY added to the view.
-        int bottom = tempRect.bottom + Math.round(child.getTranslationY());
-        int top = bottom - dividerDrawable.getIntrinsicHeight() - thickness;
-        dividerDrawable.setBounds(left, top, right, bottom);
-        dividerDrawable.draw(canvas);
-      }
+      parent.getDecoratedBoundsWithMargins(child, tempRect);
+      // Take into consideration any translationY added to the view.
+      int bottom = tempRect.bottom + Math.round(child.getTranslationY());
+      int top = bottom - dividerDrawable.getIntrinsicHeight() - thickness;
+      dividerDrawable.setBounds(left, top, right, bottom);
+      dividerDrawable.draw(canvas);
     }
     canvas.restore();
   }


### PR DESCRIPTION
Reverts 03c4353937c18ccf13855fc27dc4e6d36ef0eecf

[At the moment](https://github.com/material-components/material-components-android/tree/4e52469ec43e18aaeac6ae20efd4c4ceab66ebaf), `dividerCount` is based on the number of items _in the adapter_, although the enumeration is based on the items that are _directly inside `RecyclerView`_, and this leads to incorrect behavior.

In particular, `setLastItemDecorated(false)` no longer works if there are many items in `RecyclerView`.

The PR rolls back the commit that brought the above issues.