### PR TITLE
[Theme] Fix swapped error colors for dynamic contrast theme in light mode

### DIFF
--- a/lib/java/com/google/android/material/theme/res/values/themes_overlay.xml
+++ b/lib/java/com/google/android/material/theme/res/values/themes_overlay.xml
@@ -220,8 +220,8 @@
     <item name="colorOutline">@android:color/system_outline_light</item>
     <item name="colorOutlineVariant">@android:color/system_outline_variant_light</item>
     <item name="colorError">@android:color/system_error_light</item>
-    <item name="colorOnError">@android:color/system_error_container_light</item>
-    <item name="colorErrorContainer">@android:color/system_on_error_light</item>
+    <item name="colorOnError">@android:color/system_on_error_light</item>
+    <item name="colorErrorContainer">@android:color/system_error_container_light</item>
     <item name="colorOnErrorContainer">@android:color/system_on_error_container_light</item>
 
     <!-- Default Framework Text Colors. -->


### PR DESCRIPTION
Commit 862a7e1 which introduced dynamic contrast had a copy/paste mistake, the color values of onError and errorContainer in [L223 and L224](https://github.com/material-components/material-components-android/blob/09a058ddd9e69c8e36fba0537bf02b2f22b261f9/lib/java/com/google/android/material/theme/res/values/themes_overlay.xml#L223C5-L224C81) were swapped in light mode so an error container has a white background with 1.11.0-alpha01.