### PR TITLE
[Badge] Fix badge issues

### DIFF
--- a/docs/components/BadgeDrawable.md
+++ b/docs/components/BadgeDrawable.md
@@ -91,12 +91,12 @@ center, use `setHorizontalOffset(int)` or `setVerticalOffset(int)`
 ### `BadgeDrawable` Attributes
 
 | Feature               | Relevant attributes                                                                                                                                      |
-|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Color                 | `app:backgroundColor` <br> `app:badgeTextColor`                                                                                                                                     |
-| Width                 | `app:badgeWidth` <br> `app:badgeWithTextWidth`                                                                                                                                 |
-| Height                | `app:badgeHeight` <br> `app:badgeWithTextHeight`                                                                                                                                |
-| Shape                 | `app:badgeShapeAppearance` <br> `app:badgeShapeAppearanceOverlay` <br> `app:badgeWithTextShapeAppearance` <br> `app:badgeWithTextShapeAppearanceOverlay`                                                                                                                |
-| Label                 | `app:badgeText` (for text) <br> `app:number` (for numbers)                                                                                                                                                 |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Color                 | `app:backgroundColor` <br> `app:badgeTextColor`                                                                                                          |
+| Width                 | `app:badgeWidth` <br> `app:badgeWithTextWidth`                                                                                                           |
+| Height                | `app:badgeHeight` <br> `app:badgeWithTextHeight`                                                                                                         |
+| Shape                 | `app:badgeShapeAppearance` <br> `app:badgeShapeAppearanceOverlay` <br> `app:badgeWithTextShapeAppearance` <br> `app:badgeWithTextShapeAppearanceOverlay` |
+| Label                 | `app:badgeText` (for text) <br> `app:number` (for numbers)                                                                                               |
 | Label Length          | `app:maxCharacterCount`                                                                                                                                  |
 | Label Text Color      | `app:badgeTextColor`                                                                                                                                     |
 | Label Text Appearance | `app:badgeTextAppearance`                                                                                                                                |

--- a/lib/java/com/google/android/material/badge/BadgeState.java
+++ b/lib/java/com/google/android/material/badge/BadgeState.java
@@ -149,8 +149,7 @@ public final class BadgeState {
       currentState.text = a.getString(R.styleable.Badge_badgeText);
     }
 
-    currentState.contentDescriptionForText = storedState.contentDescriptionForText == null
-        ? currentState.text : storedState.contentDescriptionForText;
+    currentState.contentDescriptionForText = storedState.contentDescriptionForText;
 
     currentState.contentDescriptionNumberless =
         storedState.contentDescriptionNumberless == null

--- a/lib/java/com/google/android/material/badge/res/values/strings.xml
+++ b/lib/java/com/google/android/material/badge/res/values/strings.xml
@@ -16,6 +16,7 @@
   -->
 <resources xmlns:tools="http://schemas.android.com/tools"
   xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+  <string name="mtrl_exceed_max_badge_text_suffix" translatable="false"><xliff:g example="Some te" id="part of a long text">%1$s</xliff:g><xliff:g example="…" id="suffix">%2$s</xliff:g></string>
   <string name="mtrl_exceed_max_badge_number_suffix" translatable="false"><xliff:g example="999" id="maximum number">%1$d</xliff:g><xliff:g example="+" id="suffix">%2$s</xliff:g></string>
   <string name="mtrl_exceed_max_badge_number_content_description" tools:ignore="PluralsCandidate"
           description="Plural form content description for when the number of new notifications exceeds a maximum count[CHAR_LIMIT=NONE]">More than <xliff:g example="999" id="maximum number">%1$d</xliff:g> new notifications</string>


### PR DESCRIPTION
This PR contains changes that are part of [another PR](https://github.com/material-components/material-components-android/pull/2978), but were lost when merged into the main branch.

**Changes:**
- Don't redraw the badge unless its content has changed.
- Don't ignore `maxCharacterCount` if the badge text is set.
- Don't distort `contentDescriptionForText` state when copying.
- `BadgeDrawable#clearNumber()` should clear the number from the state, even if the drawable also contains text.
- The badge should frame any text, even single-digit numbers.
- Fix badge shape update when only text is set.
- Fix inaccurate comments.
- Fix table formatting in BadgeDrawable.md.