### PR TITLE
[CollapsingToolbarLayout] Use more accurate way to determine text direction

### DIFF
--- a/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
+++ b/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
@@ -198,7 +198,7 @@ public class CollapsingToolbarLayout extends FrameLayout {
 
     collapsingTextHelper = new CollapsingTextHelper(this);
     collapsingTextHelper.setTextSizeInterpolator(AnimationUtils.DECELERATE_INTERPOLATOR);
-    collapsingTextHelper.setRtlTextDirectionHeuristicsEnabled(false);
+    collapsingTextHelper.setRtlTextDirectionHeuristicsEnabled(true);
 
     elevationOverlayProvider = new ElevationOverlayProvider(context);
 

--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -721,9 +721,7 @@ public final class CollapsingTextHelper {
       collapsedTextWidth = 0;
     }
     final int collapsedAbsGravity =
-        GravityCompat.getAbsoluteGravity(
-            collapsedTextGravity,
-            isRtl ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR);
+        GravityCompat.getAbsoluteGravity(collapsedTextGravity, ViewCompat.getLayoutDirection(view));
 
     switch (collapsedAbsGravity & Gravity.VERTICAL_GRAVITY_MASK) {
       case Gravity.BOTTOM:
@@ -763,9 +761,7 @@ public final class CollapsingTextHelper {
     expandedLineCount = textLayout != null ? textLayout.getLineCount() : 0;
 
     final int expandedAbsGravity =
-        GravityCompat.getAbsoluteGravity(
-            expandedTextGravity,
-            isRtl ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR);
+        GravityCompat.getAbsoluteGravity(expandedTextGravity, ViewCompat.getLayoutDirection(view));
     switch (expandedAbsGravity & Gravity.VERTICAL_GRAVITY_MASK) {
       case Gravity.BOTTOM:
         expandedDrawY = expandedBounds.bottom - expandedTextHeight + textPaint.descent();
@@ -1087,9 +1083,7 @@ public final class CollapsingTextHelper {
 
   private Alignment getMultilineTextLayoutAlignment() {
     int absoluteGravity =
-        GravityCompat.getAbsoluteGravity(
-            expandedTextGravity,
-            isRtl ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR);
+        GravityCompat.getAbsoluteGravity(expandedTextGravity, ViewCompat.getLayoutDirection(view));
     switch (absoluteGravity & Gravity.HORIZONTAL_GRAVITY_MASK) {
       case Gravity.CENTER_HORIZONTAL:
         return ALIGN_CENTER;


### PR DESCRIPTION
Fixes https://github.com/material-components/material-components-android/issues/2830

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
   </tr> 
   <tr>
    <td><img src="https://user-images.githubusercontent.com/82187521/181303580-5a1e82c0-c677-4a80-bdb0-188440d81ccf.png" width="270px"></td>
    <td><img src="https://user-images.githubusercontent.com/82187521/181303596-5b6f16ef-9aa4-46ec-8bbd-af3092f90519.png" width="270px"></td>
    </tr>
</table>

Also see https://github.com/material-components/material-components-android/issues/2830#issuecomment-1197042582 and https://github.com/material-components/material-components-android/issues/2830#issuecomment-1197075367.