### PR TITLE
[BottomSheetBehavior] Add internal method to disable hiding gestures

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -725,7 +725,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
       }
     } else if (dy < 0) { // Downward
       if (!target.canScrollVertically(-1)) {
-        if (newTop <= collapsedOffset || (hideable && shouldEnableHidingGestures())) {
+        if (newTop <= collapsedOffset || (hideable && isHideableWhenDragging())) {
           if (!draggable) {
             // Prevent dragging
             return;
@@ -1441,7 +1441,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
     if (skipCollapsed) {
       return true;
     }
-    if (!shouldEnableHidingGestures()) {
+    if (!isHideableWhenDragging()) {
       return false;
     }
     if (child.getTop() < collapsedOffset) {
@@ -1790,7 +1790,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
           return MathUtils.clamp(
               top,
               getExpandedOffset(),
-              (hideable && shouldEnableHidingGestures()) ? parentHeight : collapsedOffset);
+              (hideable && isHideableWhenDragging()) ? parentHeight : collapsedOffset);
         }
 
         @Override
@@ -1800,7 +1800,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
 
         @Override
         public int getViewVerticalDragRange(@NonNull View child) {
-          if (hideable && shouldEnableHidingGestures()) {
+          if (hideable && isHideableWhenDragging()) {
             return parentHeight;
           } else {
             return collapsedOffset;
@@ -1878,7 +1878,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
    * @hide
    */
   @RestrictTo(LIBRARY_GROUP)
-  public boolean shouldEnableHidingGestures() {
+  public boolean isHideableWhenDragging() {
     return true;
   }
 
@@ -2136,7 +2136,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
               child, R.string.bottomsheet_action_expand_halfway, STATE_HALF_EXPANDED);
     }
 
-    if ((hideable && shouldEnableHidingGestures()) && state != STATE_HIDDEN) {
+    if ((hideable && isHideableWhenDragging()) && state != STATE_HIDDEN) {
       replaceAccessibilityActionForState(
           child, AccessibilityActionCompat.ACTION_DISMISS, STATE_HIDDEN);
     }

--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -725,7 +725,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
       }
     } else if (dy < 0) { // Downward
       if (!target.canScrollVertically(-1)) {
-        if (newTop <= collapsedOffset || hideable) {
+        if (newTop <= collapsedOffset || (hideable && shouldEnableHidingGestures())) {
           if (!draggable) {
             // Prevent dragging
             return;
@@ -1441,6 +1441,9 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
     if (skipCollapsed) {
       return true;
     }
+    if (!shouldEnableHidingGestures()) {
+      return false;
+    }
     if (child.getTop() < collapsedOffset) {
       // It should not hide, but collapse.
       return false;
@@ -1785,7 +1788,9 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
         @Override
         public int clampViewPositionVertical(@NonNull View child, int top, int dy) {
           return MathUtils.clamp(
-              top, getExpandedOffset(), hideable ? parentHeight : collapsedOffset);
+              top,
+              getExpandedOffset(),
+              (hideable && shouldEnableHidingGestures()) ? parentHeight : collapsedOffset);
         }
 
         @Override
@@ -1795,7 +1800,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
 
         @Override
         public int getViewVerticalDragRange(@NonNull View child) {
-          if (hideable) {
+          if (hideable && shouldEnableHidingGestures()) {
             return parentHeight;
           } else {
             return collapsedOffset;
@@ -1864,6 +1869,16 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
    */
   @RestrictTo(LIBRARY_GROUP)
   public boolean shouldSkipSmoothAnimation() {
+    return true;
+  }
+
+  /**
+   * Checks whether hiding gestures should be enabled while {@code isHideable} is set to true.
+   *
+   * @hide
+   */
+  @RestrictTo(LIBRARY_GROUP)
+  public boolean shouldEnableHidingGestures() {
     return true;
   }
 
@@ -2121,7 +2136,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
               child, R.string.bottomsheet_action_expand_halfway, STATE_HALF_EXPANDED);
     }
 
-    if (hideable && state != STATE_HIDDEN) {
+    if ((hideable && shouldEnableHidingGestures()) && state != STATE_HIDDEN) {
       replaceAccessibilityActionForState(
           child, AccessibilityActionCompat.ACTION_DISMISS, STATE_HIDDEN);
     }


### PR DESCRIPTION
Some users of `BottomSheetBehavior` need to enable `isHideable` so that they can set a state programmatically, but still want to disable hiding in the UI, as the hiding action would represent something too destructive (Removing the currently playing song, for example). This was discussed in #2786 and a workaround proposed, but the workaround did not necessarily work in all situations, and it was largely a band-aid around the larger issue that `isHideable` simultaneously represents the ability for the bottom sheet to hide programmatically, and the ability to hide the bottom sheet.

This PR adds a new internal method called `shouldEnableHidingGestures` (a la `shouldSkipHalfExpandedStateWhileDragging`) that allows hiding gestures to be disabled even when `isHideable` is enabled. This preserves the behavior of `isHideable` while also allowing a escape hatch for those who need the hidden state internally, but don't want to expose such to the user.

Also see #2786.
