### PR TITLE
[MaterialSwitch] Amendments to thumb icon size support

### DIFF
--- a/docs/components/Switch.md
+++ b/docs/components/Switch.md
@@ -154,15 +154,11 @@ You can add an optional icon to enhance the on/off indication of your custom
 switch by assigning `app:thumbIcon`. This icon will be centered and displayed on
 top of the thumb drawable.
 
-Element    | Attribute             | Related method(s)                                 | Default value
----------- |-----------------------|---------------------------------------------------| -------------
-**Icon**   | `app:thumbIcon`       | `setThumbIconDrawable`<br/>`getThumbIconDrawable` | `null`
-**Width**  | `app:thumbIconWidth`  | `setThumbIconWidth`<br/>`getThumbIconWidth`       | Intrinsic width
-**Height** | `app:thumbIconHeight` | `setThumbIconHeight`<br/>`getThumbIconHeight`     | Intrinsic height
-**Color**  | `app:thumbIconTint`   | `setThumbIconTintList`<br/>`getThumbIconTintList` | `?attr/colorSurfaceVariant` (unchecked)<br/>`?attr/colorOnPrimaryContainer` (checked)
-
-**Note:** Custom thumb icon width/height is supported only for API 23 and above.
-For API < 23, the intrinsic size of the thumb icon will always be used.
+Element   | Attribute           | Related method(s)                                 | Default value
+--------- |---------------------|---------------------------------------------------| -------------
+**Icon**  | `app:thumbIcon`     | `setThumbIconDrawable`<br/>`getThumbIconDrawable` | `null`
+**Size**  | `app:thumbIconSize` | `setThumbIconSize`<br/>`getThumbIconSize`         | `16dp`
+**Color** | `app:thumbIconTint` | `setThumbIconTintList`<br/>`getThumbIconTintList` | `?attr/colorSurfaceVariant` (unchecked)<br/>`?attr/colorOnPrimaryContainer` (checked)
 
 ### Track attributes
 

--- a/lib/java/com/google/android/material/drawable/DrawableUtils.java
+++ b/lib/java/com/google/android/material/drawable/DrawableUtils.java
@@ -42,7 +42,6 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
 import androidx.annotation.XmlRes;
@@ -64,7 +63,7 @@ public final class DrawableUtils {
 
   /**
    * Indicates to use the intrinsic size of the {@link Drawable}.
-   * 
+   *
    * <p>Used in {@link #compositeTwoLayeredDrawable(Drawable, Drawable, int, int)}.
    */
   public static final int INTRINSIC_SIZE = -1;
@@ -211,7 +210,7 @@ public final class DrawableUtils {
   /**
    * Composites two drawables, returning a drawable instance of {@link LayerDrawable},
    * with the top layer centered.
-   * 
+   *
    * <p>If any of the drawables is null, this method will return the other.
    *
    * @param bottomLayerDrawable the drawable to be on the bottom layer
@@ -221,27 +220,8 @@ public final class DrawableUtils {
   public static Drawable compositeTwoLayeredDrawable(
       @Nullable Drawable bottomLayerDrawable,
       @Nullable Drawable topLayerDrawable) {
-    if (VERSION.SDK_INT >= VERSION_CODES.M) {
-      return compositeTwoLayeredDrawable(
-          bottomLayerDrawable, topLayerDrawable, INTRINSIC_SIZE, INTRINSIC_SIZE);
-    }
-
-    if (bottomLayerDrawable == null) {
-      return topLayerDrawable;
-    }
-    if (topLayerDrawable == null) {
-      return bottomLayerDrawable;
-    }
-    LayerDrawable drawable =
-        new LayerDrawable(new Drawable[] {bottomLayerDrawable, topLayerDrawable});
-    int horizontalInset =
-        max(bottomLayerDrawable.getIntrinsicWidth()
-            - getTopLayerIntrinsicWidth(bottomLayerDrawable, topLayerDrawable), 0) / 2;
-    int verticalInset =
-        max(bottomLayerDrawable.getIntrinsicHeight()
-            - getTopLayerIntrinsicHeight(bottomLayerDrawable, topLayerDrawable), 0) / 2;
-    drawable.setLayerInset(1, horizontalInset, verticalInset, horizontalInset, verticalInset);
-    return drawable;
+    return compositeTwoLayeredDrawable(
+        bottomLayerDrawable, topLayerDrawable, INTRINSIC_SIZE, INTRINSIC_SIZE);
   }
 
   /**
@@ -249,7 +229,7 @@ public final class DrawableUtils {
    * with the top layer centered to the bottom layer. The top layer will be scaled according to the
    * provided desired width/height and the size of the bottom layer so the top layer can fit in the
    * bottom layer and preserve its desired aspect ratio.
-   * 
+   *
    * <p>If any of the drawables is null, this method will return the other.
    *
    * @param bottomLayerDrawable the drawable to be on the bottom layer
@@ -259,7 +239,6 @@ public final class DrawableUtils {
    * @param topLayerDesiredHeight top layer desired height in pixels, or {@link #INTRINSIC_SIZE} to
    *     use the intrinsic height.
    */
-  @RequiresApi(VERSION_CODES.M)
   @Nullable
   public static Drawable compositeTwoLayeredDrawable(
       @Nullable Drawable bottomLayerDrawable,
@@ -272,8 +251,6 @@ public final class DrawableUtils {
     if (topLayerDrawable == null) {
       return bottomLayerDrawable;
     }
-    LayerDrawable drawable =
-        new LayerDrawable(new Drawable[] {bottomLayerDrawable, topLayerDrawable});
 
     if (topLayerDesiredWidth == INTRINSIC_SIZE) {
       topLayerDesiredWidth = getTopLayerIntrinsicWidth(bottomLayerDrawable, topLayerDrawable);
@@ -308,23 +285,40 @@ public final class DrawableUtils {
       }
     }
 
-    drawable.setLayerSize(1, topLayerNewWidth, topLayerNewHeight);
-    drawable.setLayerGravity(1, Gravity.CENTER);
+    LayerDrawable drawable;
+    if (VERSION.SDK_INT >= VERSION_CODES.M) {
+      drawable = new LayerDrawable(new Drawable[] {bottomLayerDrawable, topLayerDrawable});
+
+      drawable.setLayerSize(1, topLayerNewWidth, topLayerNewHeight);
+      drawable.setLayerGravity(1, Gravity.CENTER);
+    } else {
+      Drawable scaledTopLayerDrawable =
+          new ScaledDrawableWrapper(topLayerDrawable, topLayerNewWidth, topLayerNewHeight);
+
+      drawable = new LayerDrawable(new Drawable[] {bottomLayerDrawable, scaledTopLayerDrawable});
+
+      final int horizontalInset =
+          max((bottomLayerDrawable.getIntrinsicWidth() - topLayerNewWidth) / 2, 0);
+      final int verticalInset =
+          max((bottomLayerDrawable.getIntrinsicHeight() - topLayerNewHeight) / 2, 0);
+      drawable.setLayerInset(1, horizontalInset, verticalInset, horizontalInset, verticalInset);
+    }
+
     return drawable;
   }
 
   private static int getTopLayerIntrinsicWidth(
       @NonNull Drawable bottomLayerDrawable, @NonNull Drawable topLayerDrawable) {
     int topLayerIntrinsicWidth = topLayerDrawable.getIntrinsicWidth();
-    return topLayerIntrinsicWidth == UNSPECIFIED_WIDTH
-        ? bottomLayerDrawable.getIntrinsicWidth() : topLayerIntrinsicWidth;
+    return topLayerIntrinsicWidth != UNSPECIFIED_WIDTH
+        ? topLayerIntrinsicWidth : bottomLayerDrawable.getIntrinsicWidth();
   }
 
   private static int getTopLayerIntrinsicHeight(
       @NonNull Drawable bottomLayerDrawable, @NonNull Drawable topLayerDrawable) {
     int topLayerIntrinsicHeight = topLayerDrawable.getIntrinsicHeight();
-    return topLayerIntrinsicHeight == UNSPECIFIED_HEIGHT
-        ? bottomLayerDrawable.getIntrinsicHeight() : topLayerIntrinsicHeight;
+    return topLayerIntrinsicHeight != UNSPECIFIED_HEIGHT
+        ? topLayerIntrinsicHeight : bottomLayerDrawable.getIntrinsicHeight();
   }
 
   /** Returns a new state that adds the checked state to the input state. */

--- a/lib/java/com/google/android/material/drawable/ScaledDrawableWrapper.java
+++ b/lib/java/com/google/android/material/drawable/ScaledDrawableWrapper.java
@@ -1,0 +1,31 @@
+package com.google.android.material.drawable;
+
+import android.graphics.drawable.Drawable;
+
+import androidx.appcompat.graphics.drawable.DrawableWrapperCompat;
+
+/**
+ * An extension of {@link DrawableWrapperCompat} that will take a given Drawable and scale it by
+ * the specified width and height.
+ */
+public class ScaledDrawableWrapper extends DrawableWrapperCompat {
+  private final int width;
+  private final int height;
+
+  public ScaledDrawableWrapper(Drawable drawable, int width, int height) {
+    super(drawable);
+    this.width = width;
+    this.height = height;
+  }
+
+  @Override
+  public int getIntrinsicWidth() {
+    return width;
+  }
+
+  @Override
+  public int getIntrinsicHeight() {
+    return height;
+  }
+}
+

--- a/lib/java/com/google/android/material/materialswitch/MaterialSwitch.java
+++ b/lib/java/com/google/android/material/materialswitch/MaterialSwitch.java
@@ -27,8 +27,6 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuff.Mode;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.TintTypedArray;
@@ -37,7 +35,6 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
-import androidx.annotation.RequiresApi;
 import androidx.core.graphics.drawable.DrawableCompat;
 import com.google.android.material.drawable.DrawableUtils;
 import com.google.android.material.internal.ThemeEnforcement;
@@ -59,8 +56,7 @@ public class MaterialSwitch extends SwitchCompat {
 
   @Nullable private Drawable thumbDrawable;
   @Nullable private Drawable thumbIconDrawable;
-  @Px private int thumbIconWidth = DrawableUtils.INTRINSIC_SIZE;
-  @Px private int thumbIconHeight = DrawableUtils.INTRINSIC_SIZE;
+  @Px private int thumbIconSize = DrawableUtils.INTRINSIC_SIZE;
 
   @Nullable private Drawable trackDrawable;
   @Nullable private Drawable trackDecorationDrawable;
@@ -101,12 +97,8 @@ public class MaterialSwitch extends SwitchCompat {
             context, attrs, R.styleable.MaterialSwitch, defStyleAttr, DEF_STYLE_RES);
 
     thumbIconDrawable = attributes.getDrawable(R.styleable.MaterialSwitch_thumbIcon);
-    if (VERSION.SDK_INT >= VERSION_CODES.M) {
-      thumbIconWidth = attributes.getDimensionPixelSize(
-            R.styleable.MaterialSwitch_thumbIconWidth, DrawableUtils.INTRINSIC_SIZE);
-      thumbIconHeight = attributes.getDimensionPixelSize(
-            R.styleable.MaterialSwitch_thumbIconHeight, DrawableUtils.INTRINSIC_SIZE);
-    }
+    thumbIconSize = attributes.getDimensionPixelSize(
+        R.styleable.MaterialSwitch_thumbIconSize, DrawableUtils.INTRINSIC_SIZE);
 
     thumbIconTintList = attributes.getColorStateList(R.styleable.MaterialSwitch_thumbIconTint);
     thumbIconTintMode =
@@ -213,51 +205,25 @@ public class MaterialSwitch extends SwitchCompat {
   }
 
   /**
-   * Sets the width of the thumb icon.
+   * Sets the size of the thumb icon.
    *
-   * @attr ref com.google.android.material.R.styleable#MaterialSwitch_thumbIconWidth
+   * @attr ref com.google.android.material.R.styleable#MaterialSwitch_thumbIconSize
    */
-  @RequiresApi(VERSION_CODES.M)
-  public void setThumbIconWidth(@Px final int width) {
-    if (thumbIconWidth != width) {
-      thumbIconWidth = width;
+  public void setThumbIconSize(@Px final int size) {
+    if (thumbIconSize != size) {
+      thumbIconSize = size;
       refreshThumbDrawable();
     }
   }
 
   /**
-   * Returns the width of the thumb icon.
+   * Returns the size of the thumb icon.
    *
-   * @attr ref com.google.android.material.R.styleable#MaterialSwitch_thumbIconWidth
+   * @attr ref com.google.android.material.R.styleable#MaterialSwitch_thumbIconSize
    */
-  @RequiresApi(VERSION_CODES.M)
   @Px
-  public int getThumbIconWidth() {
-    return thumbIconWidth;
-  }
-
-  /**
-   * Sets the height of the thumb icon.
-   *
-   * @attr ref com.google.android.material.R.styleable#MaterialSwitch_thumbIconHeight
-   */
-  @RequiresApi(VERSION_CODES.M)
-  public void setThumbIconHeight(@Px final int height) {
-    if (thumbIconHeight != height) {
-      thumbIconHeight = height;
-      refreshThumbDrawable();
-    }
-  }
-
-  /**
-   * Returns the height of the thumb icon.
-   *
-   * @attr ref com.google.android.material.R.styleable#MaterialSwitch_thumbIconHeight
-   */
-  @RequiresApi(VERSION_CODES.M)
-  @Px
-  public int getThumbIconHeight() {
-    return thumbIconHeight;
+  public int getThumbIconSize() {
+    return thumbIconSize;
   }
 
   /**
@@ -435,10 +401,8 @@ public class MaterialSwitch extends SwitchCompat {
 
     updateDrawableTints();
 
-    super.setThumbDrawable(VERSION.SDK_INT < VERSION_CODES.M
-            ? DrawableUtils.compositeTwoLayeredDrawable(thumbDrawable, thumbIconDrawable)
-            : DrawableUtils.compositeTwoLayeredDrawable(
-                thumbDrawable, thumbIconDrawable, thumbIconWidth, thumbIconHeight));
+    super.setThumbDrawable(DrawableUtils.compositeTwoLayeredDrawable(
+        thumbDrawable, thumbIconDrawable, thumbIconSize, thumbIconSize));
 
     refreshDrawableState();
   }

--- a/lib/java/com/google/android/material/materialswitch/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/materialswitch/res-public/values/public.xml
@@ -18,8 +18,7 @@
   <public name="Widget.Material3.CompoundButton.MaterialSwitch" type="style"/>
 
   <public name="thumbIcon" type="attr"/>
-  <public name="thumbIconWidth" type="attr"/>
-  <public name="thumbIconHeight" type="attr"/>
+  <public name="thumbIconSize" type="attr"/>
   <public name="thumbIconTint" type="attr"/>
   <public name="thumbIconTintMode" type="attr"/>
   <public name="trackDecoration" type="attr"/>

--- a/lib/java/com/google/android/material/materialswitch/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/materialswitch/res/values/attrs.xml
@@ -46,10 +46,8 @@
            result to valid color values. Saturate(S + D) -->
       <enum name="add" value="16" />
     </attr>
-    <!-- Width of the thumb icon. The attribute is supported only for API 23 and above. -->
-    <attr name="thumbIconWidth" format="dimension"/>
-    <!-- Height of the thumb icon. The attribute is supported only for API 23 and above. -->
-    <attr name="thumbIconHeight" format="dimension"/>
+    <!-- Size of the thumb icon. -->
+    <attr name="thumbIconSize" format="dimension"/>
     <!-- Drawable used for the track decoration that will be drawn upon the track.
          By default it will draw an outline on the track in the unchecked state. -->
     <attr name="trackDecoration" format="reference"/>

--- a/lib/java/com/google/android/material/materialswitch/res/values/dimens.xml
+++ b/lib/java/com/google/android/material/materialswitch/res/values/dimens.xml
@@ -17,6 +17,7 @@
 
 <resources>
   <dimen name="mtrl_switch_thumb_size">32dp</dimen>
+  <dimen name="mtrl_switch_thumb_icon_size">16dp</dimen>
   <dimen name="mtrl_switch_track_width">@dimen/m3_comp_switch_track_width</dimen>
   <dimen name="mtrl_switch_track_height">@dimen/m3_comp_switch_track_height</dimen>
   <dimen name="mtrl_switch_text_padding">16dp</dimen>

--- a/lib/java/com/google/android/material/materialswitch/res/values/styles.xml
+++ b/lib/java/com/google/android/material/materialswitch/res/values/styles.xml
@@ -19,6 +19,7 @@
     <item name="track">@drawable/mtrl_switch_track</item>
     <item name="trackDecoration">@drawable/mtrl_switch_track_decoration</item>
     <item name="thumbTint">@color/mtrl_switch_thumb_tint</item>
+    <item name="thumbIconSize">@dimen/mtrl_switch_thumb_icon_size</item>
     <item name="thumbIconTint">@color/mtrl_switch_thumb_icon_tint</item>
     <item name="trackTint">@color/mtrl_switch_track_tint</item>
     <item name="trackDecorationTint">@color/mtrl_switch_track_decoration_tint</item>


### PR DESCRIPTION
This PR:
- Adds custom thumb icon size support for API < 23.
- Replaces `thumbIconWidth` and `thumbIconHeight` with `thumbIconSize` (as in other components such as `MaterialButton`, `FloatingActionButton`, `Chip`, `Card`, and so on).
- Adds a default thumb icon size (16dp, according to [specs](https://m3.material.io/components/switch/specs#f860b994-be1f-4437-8c95-fd5af132293b)).