### PR TITLE
[BottomSheetBehavior] Check for shouldSkipHalfExpandedWhenDragging during nested scrolling

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -768,10 +768,14 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
         targetState = STATE_EXPANDED;
       } else {
         int currentTop = child.getTop();
-        if (currentTop > halfExpandedOffset) {
-          targetState = STATE_HALF_EXPANDED;
-        } else {
+        if (currentTop < halfExpandedOffset) {
           targetState = STATE_EXPANDED;
+        } else {
+          if (shouldSkipHalfExpandedStateWhenDragging()) {
+            targetState = STATE_EXPANDED;
+          } else {
+            targetState = STATE_HALF_EXPANDED;
+          }
         }
       }
     } else if (hideable && shouldHide(child, getYVelocity())) {
@@ -796,10 +800,14 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
             }
           }
         } else {
-          if (Math.abs(currentTop - halfExpandedOffset) < Math.abs(currentTop - collapsedOffset)) {
-            targetState = STATE_HALF_EXPANDED;
-          } else {
+          if (shouldSkipHalfExpandedStateWhenDragging()) {
             targetState = STATE_COLLAPSED;
+          } else {
+            if (Math.abs(currentTop - halfExpandedOffset) < Math.abs(currentTop - collapsedOffset)) {
+              targetState = STATE_HALF_EXPANDED;
+            } else {
+              targetState = STATE_COLLAPSED;
+            }
           }
         }
       }
@@ -809,10 +817,14 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
       } else {
         // Settle to nearest height.
         int currentTop = child.getTop();
-        if (Math.abs(currentTop - halfExpandedOffset) < Math.abs(currentTop - collapsedOffset)) {
-          targetState = STATE_HALF_EXPANDED;
-        } else {
+        if (shouldSkipHalfExpandedStateWhenDragging()) {
           targetState = STATE_COLLAPSED;
+        } else {
+          if (Math.abs(currentTop - halfExpandedOffset) < Math.abs(currentTop - collapsedOffset)) {
+            targetState = STATE_HALF_EXPANDED;
+          } else {
+            targetState = STATE_COLLAPSED;
+          }
         }
       }
     }


### PR DESCRIPTION
Make `BottomSheetBehavior` check the experimental `shouldSkipHalfExpandedWhenDragging` flag before setting the state to `HALF_EXPANDED`.

The code changes the following behaviors in `onStopNestedScroll`:
1. In the case of `dy > 0`, the state will be set to `STATE_EXPANDED` instead of `STATE_HALF_EXPANDED` when the flag is enabled.
2. In the case of `dy == 0`, the state will be set to `STATE_EXPANDED` when above the half-expanded offset, and `STATE_COLLAPSED` when below it when the flag is enabled.
3. In the state of `dy < 0`, the state will be set to `STATE_COLLAPSED` instead of `STATE_HALF_EXPANDED` when the flag is enabled.
