### PR TITLE
[SwipeDismissBehavior]fix SwipeDissmissBehavior not work when down touch event consumed by …

### DIFF
--- a/lib/java/com/google/android/material/behavior/SwipeDismissBehavior.java
+++ b/lib/java/com/google/android/material/behavior/SwipeDismissBehavior.java
@@ -89,6 +89,8 @@ public class SwipeDismissBehavior<V extends View> extends CoordinatorLayout.Beha
   private float sensitivity = 0f;
   private boolean sensitivitySet;
 
+  private boolean ignoreCancelEvent = false;
+
   int swipeDirection = SWIPE_DIRECTION_ANY;
   float dragDismissThreshold = DEFAULT_DRAG_DISMISS_THRESHOLD;
   float alphaStartSwipeDistance = DEFAULT_ALPHA_START_DISTANCE;
@@ -212,6 +214,12 @@ public class SwipeDismissBehavior<V extends View> extends CoordinatorLayout.Beha
   @Override
   public boolean onTouchEvent(CoordinatorLayout parent, V child, MotionEvent event) {
     if (viewDragHelper != null) {
+      // Ignore ACTION_CANCEL event from the CoordinatorLayout when the SwipeDismissBehavior calls
+      // requestDisallowInterceptTouchEvent in onViewCaptured
+      if (ignoreCancelEvent && event.getActionMasked() == MotionEvent.ACTION_CANCEL) {
+        ignoreCancelEvent = false;
+        return true;
+      }
       viewDragHelper.processTouchEvent(event);
       return true;
     }
@@ -251,7 +259,11 @@ public class SwipeDismissBehavior<V extends View> extends CoordinatorLayout.Beha
           // intercepting
           final ViewParent parent = capturedChild.getParent();
           if (parent != null) {
+            //Ignore ACTION_CANCEL event from the CoordinatorLayout when the SwipeDismissBehavior
+            // calls requestDisallowInterceptTouchEvent in onViewCaptured
+            ignoreCancelEvent = true;
             parent.requestDisallowInterceptTouchEvent(true);
+            ignoreCancelEvent = false;
           }
         }
 

--- a/lib/java/com/google/android/material/behavior/SwipeDismissBehavior.java
+++ b/lib/java/com/google/android/material/behavior/SwipeDismissBehavior.java
@@ -85,11 +85,10 @@ public class SwipeDismissBehavior<V extends View> extends CoordinatorLayout.Beha
   ViewDragHelper viewDragHelper;
   OnDismissListener listener;
   private boolean interceptingEvents;
+  private boolean ignoreCancelEvent = false;
 
   private float sensitivity = 0f;
   private boolean sensitivitySet;
-
-  private boolean ignoreCancelEvent = false;
 
   int swipeDirection = SWIPE_DIRECTION_ANY;
   float dragDismissThreshold = DEFAULT_DRAG_DISMISS_THRESHOLD;


### PR DESCRIPTION
Fix #1333
This bug is caused by two reasons
1.  Recieving a ACTION_CANCEL event from the CoordinatorLayout when the SwipeDismissBehavior calls requestDisallowInterceptTouchEvent in onViewCaptured.
2. ACTION_DOWN consumed by other view, causing the Behavior not to call back onTouchEvent
