### PR TITLE
[Buttons] Fixes text measurement to allow Spanned text

### DIFF
--- a/catalog/java/io/material/catalog/button/ButtonsMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/button/ButtonsMainDemoFragment.java
@@ -16,19 +16,27 @@
 
 package io.material.catalog.button;
 
-import io.material.catalog.R;
-
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import androidx.appcompat.widget.SwitchCompat;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
 import android.text.TextUtils;
+import android.text.style.ReplacementSpan;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SwitchCompat;
 import com.google.android.material.button.MaterialButton;
+import com.google.android.material.button.MaterialButtonToggleGroup;
 import com.google.android.material.snackbar.Snackbar;
+import io.material.catalog.R;
 import io.material.catalog.feature.DemoFragment;
 import io.material.catalog.feature.DemoUtils;
 import java.util.List;
@@ -94,7 +102,48 @@ public class ButtonsMainDemoFragment extends DemoFragment {
           });
     }
 
+    SpannableStringBuilder ssb = new SpannableStringBuilder("⌧Hello");
+    ssb.setSpan(new MySpan(), 1, 6, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    TextView spannedButton = view.findViewById(R.id.material_replaced_text_button);
+    spannedButton.setText(ssb);
+
+    Drawable check = requireActivity().getResources().getDrawable(R.drawable.ic_dialogs_24px);
+    MaterialButtonToggleGroup grp = view.findViewById(R.id.btnGrp);
+    for (int i : grp.getCheckedButtonIds()) {
+      MaterialButton btn = grp.findViewById(i);
+      btn.setIcon(check);
+    }
+    int singleId = grp.getCheckedButtonId();
+    if (singleId > 0) {
+      MaterialButton btn = grp.findViewById(singleId);
+      btn.setIcon(check);
+    }
+    grp.addOnButtonCheckedListener((g, checkedId, isChecked) -> {
+      MaterialButton btn = g.findViewById(checkedId);
+      btn.setIcon(isChecked ? check : null);
+    });
+    MaterialButton spanned = grp.findViewById(R.id.btn);
+    spanned.setText(ssb);
+
     return view;
+  }
+
+  class MySpan extends ReplacementSpan {
+    int width = 50;
+
+    @Override
+    public void draw(
+        @NonNull Canvas canvas,
+        CharSequence charSequence,
+        int i, int i1, float v, int i2, int i3, int i4,
+        @NonNull Paint paint) {
+      canvas.drawRect(v, i2, v + width, i4, paint);
+    }
+
+    @Override
+    public int getSize(Paint a, CharSequence b, int c, int d, Paint.FontMetricsInt e) {
+      return width;
+    }
   }
 
   @LayoutRes

--- a/catalog/java/io/material/catalog/button/res/layout/cat_buttons_fragment.xml
+++ b/catalog/java/io/material/catalog/button/res/layout/cat_buttons_fragment.xml
@@ -83,6 +83,51 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:paddingTop="8dp"
+          android:text="@string/cat_repl_btn_text"
+          android:textSize="16sp"/>
+
+      <Button
+          android:id="@+id/material_replaced_text_button"
+          style="@style/Widget.Material3.Button.Icon"
+          android:layout_width="200dp"
+          android:layout_height="wrap_content"
+          android:text="@string/cat_button_label_to_be_replaced"
+          app:iconGravity="textStart"
+          app:icon="@drawable/ic_dialogs_24px"/>
+
+      <com.google.android.material.button.MaterialButtonToggleGroup
+          android:id="@+id/btnGrp"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="Hello World!"
+          app:checkedButton="@+id/btn"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent">
+        <com.google.android.material.button.MaterialButton
+            style="?attr/materialIconButtonStyle"
+            android:id="@+id/btn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:iconGravity="textStart"
+            android:layout_weight="1"
+            android:text="⌧"/>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn3"
+            style="?attr/materialIconButtonStyle"
+            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            app:iconGravity="textStart"
+            android:text="⌧"/>
+      </com.google.android.material.button.MaterialButtonToggleGroup>
+
+      <TextView
+          android:textStyle="bold"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:paddingTop="8dp"
           android:text="@string/cat_text_btn_text"
           android:textSize="16sp"/>
 

--- a/catalog/java/io/material/catalog/button/res/values/strings.xml
+++ b/catalog/java/io/material/catalog/button/res/values/strings.xml
@@ -78,4 +78,6 @@
   <string name="cat_button_require_selection" translatable="false">Require Selection</string>
   <string name="cat_button_vertical_orientation" translatable="false">Vertical Orientation</string>
   <string name="cat_button_enable" translatable="false">Enabled</string>
+  <string name="cat_repl_btn_text">Spanned</string>
+  <string name="cat_button_label_to_be_replaced">to be replaced</string>
 </resources>

--- a/lib/java/com/google/android/material/button/MaterialButton.java
+++ b/lib/java/com/google/android/material/button/MaterialButton.java
@@ -20,6 +20,7 @@ import com.google.android.material.R;
 
 import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 import static com.google.android.material.theme.overlay.MaterialThemeOverlay.wrap;
+import static java.lang.Math.ceil;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
@@ -613,24 +614,12 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
   }
 
   private int getTextLayoutWidth() {
-    int maxWidth = 0;
+    float maxWidth = 0;
     int lineCount = getLineCount();
     for (int line = 0; line < lineCount; line++) {
-      maxWidth = max(maxWidth, getTextWidth(getTextInLine(line)));
+      maxWidth = max(maxWidth, getLayout().getLineWidth(line));
     }
-    return maxWidth;
-  }
-
-  private int getTextWidth(CharSequence text) {
-    Paint textPaint = getPaint();
-    String buttonText = text.toString();
-    if (getTransformationMethod() != null) {
-      // if text is transformed, add that transformation to to ensure correct calculation
-      // of icon padding.
-      buttonText = getTransformationMethod().getTransformation(buttonText, this).toString();
-    }
-
-    return min((int) textPaint.measureText(buttonText), getLayout().getEllipsizedWidth());
+    return (int) ceil(maxWidth);
   }
 
   private int getTextHeight() {
@@ -650,12 +639,6 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
     textPaint.getTextBounds(buttonText, 0, buttonText.length(), bounds);
 
     return min(bounds.height(), getLayout().getHeight());
-  }
-
-  private CharSequence getTextInLine(int line) {
-    int start = getLayout().getLineStart(line);
-    int end = getLayout().getLineEnd(line);
-    return getText().subSequence(start, end);
   }
 
   private boolean isLayoutRTL() {


### PR DESCRIPTION
Changes to use `Layout`'s text measurements so that we can leverage the existing measurements that take into account `Spanned` text (as opposed to `TextPaint` measures that does not handles `Span`s).