### PR TITLE
[TextField] Convert autoCompleteTextView's onTouchListener to onClickListener.

### DIFF
--- a/lib/java/com/google/android/material/textfield/DropdownMenuEndIconDelegate.java
+++ b/lib/java/com/google/android/material/textfield/DropdownMenuEndIconDelegate.java
@@ -106,7 +106,7 @@ class DropdownMenuEndIconDelegate extends EndIconDelegate {
   void tearDown() {
     if (autoCompleteTextView != null) {
       // Remove any listeners set on the edit text.
-      autoCompleteTextView.setOnTouchListener(null);
+      autoCompleteTextView.setOnClickListener(null);
       if (IS_LOLLIPOP) {
         autoCompleteTextView.setOnDismissListener(null);
       }
@@ -251,15 +251,12 @@ class DropdownMenuEndIconDelegate extends EndIconDelegate {
   // interactions with the dropdown menu.
   private void setUpDropdownShowHideBehavior() {
     // Set whole layout clickable.
-    autoCompleteTextView.setOnTouchListener((view, event) -> {
-      if (event.getAction() == MotionEvent.ACTION_UP) {
-        if (isDropdownPopupActive()) {
-          dropdownPopupDirty = false;
-        }
-        showHideDropdown();
-        updateDropdownPopupDirty();
+    autoCompleteTextView.setOnClickListener(view -> {
+      if (isDropdownPopupActive()) {
+        dropdownPopupDirty = false;
       }
-      return false;
+      showHideDropdown();
+      updateDropdownPopupDirty();
     });
     if (IS_LOLLIPOP) {
       autoCompleteTextView.setOnDismissListener(() -> {


### PR DESCRIPTION
ACTION_DOWN and ACTION_UP are both triggered on click, resulting in duplicate touch calls being handled. Changing over to an onClickListener mitigates this issue

Resolves https://github.com/material-components/material-components-android/issues/2840

### Thanks for starting a pull request on Material Components! 
#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #2840`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

