### PR TITLE
[TextInputLayout] Errors are hidden when Layout is disabled

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -315,6 +315,7 @@ public class TextInputLayout extends LinearLayout {
 
   @Nullable private Drawable startDummyDrawable;
   private int startDummyDrawableWidth;
+  private CharSequence disabledErrorText;
 
   /**
    * Values for the end icon mode.
@@ -2139,6 +2140,13 @@ public class TextInputLayout extends LinearLayout {
       setErrorEnabled(true);
     }
 
+    // If the layout is disabled,
+    // save the error to display it when the layout is enabled
+    if (!isEnabled()) {
+      disabledErrorText = errorText;
+      return;
+    }
+
     if (!TextUtils.isEmpty(errorText)) {
       indicatorViewController.showError(errorText);
     } else {
@@ -2763,6 +2771,15 @@ public class TextInputLayout extends LinearLayout {
     // drawable state
     recursiveSetEnabled(this, enabled);
     super.setEnabled(enabled);
+
+    if (!enabled) {
+      disabledErrorText = getError();
+      if (!TextUtils.isEmpty(disabledErrorText)) {
+        indicatorViewController.hideError();
+      }
+    } else if (!TextUtils.isEmpty(disabledErrorText) && isErrorEnabled()) {
+      setError(disabledErrorText);
+    }
   }
 
   private static void recursiveSetEnabled(@NonNull final ViewGroup vg, final boolean enabled) {


### PR DESCRIPTION
closes #3001 

If an error is displayed when the TextInputLayout is disabled, the error is hidden.
If the TextInputLayout is re-enabled, the error is displayed again.
If an error is set while the TextInputLayout is disabled, the error is displayed once the layout is enabled.

And am I doing something wrong or are some **DateStringsTest** tests timezone dependent? e.g. **getDayContentDescription_notToday**