### PR TITLE
[M3][SearchBar][SearchView] Corrected SearchBar & SearchView package path in documentation

### DIFF
--- a/docs/components/Search.md
+++ b/docs/components/Search.md
@@ -322,20 +322,20 @@ Putting it all together and using the scroll-away mode, the `SearchBar` and
   <com.google.android.material.appbar.AppBarLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content">
-    <com.google.android.libraries.material.search.SearchBar
+    <com.google.android.material.search.SearchBar
         android:id="@+id/search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/searchbar_hint" />
   </com.google.android.material.appbar.AppBarLayout>
 
-  <com.google.android.libraries.material.search.SearchView
+  <com.google.android.material.search.SearchView
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:hint="@string/searchbar_hint"
       app:layout_anchor="@id/search_bar">
     <!-- Search suggestions/results go here (ScrollView, RecyclerView, etc.). -->
-  </com.google.android.libraries.material.search.SearchView>
+  </com.google.android.material.search.SearchView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 ```
 


### PR DESCRIPTION
- [x] Link to GitHub issues it solves. `closes #3108 `
- [x] Sign the CLA bot. You can do this once the pull request is opened.

Search component [doc](https://github.com/material-components/material-components-android/blob/master/docs/components/Search.md) is using incorrect path for SearchBar and SearchView. Corrected the package path.
