### PR TITLE
[DatePicker] Distinguish between date component characters and delimiters more accurately

### DIFF
--- a/lib/java/com/google/android/material/datepicker/DateFormatTextWatcher.java
+++ b/lib/java/com/google/android/material/datepicker/DateFormatTextWatcher.java
@@ -27,6 +27,7 @@ import com.google.android.material.internal.TextWatcherAdapter;
 import com.google.android.material.textfield.TextInputLayout;
 import java.text.DateFormat;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
@@ -34,8 +35,7 @@ abstract class DateFormatTextWatcher extends TextWatcherAdapter {
 
   @NonNull private final TextInputLayout textInputLayout;
 
-  private final String formatHint;
-  private final DateFormat dateFormat;
+  private final SimpleDateFormat dateFormat;
   private final CalendarConstraints constraints;
   private final String outOfRange;
   private final Runnable setErrorCallback;
@@ -45,11 +45,10 @@ abstract class DateFormatTextWatcher extends TextWatcherAdapter {
 
   DateFormatTextWatcher(
       final String formatHint,
-      DateFormat dateFormat,
+      SimpleDateFormat dateFormat,
       @NonNull TextInputLayout textInputLayout,
       CalendarConstraints constraints) {
 
-    this.formatHint = formatHint;
     this.dateFormat = dateFormat;
     this.textInputLayout = textInputLayout;
     this.constraints = constraints;
@@ -85,7 +84,8 @@ abstract class DateFormatTextWatcher extends TextWatcherAdapter {
     textInputLayout.setError(null);
     onValidDate(null);
 
-    if (TextUtils.isEmpty(s) || s.length() < formatHint.length()) {
+    String datePattern = dateFormat.toPattern();
+    if (TextUtils.isEmpty(s) || s.length() < datePattern.length()) {
       return;
     }
 
@@ -118,14 +118,20 @@ abstract class DateFormatTextWatcher extends TextWatcherAdapter {
       return;
     }
 
-    if (s.length() == 0 || s.length() >= formatHint.length() || s.length() < lastLength) {
+    String datePattern = dateFormat.toPattern();
+    if (s.length() == 0 || s.length() >= datePattern.length() || s.length() < lastLength) {
       return;
     }
 
-    char nextCharHint = formatHint.charAt(s.length());
-    if (!Character.isDigit(nextCharHint)) {
-      s.append(nextCharHint);
+    char nextPatternChar = datePattern.charAt(s.length());
+    if (isDelimiter(nextPatternChar)) {
+      s.append(nextPatternChar);
     }
+  }
+
+  private boolean isDelimiter(char ch) {
+    return !(ch >= 'A' && ch <= 'Z')
+        && !(ch >= 'a' && ch <= 'z');
   }
 
   private Runnable createRangeErrorCallback(final long milliseconds) {


### PR DESCRIPTION
Fixes https://github.com/material-components/material-components-android/issues/3625