### PR TITLE
[MaterialDatePicker] Change hint formatting from m/d/yy → mm/dd/yyyy

### DIFF
--- a/lib/java/com/google/android/material/datepicker/UtcDates.java
+++ b/lib/java/com/google/android/material/datepicker/UtcDates.java
@@ -170,6 +170,24 @@ class UtcDates {
       formatHint = formatHint.replace("y", "yyyy");
     }
 
+    // Format year to always be displayed as 4 chars when 2 chars are used in localized pattern.
+    // Example: (fr-FR) dd/MM/y -> dd/MM/yyyy
+    if (formatHint.replaceAll("[^y]", "").length() == 2) {
+      formatHint = formatHint.replace("yy", "yyyy");
+    }
+
+    // Format month to always be displayed as 2 chars when only 1 char is used in localized pattern.
+    // Example: (fr-FR) dd/MM/y -> dd/MM/yyyy
+    if (formatHint.replaceAll("[^M]", "").length() == 1) {
+      formatHint = formatHint.replace("M", "MM");
+    }
+
+    // Format day to always be displayed as 2 chars when only 1 char is used in localized pattern.
+    // Example: (fr-FR) dd/MM/y -> dd/MM/yyyy
+    if (formatHint.replaceAll("[^d]", "").length() == 1) {
+      formatHint = formatHint.replace("d", "dd");
+    }
+
     return formatHint.replace("d", dayChar).replace("M", monthChar).replace("y", yearChar);
   }
 

--- a/lib/java/com/google/android/material/datepicker/UtcDates.java
+++ b/lib/java/com/google/android/material/datepicker/UtcDates.java
@@ -152,41 +152,53 @@ class UtcDates {
         ((SimpleDateFormat) DateFormat.getDateInstance(DateFormat.SHORT, Locale.getDefault()))
             .toPattern()
             .replaceAll("\\s+", "");
+    pattern = patternToLongerFormat(pattern);
     SimpleDateFormat format = new SimpleDateFormat(pattern, Locale.getDefault());
     format.setTimeZone(UtcDates.getTimeZone());
     format.setLenient(false);
     return format;
   }
 
-  static String getTextInputHint(Resources res, SimpleDateFormat format) {
-    String formatHint = format.toPattern();
-    String yearChar = res.getString(R.string.mtrl_picker_text_input_year_abbr);
-    String monthChar = res.getString(R.string.mtrl_picker_text_input_month_abbr);
-    String dayChar = res.getString(R.string.mtrl_picker_text_input_day_abbr);
-
+  /**
+   * Returns a more readable pattern by returning a longer date format.
+   * Given an input of m/d/yy, this method will return mm/dd/yyyy
+   * Given an input of d/m/y, this method will return dd/mm/yyyy
+   * @param pattern a Java date pattern
+   * @return
+   */
+  private static String patternToLongerFormat(String pattern) {
     // Format year to always be displayed as 4 chars when only 1 char is used in localized pattern.
     // Example: (fr-FR) dd/MM/y -> dd/MM/yyyy
-    if (formatHint.replaceAll("[^y]", "").length() == 1) {
-      formatHint = formatHint.replace("y", "yyyy");
+    if (pattern.replaceAll("[^y]", "").length() == 1) {
+      pattern = pattern.replace("y", "yyyy");
     }
 
     // Format year to always be displayed as 4 chars when 2 chars are used in localized pattern.
     // Example: (fr-FR) dd/MM/y -> dd/MM/yyyy
-    if (formatHint.replaceAll("[^y]", "").length() == 2) {
-      formatHint = formatHint.replace("yy", "yyyy");
+    if (pattern.replaceAll("[^y]", "").length() == 2) {
+      pattern = pattern.replace("yy", "yyyy");
     }
 
     // Format month to always be displayed as 2 chars when only 1 char is used in localized pattern.
     // Example: (fr-FR) dd/MM/y -> dd/MM/yyyy
-    if (formatHint.replaceAll("[^M]", "").length() == 1) {
-      formatHint = formatHint.replace("M", "MM");
+    if (pattern.replaceAll("[^M]", "").length() == 1) {
+      pattern = pattern.replace("M", "MM");
     }
 
     // Format day to always be displayed as 2 chars when only 1 char is used in localized pattern.
     // Example: (fr-FR) dd/MM/y -> dd/MM/yyyy
-    if (formatHint.replaceAll("[^d]", "").length() == 1) {
-      formatHint = formatHint.replace("d", "dd");
+    if (pattern.replaceAll("[^d]", "").length() == 1) {
+      pattern = pattern.replace("d", "dd");
     }
+
+    return pattern;
+  }
+
+  static String getTextInputHint(Resources res, SimpleDateFormat format) {
+    String formatHint = patternToLongerFormat(format.toPattern());
+    String yearChar = res.getString(R.string.mtrl_picker_text_input_year_abbr);
+    String monthChar = res.getString(R.string.mtrl_picker_text_input_month_abbr);
+    String dayChar = res.getString(R.string.mtrl_picker_text_input_day_abbr);
 
     return formatHint.replace("d", dayChar).replace("M", monthChar).replace("y", yearChar);
   }

--- a/lib/javatests/com/google/android/material/datepicker/UtcDatesTest.java
+++ b/lib/javatests/com/google/android/material/datepicker/UtcDatesTest.java
@@ -47,7 +47,7 @@ public class UtcDatesTest {
     SimpleDateFormat sdf = new SimpleDateFormat("M/d/y");
     String hint = UtcDates.getTextInputHint(context.getResources(), sdf);
 
-    assertEquals("m/d/yyyy", hint);
+    assertEquals("mm/dd/yyyy", hint);
   }
 
   @Test
@@ -55,7 +55,7 @@ public class UtcDatesTest {
     SimpleDateFormat sdf = new SimpleDateFormat("M/d/yy");
     String hint = UtcDates.getTextInputHint(context.getResources(), sdf);
 
-    assertEquals("m/d/yy", hint);
+    assertEquals("mm/dd/yyyy", hint);
   }
 
   @Test
@@ -63,7 +63,7 @@ public class UtcDatesTest {
     SimpleDateFormat sdf = new SimpleDateFormat("M/d/yyyy");
     String hint = UtcDates.getTextInputHint(context.getResources(), sdf);
 
-    assertEquals("m/d/yyyy", hint);
+    assertEquals("mm/dd/yyyy", hint);
   }
 
   @Test
@@ -72,6 +72,6 @@ public class UtcDatesTest {
     SimpleDateFormat sdf = new SimpleDateFormat("M/d/y");
     String hint = UtcDates.getTextInputHint(context.getResources(), sdf);
 
-    assertEquals("m/j/aaaa", hint);
+    assertEquals("mm/jj/aaaa", hint);
   }
 }


### PR DESCRIPTION
Closes #3039

The hint now shows as:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/116726/197248412-753dd8ca-514c-4236-8f82-b174a62f3bfd.png">


Also, the error suggestion is adjusted accordingly
<img width="463" alt="image" src="https://user-images.githubusercontent.com/116726/197284405-0b56ae7f-d0c6-4a75-9dd7-3a71be4da905.png">


