### PR TITLE
[BottomSheetBehavior] Add method to calculate slide offset

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -1075,6 +1075,10 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
    * value corresponds to an expanded state.
    */
   public float calculateSlideOffset() {
+    if (viewRef == null) {
+      return Float.MIN_VALUE;
+    }
+
     View bottomSheet = viewRef.get();
     if (bottomSheet != null) {
       return calculateSlideOffset(bottomSheet.getTop());

--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -1068,7 +1068,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
   /**
    * Calculates the current offset of the bottom sheet.
    *
-   * This method should be called when the child view is laid out. If not, 0 will be returned.
+   * This method should be called when the child view is laid out. If not, {@code Float.MIN_VALUE} will be returned.
    *
    * @return The offset of the bottom sheet, as a float value between -1 and 1. A negative value
    * corresponds to a hidden state, a zero value corresponds to a collapsed state, and a positive
@@ -1080,7 +1080,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
       return calculateSlideOffset(bottomSheet.getTop());
     }
 
-    return 0;
+    return Float.MIN_VALUE;
   }
 
   /**

--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -1068,11 +1068,12 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
   /**
    * Calculates the current offset of the bottom sheet.
    *
-   * This method should be called when the child view is laid out. If not, {@code Float.MIN_VALUE} will be returned.
+   * This method should be called when the child view is laid out.
    *
-   * @return The offset of the bottom sheet, as a float value between -1 and 1. A negative value
-   * corresponds to a hidden state, a zero value corresponds to a collapsed state, and a positive
-   * value corresponds to an expanded state.
+   * @return The offset of this bottom sheet within [-1,1] range. Offset increases
+   * as this bottom sheet is moving upward. From 0 to 1 the sheet is between collapsed and
+   * expanded states and from -1 to 0 it is between hidden and collapsed states. Returns
+   * {@code Float.MIN_VALUE} if the bottom sheet is not laid out.
    */
   public float calculateSlideOffset() {
     if (viewRef == null) {

--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -1066,6 +1066,24 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
   }
 
   /**
+   * Calculates the current offset of the bottom sheet.
+   *
+   * This method should be called when the child view is laid out. If not, 0 will be returned.
+   *
+   * @return The offset of the bottom sheet, as a float value between -1 and 1. A negative value
+   * corresponds to a hidden state, a zero value corresponds to a collapsed state, and a positive
+   * value corresponds to an expanded state.
+   */
+  public float calculateSlideOffset() {
+    View bottomSheet = viewRef.get();
+    if (bottomSheet != null) {
+      return calculateSlideOffset(bottomSheet.getTop());
+    }
+
+    return 0;
+  }
+
+  /**
    * Sets whether this bottom sheet can hide.
    *
    * @param hideable {@code true} to make this bottom sheet hideable.
@@ -1407,6 +1425,13 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
 
   private void calculateHalfExpandedOffset() {
     this.halfExpandedOffset = (int) (parentHeight * (1 - halfExpandedRatio));
+  }
+
+  private float calculateSlideOffset(int top) {
+      return
+          (top > collapsedOffset || collapsedOffset == getExpandedOffset())
+              ? (float) (collapsedOffset - top) / (parentHeight - collapsedOffset)
+              : (float) (collapsedOffset - top) / (collapsedOffset - getExpandedOffset());
   }
 
   private void reset() {
@@ -1806,10 +1831,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
   void dispatchOnSlide(int top) {
     View bottomSheet = viewRef.get();
     if (bottomSheet != null && !callbacks.isEmpty()) {
-      float slideOffset =
-          (top > collapsedOffset || collapsedOffset == getExpandedOffset())
-              ? (float) (collapsedOffset - top) / (parentHeight - collapsedOffset)
-              : (float) (collapsedOffset - top) / (collapsedOffset - getExpandedOffset());
+      float slideOffset = calculateSlideOffset(top);
       for (int i = 0; i < callbacks.size(); i++) {
         callbacks.get(i).onSlide(bottomSheet, slideOffset);
       }

--- a/tests/javatests/com/google/android/material/bottomsheet/BottomSheetBehaviorTest.java
+++ b/tests/javatests/com/google/android/material/bottomsheet/BottomSheetBehaviorTest.java
@@ -948,6 +948,23 @@ public class BottomSheetBehaviorTest {
     checkSetState(BottomSheetBehavior.STATE_EXPANDED, ViewMatchers.isDisplayed());
     checkSetState(BottomSheetBehavior.STATE_COLLAPSED, ViewMatchers.isDisplayed());
   }
+  
+  @Test
+  @SmallTest
+  public void testCalculateSlideOffset() {
+    activityTestRule.runOnUiThread(
+        () -> {
+          BottomSheetBehavior<?> behavior = getBehavior();
+          behavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+          assertThat(behavior.calculateSlideOffset(), is(1f));
+          behavior.setState(BottomSheetBehavior.STATE_HALF_EXPANDED);
+          assertThat(behavior.calculateSlideOffset(), is(0.5f));
+          behavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+          assertThat(behavior.calculateSlideOffset(), is(0f));
+          behavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+          assertThat(behavior.calculateSlideOffset(), is(-1f));
+        });
+  }
 
   @Test
   @SmallTest


### PR DESCRIPTION
Add a `calculateSlideOffset` method to `BottomSheetBehavior`, allowing the current slide offset to be obtained at runtime.

I have several runtime transitions dependent on the offset of my bottom sheet. However, these transitions need to be initialized on startup, something that can't be provided by BottomSheetCallback as it does not fire on startup. Since making that callback fire on startup would break compatibility, instead I want a way to get the slide offset so I can initialize the components myself.

This PR resolves that by adding a method (`calculateSlideOffset`) that returns the current slide offset of the bottom sheet. If the sheet is not laid out, it will return 0.

Resolves #2871.
