### PR TITLE
[Theme] Override framework `colorControlX` values in `Material3` theme

### DIFF
--- a/lib/java/com/google/android/material/color/res/color/m3_color_control_highlight_selector.xml
+++ b/lib/java/com/google/android/material/color/res/color/m3_color_control_highlight_selector.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:alpha="@dimen/m3_ripple_selectable_pressed_alpha"
+      android:color="?attr/colorOnSurfaceVariant"
+      android:state_pressed="true"/>
+  <item android:alpha="@dimen/m3_ripple_focused_alpha"
+      android:color="?attr/colorOnSurfaceVariant"
+      android:state_focused="true"/>
+  <item android:alpha="@dimen/m3_ripple_hovered_alpha"
+      android:color="?attr/colorOnSurfaceVariant"
+      android:state_hovered="true"/>
+  <item android:alpha="@dimen/m3_ripple_default_alpha"
+      android:color="?attr/colorOnSurfaceVariant"/>
+</selector>

--- a/lib/java/com/google/android/material/theme/res/values-v23/themes_base.xml
+++ b/lib/java/com/google/android/material/theme/res/values-v23/themes_base.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright (C) 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<resources>
+  <!--
+  Only API 23 supports the color selectors required to correctly override the
+  framework colorControlHighlight attribute.
+  -->
+
+  <style name="Base.V23.Theme.Material3.Light" parent="Base.V14.Theme.Material3.Light">
+    <!-- Framework Colors. -->
+    <item name="colorControlHighlight">@color/m3_color_control_highlight_selector</item>
+  </style>
+
+  <style name="Base.V23.Theme.Material3.Dark" parent="Base.V14.Theme.Material3.Dark">
+    <!-- Framework Colors. -->
+    <item name="colorControlHighlight">@color/m3_color_control_highlight_selector</item>
+  </style>
+
+  <style name="Base.Theme.Material3.Light" parent="Base.V23.Theme.Material3.Light"/>
+  <style name="Base.Theme.Material3.Dark" parent="Base.V23.Theme.Material3.Dark"/>
+</resources>

--- a/lib/java/com/google/android/material/theme/res/values-v24/themes_base.xml
+++ b/lib/java/com/google/android/material/theme/res/values-v24/themes_base.xml
@@ -15,11 +15,11 @@
   ~ limitations under the License.
 -->
 <resources>
-  <style name="Base.V24.Theme.Material3.Light" parent="Base.V14.Theme.Material3.Light">
+  <style name="Base.V24.Theme.Material3.Light" parent="Base.V23.Theme.Material3.Light">
     <item name="android:contextPopupMenuStyle">@style/Widget.Material3.PopupMenu.ContextMenu</item>
   </style>
 
-  <style name="Base.V24.Theme.Material3.Dark" parent="Base.V14.Theme.Material3.Dark">
+  <style name="Base.V24.Theme.Material3.Dark" parent="Base.V23.Theme.Material3.Dark">
     <item name="android:contextPopupMenuStyle">@style/Widget.Material3.PopupMenu.ContextMenu</item>
   </style>
 

--- a/lib/java/com/google/android/material/theme/res/values/themes_base.xml
+++ b/lib/java/com/google/android/material/theme/res/values/themes_base.xml
@@ -52,6 +52,8 @@
 
     <!-- Framework Colors. -->
     <item name="android:windowBackground">?android:attr/colorBackground</item>
+    <item name="colorControlNormal">?attr/colorOnSurfaceVariant</item>
+    <item name="colorControlActivated">?attr/colorPrimary</item>
 
     <!-- Default Framework Text Colors. -->
     <item name="android:textColorPrimary">@color/m3_default_color_primary_text</item>
@@ -289,6 +291,8 @@
 
     <!-- Framework Colors. -->
     <item name="android:windowBackground">?android:attr/colorBackground</item>
+    <item name="colorControlNormal">?attr/colorOnSurfaceVariant</item>
+    <item name="colorControlActivated">?attr/colorPrimary</item>
 
     <!-- Default Framework Text Colors. -->
     <item name="android:textColorPrimary">@color/m3_dark_default_color_primary_text</item>


### PR DESCRIPTION
Many components (like `Toolbar`) leverage framework attributes like `colorControlNormal`, `colorControlHighlight`, and `colorControlActivated` in their UI. However, these legacy values are not overridden in the `Material3` theme. This causes them to use the outdated Material 1/2 styles. This PR fixes that by overriding these attributes with the correct colors.

- `colorControlNormal` now maps to `colorOnSurfaceVariant`
- `colorControlHighlight` now maps to the `colorOnSurfaceVariant` state layers on API 23+, and remains unchanged below that version as the selector will not work before that.
- `colorControlActivated` now maps to `colorPrimary`.

Resolves #2866.