### PR TITLE
[Internal] Deprecate public MathUtils

### DIFF
--- a/lib/java/com/google/android/material/circularreveal/CircularRevealHelper.java
+++ b/lib/java/com/google/android/material/circularreveal/CircularRevealHelper.java
@@ -15,7 +15,7 @@
  */
 package com.google.android.material.circularreveal;
 
-import static com.google.android.material.math.MathUtils.DEFAULT_EPSILON;
+import static com.google.android.material.internal.MathUtils.DEFAULT_EPSILON;
 
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
@@ -37,7 +37,7 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.material.circularreveal.CircularRevealWidget.RevealInfo;
-import com.google.android.material.math.MathUtils;
+import com.google.android.material.internal.MathUtils;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 

--- a/lib/java/com/google/android/material/circularreveal/CircularRevealWidget.java
+++ b/lib/java/com/google/android/material/circularreveal/CircularRevealWidget.java
@@ -25,7 +25,7 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.material.circularreveal.CircularRevealHelper.Delegate;
-import com.google.android.material.math.MathUtils;
+import com.google.android.material.internal.MathUtils;
 
 /**
  * Interface which denotes that a {@link View} supports a circular clip and scrim color, even for

--- a/lib/java/com/google/android/material/internal/MathUtils.java
+++ b/lib/java/com/google/android/material/internal/MathUtils.java
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.android.material.math;
+package com.google.android.material.internal;
+
+import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+
+import androidx.annotation.RestrictTo;
 
 /**
  * A class that contains utility methods related to numbers.
  *
- * @deprecated The public MathUtils class is deprecated and is maintained only for binary
- * compatibility. For internal purposes, {@link com.google.android.material.internal.MathUtils}
- * is used instead.
+ * @hide
  */
-@Deprecated
+@RestrictTo(LIBRARY_GROUP)
 public final class MathUtils {
 
   /** Default epsilon value for fuzzy float comparisons. */

--- a/lib/java/com/google/android/material/timepicker/ClockHandView.java
+++ b/lib/java/com/google/android/material/timepicker/ClockHandView.java
@@ -45,7 +45,7 @@ import androidx.annotation.Px;
 import androidx.core.view.ViewCompat;
 import com.google.android.material.animation.AnimationUtils;
 import com.google.android.material.internal.ViewUtils;
-import com.google.android.material.math.MathUtils;
+import com.google.android.material.internal.MathUtils;
 import com.google.android.material.motion.MotionUtils;
 import com.google.android.material.timepicker.RadialViewGroup.Level;
 import java.util.ArrayList;

--- a/lib/java/com/google/android/material/transformation/FabTransformationBehavior.java
+++ b/lib/java/com/google/android/material/transformation/FabTransformationBehavior.java
@@ -62,7 +62,7 @@ import com.google.android.material.circularreveal.CircularRevealWidget;
 import com.google.android.material.circularreveal.CircularRevealWidget.CircularRevealScrimColorProperty;
 import com.google.android.material.circularreveal.CircularRevealWidget.RevealInfo;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.android.material.math.MathUtils;
+import com.google.android.material.internal.MathUtils;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/lib/javatests/com/google/android/material/circularreveal/CircularRevealHelperTest.java
+++ b/lib/javatests/com/google/android/material/circularreveal/CircularRevealHelperTest.java
@@ -36,7 +36,7 @@ import android.view.View.MeasureSpec;
 import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
 import com.google.android.material.circularreveal.CircularRevealWidget.RevealInfo;
-import com.google.android.material.math.MathUtils;
+import com.google.android.material.internal.MathUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Utility methods for internal use should not be public (by analogy with [AnimationUtils](https://github.com/material-components/material-components-android/blob/ba70cd72d92501d556c3a4dbf01b1446217e4627/lib/java/com/google/android/material/animation/AnimationUtils.java), [ColorUtils](https://github.com/material-components/material-components-android/blob/ba70cd72d92501d556c3a4dbf01b1446217e4627/lib/java/com/google/android/material/color/utilities/ColorUtils.java), [ContextUtils](https://github.com/material-components/material-components-android/blob/ba70cd72d92501d556c3a4dbf01b1446217e4627/lib/java/com/google/android/material/internal/ContextUtils.java) and so on).
In order not to break binary compatibility, the public `MathUtils` class is preserved, but marked as `@Deprecated`.