### PR TITLE
[MaterialTimePicker] Fix the dialog buttons getting clipped at the bottom

### DIFF
--- a/lib/java/com/google/android/material/timepicker/res/layout/material_timepicker_dialog.xml
+++ b/lib/java/com/google/android/material/timepicker/res/layout/material_timepicker_dialog.xml
@@ -83,7 +83,8 @@
     android:minWidth="72dp"
     android:text="@string/mtrl_timepicker_cancel"
     app:layout_constraintEnd_toStartOf="@id/material_timepicker_ok_button"
-    app:layout_constraintTop_toTopOf="@id/material_timepicker_mode_button" />
+    app:layout_constraintTop_toTopOf="@id/material_timepicker_mode_button"
+    app:layout_constraintBottom_toBottomOf="parent" />
 
   <Button
     android:id="@+id/material_timepicker_ok_button"
@@ -95,6 +96,7 @@
     android:minWidth="64dp"
     android:text="@string/mtrl_timepicker_confirm"
     app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintTop_toTopOf="@id/material_timepicker_mode_button" />
+    app:layout_constraintTop_toTopOf="@id/material_timepicker_mode_button"
+    app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/lib/java/com/google/android/material/timepicker/res/layout/material_timepicker_dialog.xml
+++ b/lib/java/com/google/android/material/timepicker/res/layout/material_timepicker_dialog.xml
@@ -92,7 +92,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginTop="2dp"
-    android:layout_marginEnd="8dp"
+    android:layout_marginEnd="12dp"
     android:minWidth="64dp"
     android:text="@string/mtrl_timepicker_confirm"
     app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
The "Cancel" and "Ok" buttons in the dialog are being clipped at the bottom
when the theme's `minTouchTargetSize` is not the default `48dp`.

This is because those two buttons are constrained only to the top of
the "input mode" button and have no bottom constraint. The "input mode"
button is the only one constrained to `parent` on the bottom edge, which
means that if this button gets smaller than those other two buttons - like
when the `minTouchTargetSize` is `0dp` - the bottom edge of the dialog
will move up, but because those other two buttons are only constrained
at the top edge, they stay in place and get clipped.

So this adds a bottom constraint to the "Cancel" and "Ok" buttons, which
fixes the clipping issue. I've also changed the end margin from `8dp` to
`12dp` to match the start margin of the "input mode" button, but I'm not
too sure about that one, it just seemed nicer to have equal margins on both
sides of the dialog.

closes #3584

Here are the screenshots with `minTouchTargetSize` set to `0dp`:

Before|After
-|-
![Screenshot_1695055330](https://github.com/material-components/material-components-android/assets/71154/16d60c90-dedb-4092-9972-4c7b1551f63b)|![Screenshot_1695055255](https://github.com/material-components/material-components-android/assets/71154/eeefd390-8c8a-4130-8ed4-04d15bfa0f95)
Before with layout bounds|After with layout bounds
![Screenshot_1695051473](https://github.com/material-components/material-components-android/assets/71154/fe2cd4f4-e980-4c58-b57c-d95070cd6e04)|![Screenshot_1695051555](https://github.com/material-components/material-components-android/assets/71154/31bef243-e92c-458a-a98a-32e7171430a4)
