### PR TITLE
[Internal] Guard against NPE in ManufacturerUtils

### DIFF
--- a/lib/java/com/google/android/material/internal/ManufacturerUtils.java
+++ b/lib/java/com/google/android/material/internal/ManufacturerUtils.java
@@ -15,35 +15,45 @@
  */
 package com.google.android.material.internal;
 
-import com.google.android.material.R;
-
 import android.os.Build;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
+
 import java.util.Locale;
 
-/** Utils to determine device manufacturers for special handling. */
+/**
+ * Utils to determine device manufacturers for special handling.
+ */
 @RestrictTo(Scope.LIBRARY_GROUP)
 public class ManufacturerUtils {
   private static final String LGE = "lge";
   private static final String SAMSUNG = "samsung";
   private static final String MEIZU = "meizu";
 
-  private ManufacturerUtils() {}
+  private ManufacturerUtils() {
+  }
 
-  /** Returns true if the device manufacturer is Meizu. */
+  /**
+   * Returns true if the device manufacturer is Meizu.
+   */
   public static boolean isMeizuDevice() {
-    return Build.MANUFACTURER.toLowerCase(Locale.ENGLISH).equals(MEIZU);
+    return getManufacturer().equals(MEIZU);
   }
 
-  /** Returns true if the device manufacturer is LG. */
+  /**
+   * Returns true if the device manufacturer is LG.
+   */
   public static boolean isLGEDevice() {
-    return Build.MANUFACTURER.toLowerCase(Locale.ENGLISH).equals(LGE);
+    return getManufacturer().equals(LGE);
   }
 
-  /** Returns true if the device manufacturer is Samsung. */
+  /**
+   * Returns true if the device manufacturer is Samsung.
+   */
   public static boolean isSamsungDevice() {
-    return Build.MANUFACTURER.toLowerCase(Locale.ENGLISH).equals(SAMSUNG);
+    return getManufacturer().equals(SAMSUNG);
   }
 
   /**
@@ -51,5 +61,15 @@ public class ManufacturerUtils {
    */
   public static boolean isDateInputKeyboardMissingSeparatorCharacters() {
     return isLGEDevice() || isSamsungDevice();
+  }
+
+  @NonNull
+  private static String getManufacturer() {
+    final String manufacturer = Build.MANUFACTURER;
+    if (manufacturer != null) {
+      return manufacturer.toLowerCase(Locale.ENGLISH);
+    } else {
+      return "";
+    }
   }
 }

--- a/lib/javatests/com/google/android/material/internal/ManufacturerUtilsTest.java
+++ b/lib/javatests/com/google/android/material/internal/ManufacturerUtilsTest.java
@@ -1,0 +1,22 @@
+package com.google.android.material.internal;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ManufacturerUtilsTest {
+
+  @Test
+  public void testIsMeizuDevice_shouldNotThrowNullPointerException() {
+    Assert.assertFalse(ManufacturerUtils.isMeizuDevice());
+  }
+
+  @Test
+  public void testIsLgeDevice_shouldNotThrowNullPointerException() {
+    Assert.assertFalse(ManufacturerUtils.isLGEDevice());
+  }
+
+  @Test
+  public void testIsSamsungDevice_shouldNotThrowNullPointerException() {
+    Assert.assertFalse(ManufacturerUtils.isSamsungDevice());
+  }
+}


### PR DESCRIPTION
In non-Robolectric JVM tests, `Build.MANUFACTURER` is null.

To guard against a potential NPE, return empty string instead of null.

Fixes https://github.com/cashapp/paparazzi/issues/380
### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
