### PR TITLE
[Theme] Add NoActionBar dynamic color themes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,16 +137,22 @@ Here are the `Material3` themes you can use to get the latest component styles
 and theme-level attributes, as well as their `MaterialComponents` equivalents
 when applicable.
 
-`Material3`                            | `MaterialComponents`
--------------------------------------- | --------------------
-`Theme.Material3.Light`                | `Theme.MaterialComponents.Light`
-`Theme.Material3.Light.NoActionBar`    | `Theme.MaterialComponents.Light.NoActionBar`
-`Theme.Material3.Dark`                 | `Theme.MaterialComponents`
-`Theme.Material3.Dark.NoActionBar`     | `Theme.MaterialComponents.NoActionBar`
-`Theme.Material3.DayNight`             | `Theme.MaterialComponents.DayNight`
-`Theme.Material3.DayNight.NoActionBar` | `Theme.MaterialComponents.DayNight.NoActionBar`
-N/A                                    | `Theme.MaterialComponents.Light.DarkActionBar`
-N/A                                    | `Theme.MaterialComponents.DayNight.DarkActionBar`
+| `Material3`                                          | `MaterialComponents`                              |
+|------------------------------------------------------|---------------------------------------------------|
+| `Theme.Material3.Light`                              | `Theme.MaterialComponents.Light`                  |
+| `Theme.Material3.Light.NoActionBar`                  | `Theme.MaterialComponents.Light.NoActionBar`      |
+| `Theme.Material3.Dark`                               | `Theme.MaterialComponents`                        |
+| `Theme.Material3.Dark.NoActionBar`                   | `Theme.MaterialComponents.NoActionBar`            |
+| `Theme.Material3.DayNight`                           | `Theme.MaterialComponents.DayNight`               |
+| `Theme.Material3.DayNight.NoActionBar`               | `Theme.MaterialComponents.DayNight.NoActionBar`   |
+| `Theme.Material3.DynamicColors.Light`                | N/A                                               |
+| `Theme.Material3.DynamicColors.Light.NoActionBar`    | N/A                                               |
+| `Theme.Material3.DynamicColors.Dark`                 | N/A                                               |
+| `Theme.Material3.DynamicColors.Dark.NoActionBar`     | N/A                                               |
+| `Theme.Material3.DynamicColors.DayNight`             | N/A                                               |
+| `Theme.Material3.DynamicColors.DayNight.NoActionBar` | N/A                                               |
+| N/A                                                  | `Theme.MaterialComponents.Light.DarkActionBar`    |
+| N/A                                                  | `Theme.MaterialComponents.DayNight.DarkActionBar` |
 
 Update your app theme to inherit from one of these themes:
 

--- a/lib/java/com/google/android/material/theme/res-public/values/public.xml
+++ b/lib/java/com/google/android/material/theme/res-public/values/public.xml
@@ -22,8 +22,11 @@
   <public name="Theme.Material3.DayNight" type="style"/>
   <public name="Theme.Material3.DayNight.NoActionBar" type="style"/>
   <public name="Theme.Material3.DynamicColors.Light" type="style"/>
+  <public name="Theme.Material3.DynamicColors.Light.NoActionBar" type="style"/>
   <public name="Theme.Material3.DynamicColors.Dark" type="style"/>
+  <public name="Theme.Material3.DynamicColors.Dark.NoActionBar" type="style"/>
   <public name="Theme.Material3.DynamicColors.DayNight" type="style"/>
+  <public name="Theme.Material3.DynamicColors.DayNight.NoActionBar" type="style"/>
   <public name="Theme.Material3.Light.DialogWhenLarge" type="style"/>
   <public name="Theme.Material3.Dark.DialogWhenLarge" type="style"/>
   <public name="Theme.Material3.DayNight.DialogWhenLarge" type="style"/>

--- a/lib/java/com/google/android/material/theme/res/values-night/themes_daynight.xml
+++ b/lib/java/com/google/android/material/theme/res/values-night/themes_daynight.xml
@@ -19,6 +19,7 @@
   <style name="Theme.Material3.DayNight" parent="Theme.Material3.Dark"/>
   <style name="Theme.Material3.DayNight.NoActionBar" parent="Theme.Material3.Dark.NoActionBar"/>
   <style name="Theme.Material3.DynamicColors.DayNight" parent="Theme.Material3.DynamicColors.Dark"/>
+  <style name="Theme.Material3.DynamicColors.DayNight.NoActionBar" parent="Theme.Material3.DynamicColors.Dark.NoActionBar"/>
   <style name="Theme.Material3.DayNight.DialogWhenLarge" parent="Theme.Material3.Dark.DialogWhenLarge"/>
 
   <!-- Material themes (day/night versions) for activities. -->

--- a/lib/java/com/google/android/material/theme/res/values/themes.xml
+++ b/lib/java/com/google/android/material/theme/res/values/themes.xml
@@ -44,6 +44,16 @@
 
   <style name="Theme.Material3.DynamicColors.Dark" parent="Theme.Material3.Dark"/>
 
+  <style name="Theme.Material3.DynamicColors.Light.NoActionBar">
+    <item name="windowActionBar">false</item>
+    <item name="windowNoTitle">true</item>
+  </style>
+
+  <style name="Theme.Material3.DynamicColors.Dark.NoActionBar">
+    <item name="windowActionBar">false</item>
+    <item name="windowNoTitle">true</item>
+  </style>
+
   <style name="Theme.Material3.Light.DialogWhenLarge" parent="Base.Theme.Material3.Light.DialogWhenLarge"/>
 
   <style name="Theme.Material3.Dark.DialogWhenLarge" parent="Base.Theme.Material3.Dark.DialogWhenLarge"/>

--- a/lib/java/com/google/android/material/theme/res/values/themes_daynight.xml
+++ b/lib/java/com/google/android/material/theme/res/values/themes_daynight.xml
@@ -19,6 +19,7 @@
   <style name="Theme.Material3.DayNight" parent="Theme.Material3.Light"/>
   <style name="Theme.Material3.DayNight.NoActionBar" parent="Theme.Material3.Light.NoActionBar"/>
   <style name="Theme.Material3.DynamicColors.DayNight" parent="Theme.Material3.DynamicColors.Light"/>
+  <style name="Theme.Material3.DynamicColors.DayNight.NoActionBar" parent="Theme.Material3.DynamicColors.Light.NoActionBar"/>
   <style name="Theme.Material3.DayNight.DialogWhenLarge" parent="Theme.Material3.Light.DialogWhenLarge"/>
 
   <!-- Material themes (day/night versions) for activities. -->


### PR DESCRIPTION
At the moment, the library provides the following themes with dynamic colors:
- `Theme.Material3.DynamicColors.Light` (= `Theme.Material3.Light` with dynamic colors)
- `Theme.Material3.DynamicColors.Dark` (= `Theme.Material3.Dark` with dynamic colors)
- `Theme.Material3.DynamicColors.DayNight` (= `Theme.Material3.DayNight` with dynamic colors)

This PR adds NoActionBar variants of these themes:
- `Theme.Material3.DynamicColors.Light.NoActionBar` (= `Theme.Material3.Light.NoActionBar` with dynamic colors)
- `Theme.Material3.DynamicColors.Dark.NoActionBar` (= `Theme.Material3.Dark.NoActionBar` with dynamic colors)
- `Theme.Material3.DynamicColors.DayNight.NoActionBar` (= `Theme.Material3.DayNight.NoActionBar` with dynamic colors)