### PR TITLE
Bugfix/2869 label scroll

### DIFF
--- a/catalog/java/io/material/catalog/slider/SliderScrollContainerDemoFragment.java
+++ b/catalog/java/io/material/catalog/slider/SliderScrollContainerDemoFragment.java
@@ -24,6 +24,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import androidx.annotation.Nullable;
+
+import com.google.android.material.slider.LabelFormatter;
 import com.google.android.material.slider.Slider;
 import io.material.catalog.feature.DemoFragment;
 
@@ -41,8 +43,12 @@ public class SliderScrollContainerDemoFragment extends DemoFragment {
             R.layout.cat_slider_demo_scroll, viewGroup, false /* attachToRoot */);
     LinearLayout sliderContainer = view.findViewById(R.id.sliderContainer);
     for (int i = 0; i < 50; i++) {
+      Slider slider = new Slider(layoutInflater.getContext());
+      if (i == 5) {
+        slider.setLabelBehavior(LabelFormatter.LABEL_VISIBLE);
+      }
       sliderContainer.addView(
-          new Slider(layoutInflater.getContext()),
+          slider,
           ViewGroup.LayoutParams.MATCH_PARENT,
           ViewGroup.LayoutParams.WRAP_CONTENT);
     }


### PR DESCRIPTION
Fixes #2869 

See commit messages. Not sure if the commit that adds to the sample is wanted, let me know. 

Also ran into a related issue, #2942, once the label is drawn to the canvas. My solution was to remove the Tooltip padding entirely, however I could see why that might be undesirable in the case that the Tooltip is still being drawn over the content overlay. Let me know, that could also easily be parameterized based on label behavior. I do think we at least don't want that Tooltip padding if it's drawn to the canvas, since the view will already have padding set on it.