### PR TITLE
[MaterialDatePicker] Adding an optional 'Clear' button

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11

--- a/lib/java/com/google/android/material/datepicker/DateSelector.java
+++ b/lib/java/com/google/android/material/datepicker/DateSelector.java
@@ -67,6 +67,11 @@ public interface DateSelector<S> extends Parcelable {
   void setSelection(@NonNull S selection);
 
   /**
+   * Clears the current selection.
+   */
+  void clearSelection();
+
+  /**
    * Allows this selection handler to respond to clicks within the {@link AdapterView}.
    *
    * @param selection The selected day represented as time in UTC milliseconds.

--- a/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
@@ -487,6 +487,19 @@ public final class MaterialCalendar<S> extends PickerFragment<S> {
     }
   }
 
+  public void clearSelection() {
+    if (dateSelector != null) {
+      // Clear the selection then call 'selection changed' listeners, if any
+      dateSelector.clearSelection();
+      for (OnSelectionChangedListener<S> listener : onSelectionChangedListeners) {
+        listener.onSelectionChanged(dateSelector.getSelection());
+      }
+
+      // Update the gridview
+      recyclerView.getAdapter().notifyDataSetChanged();
+    }
+  }
+
   void toggleVisibleSelector() {
     if (calendarSelector == CalendarSelector.YEAR) {
       setSelector(CalendarSelector.DAY);

--- a/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
@@ -39,6 +39,7 @@ import androidx.appcompat.widget.TooltipCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.Button;
@@ -99,10 +100,13 @@ public class MaterialDatePicker<S> extends DialogFragment {
   private static final String INPUT_MODE_KEY = "INPUT_MODE_KEY";
   private static final String CALENDAR_FRAGMENT_TAG = "CALENDAR_FRAGMENT_TAG";
   private static final String TEXT_INPUT_FRAGMENT_TAG = "TEXT_INPUT_FRAGMENT_TAG";
+  private static final String CLEARABLE_KEY = "CLEARABLE_KEY";
+  private static final String DISMISS_ON_CLEAR_KEY = "DISMISS_ON_CLEAR_KEY";
 
   static final Object CONFIRM_BUTTON_TAG = "CONFIRM_BUTTON_TAG";
   static final Object CANCEL_BUTTON_TAG = "CANCEL_BUTTON_TAG";
   static final Object TOGGLE_BUTTON_TAG = "TOGGLE_BUTTON_TAG";
+  static final Object CLEAR_BUTTON_TAG = "CLEAR_BUTTON_TAG";
 
   /** Date picker will start with calendar view. */
   public static final int INPUT_MODE_CALENDAR = 0;
@@ -143,6 +147,8 @@ public class MaterialDatePicker<S> extends DialogFragment {
       new LinkedHashSet<>();
   private final LinkedHashSet<DialogInterface.OnCancelListener> onCancelListeners =
       new LinkedHashSet<>();
+  private final LinkedHashSet<OnClickListener> onClearButtonClickListeners =
+          new LinkedHashSet<>();
   private final LinkedHashSet<DialogInterface.OnDismissListener> onDismissListeners =
       new LinkedHashSet<>();
 
@@ -169,6 +175,9 @@ public class MaterialDatePicker<S> extends DialogFragment {
   private CheckableImageButton headerToggleButton;
   @Nullable private MaterialShapeDrawable background;
   private Button confirmButton;
+  private Button clearButton;
+  private boolean isClearable;
+  private boolean dismissOnClear;
 
   private boolean edgeToEdgeEnabled;
   @Nullable private CharSequence fullTitleText;
@@ -199,6 +208,8 @@ public class MaterialDatePicker<S> extends DialogFragment {
         options.negativeButtonContentDescriptionResId);
     args.putCharSequence(
         NEGATIVE_BUTTON_CONTENT_DESCRIPTION_KEY, options.negativeButtonContentDescription);
+    args.putBoolean(CLEARABLE_KEY, options.isClearable);
+    args.putBoolean(DISMISS_ON_CLEAR_KEY, options.dismissOnClear);
     materialDatePickerDialogFragment.setArguments(args);
     return materialDatePickerDialogFragment;
   }
@@ -232,6 +243,8 @@ public class MaterialDatePicker<S> extends DialogFragment {
         NEGATIVE_BUTTON_CONTENT_DESCRIPTION_RES_ID_KEY, negativeButtonContentDescriptionResId);
     bundle.putCharSequence(
         NEGATIVE_BUTTON_CONTENT_DESCRIPTION_KEY, negativeButtonContentDescription);
+    bundle.putBoolean(CLEARABLE_KEY, isClearable);
+    bundle.putBoolean(DISMISS_ON_CLEAR_KEY, dismissOnClear);
   }
 
   @Override
@@ -261,6 +274,8 @@ public class MaterialDatePicker<S> extends DialogFragment {
     fullTitleText =
         titleText != null ? titleText : requireContext().getResources().getText(titleTextResId);
     singleLineTitleText = getFirstLineBySeparator(fullTitleText);
+    isClearable = activeBundle.getBoolean(CLEARABLE_KEY);
+    dismissOnClear = activeBundle.getBoolean(DISMISS_ON_CLEAR_KEY);
   }
 
   private int getThemeResId(Context context) {
@@ -331,11 +346,7 @@ public class MaterialDatePicker<S> extends DialogFragment {
     initHeaderToggle(context);
 
     confirmButton = root.findViewById(R.id.confirm_button);
-    if (getDateSelector().isSelectionComplete()) {
-      confirmButton.setEnabled(true);
-    } else {
-      confirmButton.setEnabled(false);
-    }
+    confirmButton.setEnabled(getDateSelector().isSelectionComplete());
     confirmButton.setTag(CONFIRM_BUTTON_TAG);
     if (positiveButtonText != null) {
       confirmButton.setText(positiveButtonText);
@@ -364,6 +375,35 @@ public class MaterialDatePicker<S> extends DialogFragment {
           getContext().getResources().getText(negativeButtonContentDescriptionResId));
     }
     cancelButton.setOnClickListener(this::onNegativeButtonClick);
+
+    clearButton = root.findViewById(R.id.clear_button);
+    clearButton.setTag(CLEAR_BUTTON_TAG);
+    if (isClearable) {
+      clearButton.setEnabled(getDateSelector().isSelectionComplete());
+      clearButton.setOnClickListener(
+              new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                  // Clear the selection
+                  calendar.clearSelection();
+
+                  // Call 'cleared' listeners, if any
+                  for (View.OnClickListener listener : onClearButtonClickListeners) {
+                    listener.onClick(v);
+                  }
+
+                  if (dismissOnClear) {
+                    dismiss();
+                  }
+                }
+              });
+
+      clearButton.setVisibility(View.VISIBLE);
+
+    } else {
+      clearButton.setVisibility(View.GONE);
+    }
+
     return root;
   }
 
@@ -531,12 +571,13 @@ public class MaterialDatePicker<S> extends DialogFragment {
           @Override
           public void onSelectionChanged(S selection) {
             updateHeader(getHeaderText());
-            confirmButton.setEnabled(getDateSelector().isSelectionComplete());
+            updateActionButtonEnabledState();
           }
 
           @Override
           public void onIncompleteSelectionChanged() {
             confirmButton.setEnabled(false);
+            clearButton.setEnabled(false);
           }
         });
 
@@ -562,7 +603,7 @@ public class MaterialDatePicker<S> extends DialogFragment {
     headerToggleButton.setOnClickListener(
         v -> {
           // Update confirm button in case in progress selection has been reset
-          confirmButton.setEnabled(getDateSelector().isSelectionComplete());
+          updateActionButtonEnabledState();
 
           headerToggleButton.toggle();
           inputMode = (inputMode == INPUT_MODE_TEXT) ? INPUT_MODE_CALENDAR : INPUT_MODE_TEXT;
@@ -570,6 +611,11 @@ public class MaterialDatePicker<S> extends DialogFragment {
           updateToggleTooltip(headerToggleButton);
           startPickerFragment();
         });
+  }
+
+  private void updateActionButtonEnabledState() {
+    confirmButton.setEnabled(getDateSelector().isSelectionComplete());
+    clearButton.setEnabled(isClearable && getDateSelector().isSelectionComplete());
   }
 
   private void updateToggleContentDescription(@NonNull CheckableImageButton toggle) {
@@ -696,6 +742,27 @@ public class MaterialDatePicker<S> extends DialogFragment {
     onNegativeButtonClickListeners.clear();
   }
 
+  /** The supplied listener is called when the user clicks the clear button. */
+  public boolean addOnClearButtonClickListener(
+      @NonNull OnClickListener onClearButtonClickListener) {
+    return onClearButtonClickListeners.add(onClearButtonClickListener);
+  }
+
+  /**
+   * Removes a listener previously added via {@link MaterialDatePicker#addOnClearButtonClickListener}.
+   */
+  public boolean removeOnClearButtonClickListener(
+      @NonNull OnClickListener onClearButtonClickListener) {
+    return onClearButtonClickListeners.remove(onClearButtonClickListener);
+  }
+
+  /**
+   * Removes all listeners added via {@link MaterialDatePicker#addOnClearButtonClickListener}.
+   */
+  public void clearOnClearButtonClickListeners() {
+    onClearButtonClickListeners.clear();
+  }
+
   /**
    * The supplied listener is called when the user cancels the picker via back button or a touch
    * outside the view. It is not called when the user clicks the cancel button. To add a listener
@@ -754,6 +821,8 @@ public class MaterialDatePicker<S> extends DialogFragment {
     CharSequence negativeButtonContentDescription = null;
     @Nullable S selection = null;
     @InputMode int inputMode = INPUT_MODE_CALENDAR;
+    boolean isClearable = false;
+    boolean dismissOnClear = false;
 
     private Builder(DateSelector<S> dateSelector) {
       this.dateSelector = dateSelector;
@@ -972,6 +1041,20 @@ public class MaterialDatePicker<S> extends DialogFragment {
     @CanIgnoreReturnValue
     public Builder<S> setInputMode(@InputMode int inputMode) {
       this.inputMode = inputMode;
+      return this;
+    }
+
+    /** Sets the state of the clear button */
+    @NonNull
+    public Builder<S> setClearable(boolean clearable) {
+      this.isClearable = clearable;
+      return this;
+    }
+
+    /** Sets the state of the dialog dismiss state when clear button is clicked */
+    @NonNull
+    public Builder<S> setDismissOnClear(boolean dismiss) {
+      this.dismissOnClear = dismiss;
       return this;
     }
 

--- a/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
@@ -175,6 +175,7 @@ public class MaterialDatePicker<S> extends DialogFragment {
   private CheckableImageButton headerToggleButton;
   @Nullable private MaterialShapeDrawable background;
   private Button confirmButton;
+  private Button headerConfirmButton;
   private Button clearButton;
   private boolean isClearable;
   private boolean dismissOnClear;
@@ -375,6 +376,47 @@ public class MaterialDatePicker<S> extends DialogFragment {
           getContext().getResources().getText(negativeButtonContentDescriptionResId));
     }
     cancelButton.setOnClickListener(this::onNegativeButtonClick);
+
+    // In fullscreen mode we have a confirm and cancel button in the header as well
+    if (fullscreen) {
+      headerConfirmButton = root.findViewById(R.id.header_confirm_button);
+      headerConfirmButton.setEnabled(getDateSelector().isSelectionComplete());
+      headerConfirmButton.setTag(CONFIRM_BUTTON_TAG);
+      if (positiveButtonText != null) {
+        headerConfirmButton.setText(positiveButtonText);
+      } else if (positiveButtonTextResId != 0) {
+        headerConfirmButton.setText(positiveButtonTextResId);
+      }
+      headerConfirmButton.setOnClickListener(
+          new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+              for (MaterialPickerOnPositiveButtonClickListener<? super S> listener :
+                  onPositiveButtonClickListeners) {
+                listener.onPositiveButtonClick(getSelection());
+              }
+              dismiss();
+            }
+          });
+
+      Button headerCancelButton = root.findViewById(R.id.header_cancel_button);
+      headerCancelButton.setTag(CANCEL_BUTTON_TAG);
+      if (negativeButtonText != null) {
+        headerCancelButton.setText(negativeButtonText);
+      } else if (negativeButtonTextResId != 0) {
+        headerCancelButton.setText(negativeButtonTextResId);
+      }
+      headerCancelButton.setOnClickListener(
+          new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+              for (View.OnClickListener listener : onNegativeButtonClickListeners) {
+                listener.onClick(v);
+              }
+              dismiss();
+            }
+          });
+    }
 
     clearButton = root.findViewById(R.id.clear_button);
     clearButton.setTag(CLEAR_BUTTON_TAG);
@@ -577,6 +619,7 @@ public class MaterialDatePicker<S> extends DialogFragment {
           @Override
           public void onIncompleteSelectionChanged() {
             confirmButton.setEnabled(false);
+            if (fullscreen) headerConfirmButton.setEnabled(false);
             clearButton.setEnabled(false);
           }
         });
@@ -615,6 +658,7 @@ public class MaterialDatePicker<S> extends DialogFragment {
 
   private void updateActionButtonEnabledState() {
     confirmButton.setEnabled(getDateSelector().isSelectionComplete());
+    if (fullscreen) headerConfirmButton.setEnabled(getDateSelector().isSelectionComplete());
     clearButton.setEnabled(isClearable && getDateSelector().isSelectionComplete());
   }
 

--- a/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialDatePicker.java
@@ -647,6 +647,9 @@ public class MaterialDatePicker<S> extends DialogFragment {
         v -> {
           // Update confirm button in case in progress selection has been reset
           updateActionButtonEnabledState();
+          v -> {
+            // Update confirm button in case in progress selection has been reset
+            updateActionButtonEnabledState();
 
           headerToggleButton.toggle();
           inputMode = (inputMode == INPUT_MODE_TEXT) ? INPUT_MODE_CALENDAR : INPUT_MODE_TEXT;

--- a/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
+++ b/lib/java/com/google/android/material/datepicker/RangeDateSelector.java
@@ -84,6 +84,12 @@ public class RangeDateSelector implements DateSelector<Pair<Long, Long>> {
   }
 
   @Override
+  public void clearSelection() {
+    selectedStartItem = null;
+    selectedEndItem = null;
+  }
+
+  @Override
   public void setSelection(@NonNull Pair<Long, Long> selection) {
     if (selection.first != null && selection.second != null) {
       Preconditions.checkArgument(isValidRange(selection.first, selection.second));

--- a/lib/java/com/google/android/material/datepicker/SingleDateSelector.java
+++ b/lib/java/com/google/android/material/datepicker/SingleDateSelector.java
@@ -58,7 +58,8 @@ public class SingleDateSelector implements DateSelector<Long> {
     selectedItem = selection;
   }
 
-  private void clearSelection() {
+  @Override
+  public void clearSelection() {
     selectedItem = null;
   }
 

--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_actions.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_actions.xml
@@ -25,6 +25,20 @@
   android:orientation="horizontal">
 
   <Button
+    android:id="@+id/clear_button"
+    style="?attr/buttonBarNeutralButtonStyle"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:text="@string/mtrl_picker_clear"/>
+
+  <Space
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:visibility="invisible" />
+
+  <Button
     android:id="@+id/cancel_button"
     style="?attr/buttonBarNegativeButtonStyle"
     android:layout_width="wrap_content"

--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_actions_fullscreen.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_actions_fullscreen.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2019 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/date_picker_actions"
+  android:layout_width="match_parent"
+  android:layout_height="@dimen/mtrl_calendar_action_height_fullscreen"
+  android:paddingStart="@dimen/mtrl_calendar_action_padding_fullscreen"
+  android:paddingLeft="@dimen/mtrl_calendar_action_padding_fullscreen"
+  android:paddingEnd="@dimen/mtrl_calendar_action_padding_fullscreen"
+  android:paddingRight="@dimen/mtrl_calendar_action_padding_fullscreen"
+  android:gravity="end"
+  android:orientation="horizontal">
+
+  <Button
+    android:id="@+id/clear_button"
+    style="?attr/buttonBarNeutralButtonStyle"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:text="@string/mtrl_picker_clear"/>
+
+  <Space
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:visibility="invisible" />
+
+  <Button
+    android:id="@+id/cancel_button"
+    style="?attr/buttonBarNegativeButtonStyle"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:text="@string/mtrl_picker_cancel"/>
+
+  <Button
+    android:id="@+id/confirm_button"
+    style="?attr/buttonBarPositiveButtonStyle"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:minWidth="@dimen/mtrl_calendar_action_confirm_button_min_width"
+    android:text="@string/mtrl_picker_confirm"/>
+
+</LinearLayout>

--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_fullscreen.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_fullscreen.xml
@@ -24,13 +24,35 @@
 
   <include layout="@layout/mtrl_picker_header_fullscreen"/>
 
-  <androidx.fragment.app.FragmentContainerView
+  <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="0dp"
+    android:layout_weight="1"
+    android:paddingStart="@dimen/mtrl_calendar_content_padding"
+    android:paddingEnd="@dimen/mtrl_calendar_content_padding"
+    android:paddingLeft="@dimen/mtrl_calendar_content_padding"
+    android:paddingRight="@dimen/mtrl_calendar_content_padding"
+    android:orientation="vertical"
+    android:gravity="center_horizontal">
+
+    <androidx.fragment.app.FragmentContainerView
       android:id="@+id/mtrl_calendar_frame"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:paddingStart="@dimen/mtrl_calendar_content_padding"
-      android:paddingEnd="@dimen/mtrl_calendar_content_padding"
-      android:paddingLeft="@dimen/mtrl_calendar_content_padding"
-      android:paddingRight="@dimen/mtrl_calendar_content_padding"/>
+      android:layout_height="wrap_content" />
+  </LinearLayout>
+
+  <View
+    style="?attr/materialCalendarHeaderDivider"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/mtrl_calendar_header_divider_thickness"
+    android:paddingTop="@dimen/mtrl_calendar_navigation_top_padding"
+    android:paddingBottom="@dimen/mtrl_calendar_navigation_bottom_padding"
+    android:layout_gravity="center_vertical"/>
+
+  <include
+    layout="@layout/mtrl_picker_actions_fullscreen"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/mtrl_calendar_action_height_fullscreen"
+    android:layout_marginBottom="@dimen/mtrl_calendar_action_padding_fullscreen"/>
 
 </LinearLayout>

--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_fullscreen.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_fullscreen.xml
@@ -76,6 +76,16 @@
         android:gravity="start|bottom"
         app:firstBaselineToTopHeight="@dimen/mtrl_calendar_selection_baseline_to_top_fullscreen"
         app:lineHeight="@dimen/mtrl_calendar_header_selection_line_height"/>
+
+      <Button
+        android:id="@+id/clear_button"
+        style="?attr/materialCalendarHeaderConfirmButton"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/mtrl_min_touch_target_size"
+        android:layout_gravity="end|top"
+        android:contentDescription="@string/mtrl_picker_clear"
+        android:text="@string/mtrl_picker_clear"/>
+
     </FrameLayout>
 
     <LinearLayout

--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_fullscreen.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_fullscreen.xml
@@ -30,12 +30,12 @@
     android:paddingStart="@dimen/mtrl_calendar_header_content_padding_fullscreen"
     android:paddingLeft="@dimen/mtrl_calendar_header_content_padding_fullscreen"
     android:paddingTop="@dimen/mtrl_calendar_header_content_padding_fullscreen"
-    android:paddingEnd="@dimen/mtrl_calendar_header_content_padding_fullscreen"
-    android:paddingRight="@dimen/mtrl_calendar_header_content_padding_fullscreen"
+    android:paddingEnd="@dimen/mtrl_calendar_content_padding_fullscreen_right"
+    android:paddingRight="@dimen/mtrl_calendar_content_padding_fullscreen_right"
     tools:ignore="Overdraw">
 
     <com.google.android.material.button.MaterialButton
-      android:id="@+id/cancel_button"
+      android:id="@+id/header_cancel_button"
       style="?attr/materialCalendarHeaderCancelButton"
       android:layout_width="@dimen/mtrl_min_touch_target_size"
       android:layout_height="@dimen/mtrl_min_touch_target_size"
@@ -77,15 +77,6 @@
         app:firstBaselineToTopHeight="@dimen/mtrl_calendar_selection_baseline_to_top_fullscreen"
         app:lineHeight="@dimen/mtrl_calendar_header_selection_line_height"/>
 
-      <Button
-        android:id="@+id/clear_button"
-        style="?attr/materialCalendarHeaderConfirmButton"
-        android:layout_width="wrap_content"
-        android:layout_height="@dimen/mtrl_min_touch_target_size"
-        android:layout_gravity="end|top"
-        android:contentDescription="@string/mtrl_picker_clear"
-        android:text="@string/mtrl_picker_clear"/>
-
     </FrameLayout>
 
     <LinearLayout
@@ -94,10 +85,10 @@
       android:orientation="@integer/mtrl_calendar_header_orientation">
 
       <com.google.android.material.button.MaterialButton
-        android:id="@+id/confirm_button"
+        android:id="@+id/header_confirm_button"
         style="?attr/materialCalendarHeaderConfirmButton"
         android:layout_width="wrap_content"
-        android:layout_height="@dimen/mtrl_min_touch_target_size"
+        android:layout_height="@dimen/mtrl_calendar_action_height_fullscreen"
         android:layout_gravity="end|top"
         android:contentDescription="@string/mtrl_picker_save"
         android:text="@string/mtrl_picker_save"/>

--- a/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_fullscreen.xml
+++ b/lib/java/com/google/android/material/datepicker/res/layout/mtrl_picker_header_fullscreen.xml
@@ -77,6 +77,15 @@
         app:firstBaselineToTopHeight="@dimen/mtrl_calendar_selection_baseline_to_top_fullscreen"
         app:lineHeight="@dimen/mtrl_calendar_header_selection_line_height"/>
 
+      <Button
+        android:id="@+id/clear_button"
+        style="?attr/materialCalendarHeaderConfirmButton"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/mtrl_min_touch_target_size"
+        android:layout_gravity="end|top"
+        android:contentDescription="@string/mtrl_picker_clear"
+        android:text="@string/mtrl_picker_clear"/>
+
     </FrameLayout>
 
     <LinearLayout

--- a/lib/java/com/google/android/material/datepicker/res/values/dimens.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values/dimens.xml
@@ -25,12 +25,15 @@
   <dimen name="mtrl_calendar_header_text_padding">12dp</dimen>
   <dimen name="mtrl_calendar_day_today_stroke">1dp</dimen>
   <dimen name="mtrl_calendar_content_padding">12dp</dimen>
+  <dimen name="mtrl_calendar_content_padding_fullscreen_right">12dp</dimen>
   <dimen name="mtrl_calendar_navigation_height">48dp</dimen>
   <dimen name="mtrl_calendar_navigation_top_padding">4dp</dimen>
   <dimen name="mtrl_calendar_navigation_bottom_padding">4dp</dimen>
   <dimen name="mtrl_calendar_month_vertical_padding">0dp</dimen>
   <dimen name="mtrl_calendar_action_height">52dp</dimen>
+  <dimen name="mtrl_calendar_action_height_fullscreen">40dp</dimen>
   <dimen name="mtrl_calendar_action_padding">8dp</dimen>
+  <dimen name="mtrl_calendar_action_padding_fullscreen">12dp</dimen>
   <dimen name="mtrl_calendar_action_confirm_button_min_width">64dp</dimen>
   <dimen name="mtrl_calendar_header_content_padding_fullscreen">4dp</dimen>
   <dimen name="mtrl_calendar_header_selection_line_height">32dp</dimen>

--- a/lib/java/com/google/android/material/datepicker/res/values/strings.xml
+++ b/lib/java/com/google/android/material/datepicker/res/values/strings.xml
@@ -25,6 +25,7 @@
   <string name="mtrl_picker_date_header_selected" description="A single date [CHAR_LIMIT=60]">%1$s</string>
   <string name="mtrl_picker_confirm" description="Button text to indicate that the widget will save the user's selection [CHAR_LIMIT=16]">OK</string>
   <string name="mtrl_picker_cancel" description="Button text to indicate that the widget will ignore the user's selection [CHAR_LIMIT=16]">Cancel</string>
+  <string name="mtrl_picker_clear" description="Button text to indicate that the user can clear the current selection [CHAR_LIMIT=16]">Clear</string>
   <string name="mtrl_picker_text_input_date_hint" description="Label for a single date selected by the user [CHAR_LIMIT=60]">Date</string>
   <string name="mtrl_picker_text_input_date_range_start_hint" description="Label for the start date in a range selected by the user [CHAR_LIMIT=60]">Start date</string>
   <string name="mtrl_picker_text_input_date_range_end_hint" description="Label for the end date in a range selected by the user [CHAR_LIMIT=60]">End date</string>


### PR DESCRIPTION
This change adds an optional 'Clear' button that can be used to remove the selected date with the option to calling a clear listener and dismissing the dialog when clicked.

closes #1332 

Note: This is the same code as previously submitted as a pull request but it has been rebased against the latest codebase as of 18 December 2022
