### PR TITLE
[Gradle] Fix Gradle warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ before_script:
   - adb shell input keyevent 82
 
 script:
-  - ./gradlew test -PdisablePreDex
-  - ./gradlew connectedAndroidTest -PdisablePreDex
+  - ./gradlew test
+  - ./gradlew connectedAndroidTest

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,6 @@ ext {
   // required for the doclava dependency.
   usePrebuilts = "true"
 
-  // Disable pre-dexing when gradle called with -PdisablePreDex;
-  preDexLibs = !project.hasProperty('disablePreDex')
-
   mavenRepoUrl = (project.hasProperty('mavenRepoUrl')
     ? project.property('mavenRepoUrl') : '/tmp/myRepo/')
 
@@ -190,9 +187,6 @@ subprojects {
     }
 
     if (isAndroidLibrary || isAndroidApp || isAndroidTest) {
-      // Disable pre-dexing when gradle called with -PdisablePreDex;
-      project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
-
       project.android {
         compileSdkVersion rootProject.ext.compileSdkVersion
 
@@ -208,8 +202,8 @@ subprojects {
         aaptOptions.additionalParameters "--no-version-vectors"
 
         android {
-          lintOptions {
-            check 'NewApi'
+          lint {
+            checkOnly 'NewApi'
           }
         }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -238,7 +238,7 @@ afterEvaluate {
 }
 
 task androidSourcesJar(type: Jar) {
-  classifier = 'sources'
+  archiveClassifier.set('sources')
   from(android.sourceSets.main.java.srcDirs) {
     // Needed because we have Java sources and resources in same directory
     include '**/*.java'


### PR DESCRIPTION
- `dexOptions` is obsolete and using it has no effect ([link](https://issuetracker.google.com/issues/183295952#comment3))
- `android.lintOptions` has been renamed to `android.lint` ([link](https://developer.android.com/reference/tools/gradle-api/7.3/com/android/build/api/dsl/LintOptions))
- `android.lintOptions.check` is obsolete and has been replaced with `android.lintOptions.checkOnly` ([link](https://developer.android.com/reference/tools/gradle-api/7.3/com/android/build/api/dsl/LintOptions#check(kotlin.String)))
- `setClassifier` is deprecated, it's supposed to use `getArchiveClassifier` instead ([link](https://docs.gradle.org/7.3.3/javadoc/org/gradle/api/tasks/bundling/AbstractArchiveTask.html#setClassifier-java.lang.String-))