### PR TITLE
Remove redundant version checks

### DIFF
--- a/catalog/java/io/material/catalog/application/theme/res/values/themes.xml
+++ b/catalog/java/io/material/catalog/application/theme/res/values/themes.xml
@@ -26,7 +26,7 @@
 
   <!-- A theme which sets the status bar color to transparent -->
   <style name="Theme.Catalog.TransparentStatus">
-    <item name="android:statusBarColor" tools:targetApi="21">@android:color/transparent</item>
+    <item name="android:statusBarColor" tools:targetApi="lollipop">@android:color/transparent</item>
   </style>
 
   <style name="CatalogPreferenceThemeOverlay" parent="PreferenceThemeOverlay">

--- a/catalog/java/io/material/catalog/card/DraggableCardFragment.java
+++ b/catalog/java/io/material/catalog/card/DraggableCardFragment.java
@@ -58,9 +58,7 @@ public class DraggableCardFragment extends DemoFragment {
             R.layout.cat_card_draggable_fragment, viewGroup, false /* attachToRoot */);
     DraggableCoordinatorLayout container = (DraggableCoordinatorLayout) view;
     LayoutTransition transition = ((CoordinatorLayout) view).getLayoutTransition();
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
-      transition.enableTransitionType(LayoutTransition.CHANGING);
-    }
+    transition.enableTransitionType(LayoutTransition.CHANGING);
 
     card = view.findViewById(R.id.draggable_card);
     card.setAccessibilityDelegate(cardDelegate);

--- a/catalog/java/io/material/catalog/card/res/layout/cat_card_list_item.xml
+++ b/catalog/java/io/material/catalog/card/res/layout/cat_card_list_item.xml
@@ -18,7 +18,6 @@
 <com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/cat_card_list_item_card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -42,6 +41,5 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_gravity="end"
-      app:srcCompat="@drawable/ic_drag_handle_vd_theme_24px"
-      tools:targetApi="jelly_bean"/>
+      app:srcCompat="@drawable/ic_drag_handle_vd_theme_24px"/>
 </com.google.android.material.card.MaterialCardView>

--- a/catalog/java/io/material/catalog/feature/MemoryView.java
+++ b/catalog/java/io/material/catalog/feature/MemoryView.java
@@ -24,8 +24,6 @@ import android.graphics.Paint;
 import android.graphics.Paint.Style;
 import android.graphics.Path;
 import android.graphics.Path.Direction;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import androidx.appcompat.widget.AppCompatTextView;
 import android.text.format.Formatter;
 import android.util.AttributeSet;
@@ -59,9 +57,7 @@ public final class MemoryView extends AppCompatTextView {
 
   public MemoryView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
-      setGravity(TEXT_ALIGNMENT_CENTER);
-    }
+    setGravity(TEXT_ALIGNMENT_CENTER);
 
     paint.setStyle(Style.FILL_AND_STROKE);
     paint.setStrokeWidth(STROKE_WIDTH);

--- a/catalog/java/io/material/catalog/musicplayer/res/values/styles.xml
+++ b/catalog/java/io/material/catalog/musicplayer/res/values/styles.xml
@@ -20,7 +20,7 @@
     <item name="colorSecondary">@color/cat_music_player_secondary</item>
     <item name="colorOnSecondary">@color/cat_music_player_on_secondary</item>
 
-    <item name="android:statusBarColor" tools:targetApi="21">?attr/colorControlNormal</item>
+    <item name="android:statusBarColor" tools:targetApi="lollipop">?attr/colorControlNormal</item>
     <item name="android:windowLightStatusBar" tools:targetApi="m">?attr/isLightTheme</item>
   </style>
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -279,7 +279,7 @@ afterEvaluate {
           description = 'Material Components for Android is a static library ' +
             'that you can add to your Android application in order to use ' +
             'APIs that provide implementations of the Material Design specification. ' +
-            'Compatible on devices running API 14 or later.'
+            'Compatible on devices running API 19 or later.'
           url = 'https://github.com/material-components/material-components-android'
           inceptionYear = '2015'
           licenses {

--- a/lib/java/com/google/android/material/animation/DrawableAlphaProperty.java
+++ b/lib/java/com/google/android/material/animation/DrawableAlphaProperty.java
@@ -16,12 +16,9 @@
 package com.google.android.material.animation;
 
 import android.graphics.drawable.Drawable;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.util.Property;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import java.util.WeakHashMap;
 
 /**
  * Compat property for {@link Drawable#getAlpha()} and {@link Drawable#setAlpha(int)} for pre-K
@@ -36,8 +33,6 @@ public class DrawableAlphaProperty extends Property<Drawable, Integer> {
   public static final Property<Drawable, Integer> DRAWABLE_ALPHA_COMPAT =
       new DrawableAlphaProperty();
 
-  private final WeakHashMap<Drawable, Integer> alphaCache = new WeakHashMap<>();
-
   private DrawableAlphaProperty() {
     super(Integer.class, "drawableAlphaCompat");
   }
@@ -45,21 +40,11 @@ public class DrawableAlphaProperty extends Property<Drawable, Integer> {
   @Nullable
   @Override
   public Integer get(@NonNull Drawable object) {
-    if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-      return object.getAlpha();
-    }
-    if (alphaCache.containsKey(object)) {
-      return alphaCache.get(object);
-    }
-    return 0xFF;
+    return object.getAlpha();
   }
 
   @Override
   public void set(@NonNull Drawable object, @NonNull Integer value) {
-    if (VERSION.SDK_INT < VERSION_CODES.KITKAT) {
-      alphaCache.put(object, value);
-    }
-
     object.setAlpha(value);
   }
 }

--- a/lib/java/com/google/android/material/appbar/AppBarLayout.java
+++ b/lib/java/com/google/android/material/appbar/AppBarLayout.java
@@ -238,7 +238,7 @@ public class AppBarLayout extends LinearLayout implements CoordinatorLayout.Atta
     context = getContext();
     setOrientation(VERTICAL);
 
-    if (VERSION.SDK_INT >= 21) {
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
       // Use the bounds view outline provider so that we cast a shadow, even without a
       // background
       if (getOutlineProvider() == ViewOutlineProvider.BACKGROUND) {
@@ -287,7 +287,7 @@ public class AppBarLayout extends LinearLayout implements CoordinatorLayout.Atta
           /* force= */ false);
     }
 
-    if (VERSION.SDK_INT >= 21 && a.hasValue(R.styleable.AppBarLayout_elevation)) {
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP && a.hasValue(R.styleable.AppBarLayout_elevation)) {
       ViewUtilsLollipop.setDefaultAppBarLayoutStateListAnimator(
           this, a.getDimensionPixelSize(R.styleable.AppBarLayout_elevation, 0));
     }
@@ -748,7 +748,7 @@ public class AppBarLayout extends LinearLayout implements CoordinatorLayout.Atta
 
   @Override
   protected LayoutParams generateLayoutParams(ViewGroup.LayoutParams p) {
-    if (Build.VERSION.SDK_INT >= 19 && p instanceof LinearLayout.LayoutParams) {
+    if (p instanceof LinearLayout.LayoutParams) {
       return new LayoutParams((LinearLayout.LayoutParams) p);
     } else if (p instanceof MarginLayoutParams) {
       return new LayoutParams((MarginLayoutParams) p);
@@ -1155,7 +1155,7 @@ public class AppBarLayout extends LinearLayout implements CoordinatorLayout.Atta
    */
   @Deprecated
   public void setTargetElevation(float elevation) {
-    if (Build.VERSION.SDK_INT >= 21) {
+    if (Build.VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
       ViewUtilsLollipop.setDefaultAppBarLayoutStateListAnimator(this, elevation);
     }
   }

--- a/lib/java/com/google/android/material/appbar/AppBarLayout.java
+++ b/lib/java/com/google/android/material/appbar/AppBarLayout.java
@@ -1352,13 +1352,11 @@ public class AppBarLayout extends LinearLayout implements CoordinatorLayout.Atta
       super(source);
     }
 
-    @RequiresApi(19)
     public LayoutParams(LinearLayout.LayoutParams source) {
       // The copy constructor called here only exists on API 19+.
       super(source);
     }
 
-    @RequiresApi(19)
     public LayoutParams(@NonNull LayoutParams source) {
       // The copy constructor called here only exists on API 19+.
       super(source);

--- a/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
+++ b/lib/java/com/google/android/material/appbar/CollapsingToolbarLayout.java
@@ -1689,13 +1689,11 @@ public class CollapsingToolbarLayout extends FrameLayout {
       super(source);
     }
 
-    @RequiresApi(19)
     public LayoutParams(@NonNull FrameLayout.LayoutParams source) {
       // The copy constructor called here only exists on API 19+.
       super(source);
     }
 
-    @RequiresApi(19)
     public LayoutParams(@NonNull LayoutParams source) {
       // The copy constructor called here only exists on API 19+.
       super(source);

--- a/lib/java/com/google/android/material/appbar/ViewUtilsLollipop.java
+++ b/lib/java/com/google/android/material/appbar/ViewUtilsLollipop.java
@@ -23,6 +23,7 @@ import android.animation.ObjectAnimator;
 import android.animation.StateListAnimator;
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewOutlineProvider;
@@ -30,7 +31,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import com.google.android.material.internal.ThemeEnforcement;
 
-@RequiresApi(21)
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 class ViewUtilsLollipop {
 
   private static final int[] STATE_LIST_ANIM_ATTRS = new int[] {android.R.attr.stateListAnimator};

--- a/lib/java/com/google/android/material/badge/BadgeUtils.java
+++ b/lib/java/com/google/android/material/badge/BadgeUtils.java
@@ -47,7 +47,7 @@ import com.google.android.material.internal.ToolbarUtils;
 @ExperimentalBadgeUtils
 public class BadgeUtils {
 
-  public static final boolean USE_COMPAT_PARENT = VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN_MR2;
+  public static final boolean USE_COMPAT_PARENT = false;
 
   private static final String LOG_TAG = "BadgeUtils";
 

--- a/lib/java/com/google/android/material/bottomnavigation/BottomNavigationView.java
+++ b/lib/java/com/google/android/material/bottomnavigation/BottomNavigationView.java
@@ -23,6 +23,7 @@ import static java.lang.Math.min;
 
 import android.content.Context;
 import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import androidx.appcompat.widget.TintTypedArray;
 import android.util.AttributeSet;
 import android.view.View;
@@ -226,7 +227,7 @@ public class BottomNavigationView extends NavigationBarView {
    * legacy backgrounds.
    */
   private boolean shouldDrawCompatibilityTopDivider() {
-    return VERSION.SDK_INT < 21 && !(getBackground() instanceof MaterialShapeDrawable);
+    return VERSION.SDK_INT < VERSION_CODES.LOLLIPOP && !(getBackground() instanceof MaterialShapeDrawable);
   }
 
   /**

--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -29,7 +29,6 @@ import android.animation.ValueAnimator.AnimatorUpdateListener;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
-import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Parcel;
@@ -2273,7 +2272,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
 
     CoordinatorLayout parent = (CoordinatorLayout) viewParent;
     final int childCount = parent.getChildCount();
-    if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) && expanded) {
+    if (expanded) {
       if (importantForAccessibilityMap == null) {
         importantForAccessibilityMap = new HashMap<>(childCount);
       } else {
@@ -2290,9 +2289,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
 
       if (expanded) {
         // Saves the important for accessibility value of the child view.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-          importantForAccessibilityMap.put(child, child.getImportantForAccessibility());
-        }
+        importantForAccessibilityMap.put(child, child.getImportantForAccessibility());
         if (updateImportantForAccessibilityOnSiblings) {
           ViewCompat.setImportantForAccessibility(
               child, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);

--- a/lib/java/com/google/android/material/button/MaterialButton.java
+++ b/lib/java/com/google/android/material/button/MaterialButton.java
@@ -508,7 +508,6 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
     }
   }
 
-  @RequiresApi(VERSION_CODES.JELLY_BEAN_MR1)
   @Override
   public void setTextAlignment(int textAlignment) {
     super.setTextAlignment(textAlignment);

--- a/lib/java/com/google/android/material/button/MaterialButton.java
+++ b/lib/java/com/google/android/material/button/MaterialButton.java
@@ -545,9 +545,6 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
    * TextView.
    */
   private Alignment getActualTextAlignment() {
-    if (VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN_MR1) {
-      return getGravityTextAlignment();
-    }
     switch (getTextAlignment()) {
       case TEXT_ALIGNMENT_GRAVITY:
         return getGravityTextAlignment();

--- a/lib/java/com/google/android/material/card/res/animator/m3_card_elevated_state_list_anim.xml
+++ b/lib/java/com/google/android/material/card/res/animator/m3_card_elevated_state_list_anim.xml
@@ -17,8 +17,7 @@
 
 <selector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <!-- Hovered state -->
   <item android:state_enabled="true" android:state_hovered="true">
@@ -28,8 +27,7 @@
       android:propertyName="translationZ"
       android:startDelay="?attr/motionDurationMedium1"
       android:valueTo="@dimen/m3_card_elevated_hovered_z"
-      android:valueType="floatType"
-      tools:targetApi="kitkat"/>
+      android:valueType="floatType"/>
   </item>
 
   <!-- Dragged state  -->
@@ -40,8 +38,7 @@
       android:propertyName="translationZ"
       android:startDelay="?attr/motionDurationMedium1"
       android:valueTo="@dimen/m3_card_elevated_dragged_z"
-      android:valueType="floatType"
-      tools:targetApi="kitkat"/>
+      android:valueType="floatType"/>
   </item>
 
   <!-- Base state -->

--- a/lib/java/com/google/android/material/card/res/animator/m3_card_state_list_anim.xml
+++ b/lib/java/com/google/android/material/card/res/animator/m3_card_state_list_anim.xml
@@ -17,8 +17,7 @@
 
 <selector
   xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools">
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <!-- Hovered state -->
   <item android:state_enabled="true" android:state_hovered="true">
@@ -28,8 +27,7 @@
       android:valueTo="@dimen/m3_card_hovered_z"
       android:startDelay="?attr/motionDurationMedium1"
       android:interpolator="?attr/motionEasingEmphasizedInterpolator"
-      android:valueType="floatType"
-      tools:targetApi="kitkat"/>
+      android:valueType="floatType"/>
   </item>
 
   <!-- Dragged state -->
@@ -40,8 +38,7 @@
       android:valueTo="@dimen/m3_card_dragged_z"
       android:startDelay="?attr/motionDurationMedium1"
       android:interpolator="?attr/motionEasingEmphasizedInterpolator"
-      android:valueType="floatType"
-      tools:targetApi="kitkat"/>
+      android:valueType="floatType"/>
   </item>
 
   <!-- Base state -->

--- a/lib/java/com/google/android/material/checkbox/MaterialCheckBox.java
+++ b/lib/java/com/google/android/material/checkbox/MaterialCheckBox.java
@@ -831,7 +831,7 @@ public class MaterialCheckBox extends AppCompatCheckBox {
     if (buttonTintList != null) {
       return buttonTintList;
     }
-    if (VERSION.SDK_INT >= 21 && super.getButtonTintList() != null) {
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP && super.getButtonTintList() != null) {
       return super.getButtonTintList();
     }
     return ((TintableCompoundButton) this).getSupportButtonTintList();
@@ -841,7 +841,7 @@ public class MaterialCheckBox extends AppCompatCheckBox {
     int buttonResourceId = attributes.getResourceId(R.styleable.MaterialCheckBox_android_button, 0);
     int buttonCompatResourceId =
         attributes.getResourceId(R.styleable.MaterialCheckBox_buttonCompat, 0);
-    if (VERSION.SDK_INT < 21) {
+    if (VERSION.SDK_INT < VERSION_CODES.LOLLIPOP) {
       return buttonResourceId == R.drawable.abc_btn_check_material
           && buttonCompatResourceId == R.drawable.abc_btn_check_material_anim;
     } else {

--- a/lib/java/com/google/android/material/chip/Chip.java
+++ b/lib/java/com/google/android/material/chip/Chip.java
@@ -1311,9 +1311,7 @@ public class Chip extends AppCompatCheckBox
     if (chipDrawable == null) {
       return;
     }
-    if (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
-      super.setLayoutDirection(layoutDirection);
-    }
+    super.setLayoutDirection(layoutDirection);
   }
 
   @Override
@@ -2316,15 +2314,10 @@ public class Chip extends AppCompatCheckBox
         return true;
       }
     }
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
-      if (getMinHeight() != minTargetPx) {
-        setMinHeight(minTargetPx);
-      }
-      if (getMinWidth() != minTargetPx) {
-        setMinWidth(minTargetPx);
-      }
-    } else {
+    if (getMinHeight() != minTargetPx) {
       setMinHeight(minTargetPx);
+    }
+    if (getMinWidth() != minTargetPx) {
       setMinWidth(minTargetPx);
     }
     insetChipBackgroundDrawable(deltaX, deltaY, deltaX, deltaY);

--- a/lib/java/com/google/android/material/chip/Chip.java
+++ b/lib/java/com/google/android/material/chip/Chip.java
@@ -372,7 +372,6 @@ public class Chip extends AppCompatCheckBox
   }
 
   @Override
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   public void onRtlPropertiesChanged(int layoutDirection) {
     super.onRtlPropertiesChanged(layoutDirection);
 

--- a/lib/java/com/google/android/material/chip/Chip.java
+++ b/lib/java/com/google/android/material/chip/Chip.java
@@ -604,7 +604,6 @@ public class Chip extends AppCompatCheckBox
     super.setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom);
   }
 
-  @RequiresApi(17)
   @Override
   public void setCompoundDrawablesRelative(
       @Nullable Drawable start,

--- a/lib/java/com/google/android/material/circularreveal/CircularRevealHelper.java
+++ b/lib/java/com/google/android/material/circularreveal/CircularRevealHelper.java
@@ -82,8 +82,7 @@ public class CircularRevealHelper {
   public static final int BITMAP_SHADER = 0;
   /**
    * Specify that this view should use {@link Canvas#clipPath(Path)} to create the circular reveal
-   * effect. clipPath() is only hardware accelerated on {@link VERSION_CODES#JELLY_BEAN_MR2} and
-   * above.
+   * effect.
    */
   public static final int CLIP_PATH = 1;
   /**

--- a/lib/java/com/google/android/material/circularreveal/CircularRevealHelper.java
+++ b/lib/java/com/google/android/material/circularreveal/CircularRevealHelper.java
@@ -126,10 +126,8 @@ public class CircularRevealHelper {
   static {
     if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
       STRATEGY = REVEAL_ANIMATOR;
-    } else if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
-      STRATEGY = CLIP_PATH;
     } else {
-      STRATEGY = BITMAP_SHADER;
+      STRATEGY = CLIP_PATH;
     }
   }
 

--- a/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
@@ -20,8 +20,6 @@ import com.google.android.material.R;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Canvas;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -35,7 +33,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
-import android.view.accessibility.AccessibilityEvent;
 import android.widget.GridView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -449,11 +446,7 @@ public final class MaterialCalendar<S> extends PickerFragment<S> {
           public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
             if (newState == RecyclerView.SCROLL_STATE_IDLE) {
               CharSequence announcementText = monthDropSelect.getText();
-              if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
-                recyclerView.announceForAccessibility(announcementText);
-              } else {
-                recyclerView.sendAccessibilityEvent(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED);
-              }
+              recyclerView.announceForAccessibility(announcementText);
             }
           }
         });

--- a/lib/java/com/google/android/material/dialog/MaterialAlertDialogBuilder.java
+++ b/lib/java/com/google/android/material/dialog/MaterialAlertDialogBuilder.java
@@ -182,9 +182,8 @@ public class MaterialAlertDialogBuilder extends AlertDialog.Builder {
   @NonNull
   @CanIgnoreReturnValue
   public MaterialAlertDialogBuilder setBackgroundInsetStart(@Px int backgroundInsetStart) {
-    if (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1
-        && getContext().getResources().getConfiguration().getLayoutDirection()
-            == ViewCompat.LAYOUT_DIRECTION_RTL) {
+    if (getContext().getResources().getConfiguration().getLayoutDirection()
+          == ViewCompat.LAYOUT_DIRECTION_RTL) {
       backgroundInsets.right = backgroundInsetStart;
     } else {
       backgroundInsets.left = backgroundInsetStart;
@@ -202,9 +201,8 @@ public class MaterialAlertDialogBuilder extends AlertDialog.Builder {
   @NonNull
   @CanIgnoreReturnValue
   public MaterialAlertDialogBuilder setBackgroundInsetEnd(@Px int backgroundInsetEnd) {
-    if (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1
-        && getContext().getResources().getConfiguration().getLayoutDirection()
-            == ViewCompat.LAYOUT_DIRECTION_RTL) {
+    if (getContext().getResources().getConfiguration().getLayoutDirection()
+          == ViewCompat.LAYOUT_DIRECTION_RTL) {
       backgroundInsets.left = backgroundInsetEnd;
     } else {
       backgroundInsets.right = backgroundInsetEnd;

--- a/lib/java/com/google/android/material/dialog/MaterialDialogs.java
+++ b/lib/java/com/google/android/material/dialog/MaterialDialogs.java
@@ -22,8 +22,6 @@ import android.content.res.TypedArray;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.InsetDrawable;
-import android.os.Build;
-import android.os.Build.VERSION_CODES;
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -94,12 +92,10 @@ public class MaterialDialogs {
 
     int backgroundInsetLeft = backgroundInsetStart;
     int backgroundInsetRight = backgroundInsetEnd;
-    if (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
-      int layoutDirection = context.getResources().getConfiguration().getLayoutDirection();
-      if (layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL) {
-        backgroundInsetLeft = backgroundInsetEnd;
-        backgroundInsetRight = backgroundInsetStart;
-      }
+    int layoutDirection = context.getResources().getConfiguration().getLayoutDirection();
+    if (layoutDirection == ViewCompat.LAYOUT_DIRECTION_RTL) {
+      backgroundInsetLeft = backgroundInsetEnd;
+      backgroundInsetRight = backgroundInsetStart;
     }
 
     return new Rect(

--- a/lib/java/com/google/android/material/dialog/res/values/styles.xml
+++ b/lib/java/com/google/android/material/dialog/res/values/styles.xml
@@ -54,7 +54,7 @@
     <item name="android:scaleType">fitCenter</item>
     <item name="android:src">@null</item>
     <item name="android:contentDescription">@null</item>
-    <item name="android:importantForAccessibility" tools:targetApi="jelly_bean">no</item>
+    <item name="android:importantForAccessibility">no</item>
   </style>
 
   <style name="Base.MaterialAlertDialog.MaterialComponents.Title.Text" parent="RtlOverlay.DialogWindowTitle.AppCompat">

--- a/lib/java/com/google/android/material/dialog/res/values/themes_base.xml
+++ b/lib/java/com/google/android/material/dialog/res/values/themes_base.xml
@@ -207,7 +207,7 @@
     <!-- Default Framework Text styles. -->
     <item name="android:textAppearanceListItem">?attr/textAppearanceTitleMedium</item>
     <item name="android:textAppearanceListItemSmall">?attr/textAppearanceTitleMedium</item>
-    <item name="android:textAppearanceListItemSecondary" tools:targetApi="21">?attr/textAppearanceBodyMedium</item>
+    <item name="android:textAppearanceListItemSecondary" tools:targetApi="lollipop">?attr/textAppearanceBodyMedium</item>
     <item name="textAppearanceListItem">?attr/textAppearanceTitleMedium</item>
     <item name="textAppearanceListItemSmall">?attr/textAppearanceTitleMedium</item>
     <item name="textAppearanceListItemSecondary">?attr/textAppearanceBodyMedium</item>
@@ -469,7 +469,7 @@
     <!-- Default Framework Text styles. -->
     <item name="android:textAppearanceListItem">?attr/textAppearanceTitleMedium</item>
     <item name="android:textAppearanceListItemSmall">?attr/textAppearanceTitleMedium</item>
-    <item name="android:textAppearanceListItemSecondary" tools:targetApi="21">?attr/textAppearanceBodyMedium</item>
+    <item name="android:textAppearanceListItemSecondary" tools:targetApi="lollipop">?attr/textAppearanceBodyMedium</item>
     <item name="textAppearanceListItem">?attr/textAppearanceTitleMedium</item>
     <item name="textAppearanceListItemSmall">?attr/textAppearanceTitleMedium</item>
     <item name="textAppearanceListItemSecondary">?attr/textAppearanceBodyMedium</item>

--- a/lib/java/com/google/android/material/floatingactionbutton/FloatingActionButton.java
+++ b/lib/java/com/google/android/material/floatingactionbutton/FloatingActionButton.java
@@ -323,7 +323,7 @@ public class FloatingActionButton extends VisibilityAwareImageButton
   /**
    * Sets the ripple color for this button.
    *
-   * <p>When running on devices with KitKat or below, we draw this color as a filled circle rather
+   * <p>When running on devices with KitKat, we draw this color as a filled circle rather
    * than a ripple.
    *
    * @param color ARGB color to use for the ripple
@@ -337,7 +337,7 @@ public class FloatingActionButton extends VisibilityAwareImageButton
   /**
    * Sets the ripple color for this button.
    *
-   * <p>When running on devices with KitKat or below, we draw this color as a filled circle rather
+   * <p>When running on devices with KitKat, we draw this color as a filled circle rather
    * than a ripple.
    *
    * @param color color state list to use for the ripple

--- a/lib/java/com/google/android/material/floatingactionbutton/FloatingActionButtonImpl.java
+++ b/lib/java/com/google/android/material/floatingactionbutton/FloatingActionButtonImpl.java
@@ -925,7 +925,7 @@ class FloatingActionButtonImpl {
   }
 
   void updateFromViewRotation() {
-    if (Build.VERSION.SDK_INT == 19) {
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
       // KitKat seems to have an issue with views which are rotated with angles which are
       // not divisible by 90. Worked around by moving to software rendering in these cases.
       if ((rotation % 90) != 0) {

--- a/lib/java/com/google/android/material/floatingactionbutton/FloatingActionButtonImplLollipop.java
+++ b/lib/java/com/google/android/material/floatingactionbutton/FloatingActionButtonImplLollipop.java
@@ -141,7 +141,7 @@ class FloatingActionButtonImplLollipop extends FloatingActionButtonImpl {
     AnimatorSet set = new AnimatorSet();
     List<Animator> animators = new ArrayList<>();
     animators.add(ObjectAnimator.ofFloat(view, "elevation", elevation).setDuration(0));
-    if (Build.VERSION.SDK_INT >= 22 && Build.VERSION.SDK_INT <= 24) {
+    if (Build.VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP_MR1 && Build.VERSION.SDK_INT <= VERSION_CODES.N) {
       // This is a no-op animation which exists here only for introducing the duration
       // because setting the delay (on the next animation) via "setDelay" or "after"
       // can trigger a NPE between android versions 22 and 24 (due to a framework

--- a/lib/java/com/google/android/material/floatingactionbutton/FloatingActionButtonImplLollipop.java
+++ b/lib/java/com/google/android/material/floatingactionbutton/FloatingActionButtonImplLollipop.java
@@ -45,7 +45,7 @@ import com.google.android.material.shape.ShapeAppearanceModel;
 import java.util.ArrayList;
 import java.util.List;
 
-@RequiresApi(21)
+@RequiresApi(VERSION_CODES.LOLLIPOP)
 class FloatingActionButtonImplLollipop extends FloatingActionButtonImpl {
   @Nullable private StateListAnimator stateListAnimator;
 

--- a/lib/java/com/google/android/material/imageview/ShapeableImageView.java
+++ b/lib/java/com/google/android/material/imageview/ShapeableImageView.java
@@ -47,7 +47,6 @@ import androidx.annotation.DimenRes;
 import androidx.annotation.Dimension;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import com.google.android.material.resources.MaterialResources;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.ShapeAppearanceModel;
@@ -231,7 +230,6 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
    * @param end    the padding on the end of the image in pixels
    * @param bottom the padding on the bottom of the image in pixels
    */
-  @RequiresApi(17)
   public void setContentPaddingRelative(
       @Dimension int start, @Dimension int top, @Dimension int end, @Dimension int bottom) {
     // Super padding is equal to background padding + content padding. Adjust the content padding

--- a/lib/java/com/google/android/material/imageview/ShapeableImageView.java
+++ b/lib/java/com/google/android/material/imageview/ShapeableImageView.java
@@ -159,7 +159,7 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
       return;
     }
 
-    if (VERSION.SDK_INT > 19 && !isLayoutDirectionResolved()) {
+    if (VERSION.SDK_INT > VERSION_CODES.KITKAT && !isLayoutDirectionResolved()) {
       return;
     }
 
@@ -167,7 +167,7 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
 
     // Update the super padding to be the combined `android:padding` and
     // `app:contentPadding`, keeping with ShapeableImageView's internal padding contract:
-    if (VERSION.SDK_INT >= 21 && (isPaddingRelative() || isContentPaddingRelative())) {
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP && (isPaddingRelative() || isContentPaddingRelative())) {
       setPaddingRelative(
           super.getPaddingStart(),
           super.getPaddingTop(),
@@ -339,7 +339,7 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
   }
 
   private boolean isRtl() {
-    return VERSION.SDK_INT >= 17 && getLayoutDirection() == LAYOUT_DIRECTION_RTL;
+    return getLayoutDirection() == LAYOUT_DIRECTION_RTL;
   }
 
   /**
@@ -454,7 +454,7 @@ public class ShapeableImageView extends AppCompatImageView implements Shapeable 
     }
     updateShapeMask(getWidth(), getHeight());
     invalidate();
-    if (VERSION.SDK_INT >= 21) {
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
       invalidateOutline();
     }
   }

--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -27,7 +27,6 @@ import static java.lang.Math.min;
 import android.animation.TimeInterpolator;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
-import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -127,8 +126,6 @@ public final class CollapsingTextHelper {
   @Nullable private CharSequence textToDraw;
   private boolean isRtl;
   private boolean isRtlTextDirectionHeuristicsEnabled = true;
-
-  @Nullable private Bitmap expandedTitleTexture;
 
   private float scale;
   private float currentTextSize;
@@ -803,8 +800,6 @@ public final class CollapsingTextHelper {
         break;
     }
 
-    // The bounds have changed so we need to clear the texture
-    clearTexture();
     // Now reset the text size back to the original
     setInterpolatedTextSize(expandedFraction);
   }
@@ -1126,7 +1121,6 @@ public final class CollapsingTextHelper {
     if (text == null || !TextUtils.equals(this.text, text)) {
       this.text = text;
       textToDraw = null;
-      clearTexture();
       recalculate();
     }
   }
@@ -1136,17 +1130,9 @@ public final class CollapsingTextHelper {
     return text;
   }
 
-  private void clearTexture() {
-    if (expandedTitleTexture != null) {
-      expandedTitleTexture.recycle();
-      expandedTitleTexture = null;
-    }
-  }
-
   public void setMaxLines(int maxLines) {
     if (maxLines != this.maxLines) {
       this.maxLines = maxLines;
-      clearTexture();
       recalculate();
     }
   }

--- a/lib/java/com/google/android/material/internal/ForegroundLinearLayout.java
+++ b/lib/java/com/google/android/material/internal/ForegroundLinearLayout.java
@@ -27,6 +27,7 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import androidx.appcompat.widget.LinearLayoutCompat;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import androidx.annotation.NonNull;
@@ -236,7 +237,7 @@ public class ForegroundLinearLayout extends LinearLayoutCompat {
   }
 
   @TargetApi(21)
-  @RequiresApi(21)
+  @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
   @Override
   public void drawableHotspotChanged(float x, float y) {
     super.drawableHotspotChanged(x, y);

--- a/lib/java/com/google/android/material/internal/ForegroundLinearLayout.java
+++ b/lib/java/com/google/android/material/internal/ForegroundLinearLayout.java
@@ -236,7 +236,7 @@ public class ForegroundLinearLayout extends LinearLayoutCompat {
     }
   }
 
-  @TargetApi(21)
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
   @Override
   public void drawableHotspotChanged(float x, float y) {

--- a/lib/java/com/google/android/material/internal/StaticLayoutBuilderCompat.java
+++ b/lib/java/com/google/android/material/internal/StaticLayoutBuilderCompat.java
@@ -61,11 +61,6 @@ final class StaticLayoutBuilderCompat {
   static final float DEFAULT_LINE_SPACING_ADD = 0.0f;
   static final float DEFAULT_LINE_SPACING_MULTIPLIER = 1.0f;
 
-  private static final String TEXT_DIR_CLASS = "android.text.TextDirectionHeuristic";
-  private static final String TEXT_DIRS_CLASS = "android.text.TextDirectionHeuristics";
-  private static final String TEXT_DIR_CLASS_LTR = "LTR";
-  private static final String TEXT_DIR_CLASS_RTL = "RTL";
-
   private static boolean initialized;
 
   @Nullable private static Constructor<StaticLayout> constructor;
@@ -338,16 +333,8 @@ final class StaticLayoutBuilderCompat {
     try {
       final Class<?> textDirClass;
       boolean useRtl = isRtl && Build.VERSION.SDK_INT >= VERSION_CODES.M;
-      if (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
-        textDirClass = TextDirectionHeuristic.class;
-        textDirection = useRtl ? TextDirectionHeuristics.RTL : TextDirectionHeuristics.LTR;
-      } else {
-        ClassLoader loader = StaticLayoutBuilderCompat.class.getClassLoader();
-        String textDirClassName = isRtl ? TEXT_DIR_CLASS_RTL : TEXT_DIR_CLASS_LTR;
-        textDirClass = loader.loadClass(TEXT_DIR_CLASS);
-        Class<?> textDirsClass = loader.loadClass(TEXT_DIRS_CLASS);
-        textDirection = textDirsClass.getField(textDirClassName).get(textDirsClass);
-      }
+      textDirClass = TextDirectionHeuristic.class;
+      textDirection = useRtl ? TextDirectionHeuristics.RTL : TextDirectionHeuristics.LTR;
 
       final Class<?>[] signature =
           new Class<?>[] {

--- a/lib/java/com/google/android/material/internal/ViewGroupOverlayApi18.java
+++ b/lib/java/com/google/android/material/internal/ViewGroupOverlayApi18.java
@@ -21,9 +21,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroupOverlay;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 
-@RequiresApi(18)
 class ViewGroupOverlayApi18 implements ViewGroupOverlayImpl {
 
   private final ViewGroupOverlay viewGroupOverlay;

--- a/lib/java/com/google/android/material/internal/ViewOverlayApi18.java
+++ b/lib/java/com/google/android/material/internal/ViewOverlayApi18.java
@@ -20,9 +20,7 @@ import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewOverlay;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 
-@RequiresApi(18)
 class ViewOverlayApi18 implements ViewOverlayImpl {
 
   private final ViewOverlay viewOverlay;

--- a/lib/java/com/google/android/material/internal/ViewUtils.java
+++ b/lib/java/com/google/android/material/internal/ViewUtils.java
@@ -29,7 +29,6 @@ import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.ColorStateListDrawable;
-import android.os.Build.VERSION_CODES;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;
@@ -43,7 +42,6 @@ import android.view.inputmethod.InputMethodManager;
 import androidx.annotation.Dimension;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -62,7 +60,6 @@ public class ViewUtils {
 
   private ViewUtils() {}
 
-  @RequiresApi(VERSION_CODES.JELLY_BEAN)
   public static final int EDGE_TO_EDGE_FLAGS =
       View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
 

--- a/lib/java/com/google/android/material/internal/ViewUtils.java
+++ b/lib/java/com/google/android/material/internal/ViewUtils.java
@@ -29,8 +29,6 @@ import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.ColorStateListDrawable;
-import android.os.Build;
-import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -377,10 +375,7 @@ public class ViewUtils {
     if (view == null) {
       return null;
     }
-    if (Build.VERSION.SDK_INT >= 18) {
-      return new ViewOverlayApi18(view);
-    }
-    return ViewOverlayApi14.createFrom(view);
+    return new ViewOverlayApi18(view);
   }
 
   /** Returns the content view that is the parent of the provided view. */
@@ -431,11 +426,7 @@ public class ViewUtils {
 
   public static void removeOnGlobalLayoutListener(
       @NonNull ViewTreeObserver viewTreeObserver, @NonNull OnGlobalLayoutListener victim) {
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
-      viewTreeObserver.removeOnGlobalLayoutListener(victim);
-    } else {
-      viewTreeObserver.removeGlobalOnLayoutListener(victim);
-    }
+    viewTreeObserver.removeOnGlobalLayoutListener(victim);
   }
 
   /**

--- a/lib/java/com/google/android/material/internal/WindowUtils.java
+++ b/lib/java/com/google/android/material/internal/WindowUtils.java
@@ -22,14 +22,11 @@ import android.content.Context;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Build;
-import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 /**
  * A util class for window operations.
@@ -39,8 +36,6 @@ import java.lang.reflect.Method;
 @RestrictTo(LIBRARY_GROUP)
 public class WindowUtils {
 
-  private static final String TAG = WindowUtils.class.getSimpleName();
-
   private WindowUtils() {}
 
   @NonNull
@@ -48,10 +43,8 @@ public class WindowUtils {
     WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       return Api30Impl.getCurrentWindowBounds(windowManager);
-    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      return Api17Impl.getCurrentWindowBounds(windowManager);
     } else {
-      return Api14Impl.getCurrentWindowBounds(windowManager);
+      return Api17Impl.getCurrentWindowBounds(windowManager);
     }
   }
 
@@ -79,41 +72,6 @@ public class WindowUtils {
       bounds.bottom = defaultDisplaySize.y;
 
       return bounds;
-    }
-  }
-
-  private static class Api14Impl {
-
-    @NonNull
-    static Rect getCurrentWindowBounds(@NonNull WindowManager windowManager) {
-      Display defaultDisplay = windowManager.getDefaultDisplay();
-      Point defaultDisplaySize = getRealSizeForDisplay(defaultDisplay);
-
-      Rect bounds = new Rect();
-      if (defaultDisplaySize.x == 0 || defaultDisplaySize.y == 0) {
-        defaultDisplay.getRectSize(bounds);
-      } else {
-        bounds.right = defaultDisplaySize.x;
-        bounds.bottom = defaultDisplaySize.y;
-      }
-
-      return bounds;
-    }
-
-    private static Point getRealSizeForDisplay(Display display) {
-      Point size = new Point();
-      try {
-        Method getRealSizeMethod = Display.class.getDeclaredMethod("getRealSize", Point.class);
-        getRealSizeMethod.setAccessible(true);
-        getRealSizeMethod.invoke(display, size);
-      } catch (NoSuchMethodException e) {
-        Log.w(TAG, e);
-      } catch (IllegalAccessException e) {
-        Log.w(TAG, e);
-      } catch (InvocationTargetException e) {
-        Log.w(TAG, e);
-      }
-      return size;
     }
   }
 }

--- a/lib/java/com/google/android/material/internal/WindowUtils.java
+++ b/lib/java/com/google/android/material/internal/WindowUtils.java
@@ -57,7 +57,6 @@ public class WindowUtils {
     }
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
   private static class Api17Impl {
 
     @NonNull

--- a/lib/java/com/google/android/material/navigation/NavigationView.java
+++ b/lib/java/com/google/android/material/navigation/NavigationView.java
@@ -33,7 +33,6 @@ import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.InsetDrawable;
 import android.graphics.drawable.RippleDrawable;
-import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
@@ -473,11 +472,7 @@ public class NavigationView extends ScrimInsetsFrameLayout implements MaterialBa
   protected void onDetachedFromWindow() {
     super.onDetachedFromWindow();
 
-    if (Build.VERSION.SDK_INT < 16) {
-      getViewTreeObserver().removeGlobalOnLayoutListener(onGlobalLayoutListener);
-    } else {
-      getViewTreeObserver().removeOnGlobalLayoutListener(onGlobalLayoutListener);
-    }
+    getViewTreeObserver().removeOnGlobalLayoutListener(onGlobalLayoutListener);
 
     ViewParent parent = getParent();
     if (parent instanceof DrawerLayout) {

--- a/lib/java/com/google/android/material/progressindicator/AnimatorDurationScaleProvider.java
+++ b/lib/java/com/google/android/material/progressindicator/AnimatorDurationScaleProvider.java
@@ -18,12 +18,9 @@ package com.google.android.material.progressindicator;
 import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
 import android.content.ContentResolver;
-import android.os.Build.VERSION;
 import android.provider.Settings.Global;
-import android.provider.Settings.System;
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
-import androidx.annotation.VisibleForTesting;
 
 /**
  * This is a utility class to get system animator duration scale from the system settings. It's used
@@ -34,29 +31,8 @@ import androidx.annotation.VisibleForTesting;
 @RestrictTo(LIBRARY_GROUP)
 public class AnimatorDurationScaleProvider {
 
-  /** The emulated system animator duration scale setting for SDK_INT < 16. */
-  private static float defaultSystemAnimatorDurationScale = 1f;
-
   /** Returns the animator duration scale from developer options setting. */
   public float getSystemAnimatorDurationScale(@NonNull ContentResolver contentResolver) {
-    if (VERSION.SDK_INT >= 17) {
-      return Global.getFloat(contentResolver, Global.ANIMATOR_DURATION_SCALE, 1f);
-    }
-    if (VERSION.SDK_INT == 16) {
-      return System.getFloat(contentResolver, System.ANIMATOR_DURATION_SCALE, 1f);
-    }
-    return defaultSystemAnimatorDurationScale;
-  }
-
-  /**
-   * Sets the default system animator duration scale for SDK < 16.
-   *
-   * @param scale New system animator duration scale.
-   * @see android.provider.Settings.Global#ANIMATOR_DURATION_SCALE
-   * @see android.provider.Settings.System#ANIMATOR_DURATION_SCALE
-   */
-  @VisibleForTesting
-  public static void setDefaultSystemAnimatorDurationScale(float scale) {
-    defaultSystemAnimatorDurationScale = scale;
+    return Global.getFloat(contentResolver, Global.ANIMATOR_DURATION_SCALE, 1f);
   }
 }

--- a/lib/java/com/google/android/material/progressindicator/DrawableWithAnimatedVisibilityChange.java
+++ b/lib/java/com/google/android/material/progressindicator/DrawableWithAnimatedVisibilityChange.java
@@ -24,7 +24,6 @@ import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.Drawable;
-import android.os.Build.VERSION;
 import android.util.Property;
 import androidx.annotation.FloatRange;
 import androidx.annotation.IntRange;
@@ -301,7 +300,7 @@ abstract class DrawableWithAnimatedVisibilityChange extends Drawable implements 
       return changed;
     }
 
-    if (restart || VERSION.SDK_INT < 19 || !animatorInAction.isPaused()) {
+    if (restart || !animatorInAction.isPaused()) {
       // Starts/restarts the animator if requested or not eligible to resume.
       animatorInAction.start();
     } else {

--- a/lib/java/com/google/android/material/resources/MaterialResources.java
+++ b/lib/java/com/google/android/material/resources/MaterialResources.java
@@ -26,7 +26,6 @@ import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.TintTypedArray;
@@ -69,15 +68,6 @@ public class MaterialResources {
       }
     }
 
-    // Reading a single color with getColorStateList() on API 15 and below doesn't always correctly
-    // read the value. Instead we'll first try to read the color directly here.
-    if (VERSION.SDK_INT <= VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
-      int color = attributes.getColor(index, -1);
-      if (color != -1) {
-        return ColorStateList.valueOf(color);
-      }
-    }
-
     return attributes.getColorStateList(index);
   }
 
@@ -95,15 +85,6 @@ public class MaterialResources {
         if (value != null) {
           return value;
         }
-      }
-    }
-
-    // Reading a single color with getColorStateList() on API 15 and below doesn't always correctly
-    // read the value. Instead we'll first try to read the color directly here.
-    if (VERSION.SDK_INT <= VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
-      int color = attributes.getColor(index, -1);
-      if (color != -1) {
-        return ColorStateList.valueOf(color);
       }
     }
 

--- a/lib/java/com/google/android/material/search/SearchBar.java
+++ b/lib/java/com/google/android/material/search/SearchBar.java
@@ -343,9 +343,7 @@ public class SearchBar extends Toolbar {
   public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
     super.onInitializeAccessibilityNodeInfo(info);
     info.setClassName(EditText.class.getCanonicalName());
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
-      info.setEditable(isEnabled());
-    }
+    info.setEditable(isEnabled());
 
     CharSequence text = getText();
     boolean isTextEmpty = TextUtils.isEmpty(text);

--- a/lib/java/com/google/android/material/search/SearchView.java
+++ b/lib/java/com/google/android/material/search/SearchView.java
@@ -937,7 +937,7 @@ public class SearchView extends FrameLayout
   public void setModalForAccessibility(boolean isSearchViewModal) {
     ViewGroup rootView = (ViewGroup) this.getRootView();
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && isSearchViewModal) {
+    if (isSearchViewModal) {
       childImportantForAccessibilityMap = new HashMap<>(rootView.getChildCount());
     }
     updateChildImportantForAccessibility(rootView, isSearchViewModal);
@@ -982,9 +982,7 @@ public class SearchView extends FrameLayout
         }
       } else {
         // Saves the important for accessibility value of the child view.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-          childImportantForAccessibilityMap.put(child, child.getImportantForAccessibility());
-        }
+        childImportantForAccessibilityMap.put(child, child.getImportantForAccessibility());
 
         ViewCompat.setImportantForAccessibility(
             child, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);

--- a/lib/java/com/google/android/material/shape/ShapeAppearancePathProvider.java
+++ b/lib/java/com/google/android/material/shape/ShapeAppearancePathProvider.java
@@ -24,10 +24,8 @@ import android.graphics.Path.Direction;
 import android.graphics.Path.Op;
 import android.graphics.PointF;
 import android.graphics.RectF;
-import android.os.Build.VERSION_CODES;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.UiThread;
 
@@ -227,7 +225,6 @@ public class ShapeAppearancePathProvider {
     }
   }
 
-  @RequiresApi(VERSION_CODES.KITKAT)
   private boolean pathOverlapsCorner(Path edgePath, int index) {
     cornerPath.reset();
     cornerPaths[index].applyToPath(cornerTransforms[index], cornerPath);

--- a/lib/java/com/google/android/material/shape/ShapeAppearancePathProvider.java
+++ b/lib/java/com/google/android/material/shape/ShapeAppearancePathProvider.java
@@ -24,7 +24,6 @@ import android.graphics.Path.Direction;
 import android.graphics.Path.Op;
 import android.graphics.PointF;
 import android.graphics.RectF;
-import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -139,7 +138,7 @@ public class ShapeAppearancePathProvider {
     overlappedEdgePath.close();
 
     // Union with the edge paths that had an intersection to handle overlaps.
-    if (VERSION.SDK_INT >= VERSION_CODES.KITKAT && !overlappedEdgePath.isEmpty()) {
+    if (!overlappedEdgePath.isEmpty()) {
       path.op(overlappedEdgePath, Op.UNION);
     }
   }
@@ -202,7 +201,6 @@ public class ShapeAppearancePathProvider {
     shapePath.applyToPath(edgeTransforms[index], edgePath);
 
     if (edgeIntersectionCheckEnabled
-        && VERSION.SDK_INT >= VERSION_CODES.KITKAT
         && (edgeTreatment.forceIntersection()
             || pathOverlapsCorner(edgePath, index)
             || pathOverlapsCorner(edgePath, nextIndex))) {

--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -1036,7 +1036,7 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
           public void onAnimationUpdate(@NonNull ValueAnimator animator) {
             int currentAnimatedIntValue = (int) animator.getAnimatedValue();
             if (USE_OFFSET_API) {
-              // On JB/KK versions of the platform sometimes View.setTranslationY does not
+              // On KitKat versions of the platform sometimes View.setTranslationY does not
               // result in layout / draw pass
               ViewCompat.offsetTopAndBottom(
                   view, currentAnimatedIntValue - previousAnimatedIntValue);
@@ -1074,7 +1074,7 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
           public void onAnimationUpdate(@NonNull ValueAnimator animator) {
             int currentAnimatedIntValue = (int) animator.getAnimatedValue();
             if (USE_OFFSET_API) {
-              // On JB/KK versions of the platform sometimes View.setTranslationY does not
+              // On KitKat versions of the platform sometimes View.setTranslationY does not
               // result in layout / draw pass
               ViewCompat.offsetTopAndBottom(
                   view, currentAnimatedIntValue - previousAnimatedIntValue);

--- a/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
+++ b/lib/java/com/google/android/material/snackbar/BaseTransientBottomBar.java
@@ -239,12 +239,10 @@ public abstract class BaseTransientBottomBar<B extends BaseTransientBottomBar<B>
   static final int MSG_SHOW = 0;
   static final int MSG_DISMISS = 1;
 
-  // On JB/KK versions of the platform sometimes View.setTranslationY does not result in
-  // layout / draw pass, and CoordinatorLayout relies on a draw pass to happen to sync vertical
+  // On KK sometimes View.setTranslationY does not result in  layout / draw pass,
+  // and CoordinatorLayout relies on a draw pass to happen to sync vertical
   // positioning of all its child views
-  private static final boolean USE_OFFSET_API =
-      (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN)
-          && (Build.VERSION.SDK_INT <= VERSION_CODES.KITKAT);
+  private static final boolean USE_OFFSET_API = Build.VERSION.SDK_INT == VERSION_CODES.KITKAT;
 
   private static final int[] SNACKBAR_STYLE_ATTR = new int[] {R.attr.snackbarStyle};
 

--- a/lib/java/com/google/android/material/tabs/TabLayout.java
+++ b/lib/java/com/google/android/material/tabs/TabLayout.java
@@ -1442,7 +1442,7 @@ public class TabLayout extends HorizontalScrollView {
   /**
    * Sets the ripple color for this TabLayout.
    *
-   * <p>When running on devices with KitKat or below, we draw this color as a filled overlay rather
+   * <p>When running on devices with KitKat, we draw this color as a filled overlay rather
    * than a ripple.
    *
    * @param color color (or ColorStateList) to use for the ripple
@@ -1464,7 +1464,7 @@ public class TabLayout extends HorizontalScrollView {
   /**
    * Sets the ripple color resource for this TabLayout.
    *
-   * <p>When running on devices with KitKat or below, we draw this color as a filled overlay rather
+   * <p>When running on devices with KitKat, we draw this color as a filled overlay rather
    * than a ripple.
    *
    * @param tabRippleColorResourceId A color resource to use as ripple color.

--- a/lib/java/com/google/android/material/tabs/TabLayout.java
+++ b/lib/java/com/google/android/material/tabs/TabLayout.java
@@ -57,7 +57,6 @@ import android.view.SoundEffectConstants;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
-import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.FrameLayout;
 import android.widget.HorizontalScrollView;
@@ -2656,11 +2655,6 @@ public class TabLayout extends HorizontalScrollView {
       final boolean changed = isSelected() != selected;
 
       super.setSelected(selected);
-
-      if (changed && selected && Build.VERSION.SDK_INT < 16) {
-        // Pre-JB we need to manually send the TYPE_VIEW_SELECTED event
-        sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_SELECTED);
-      }
 
       // Always dispatch this to the child views, regardless of whether the value has
       // changed

--- a/lib/java/com/google/android/material/textfield/CutoutDrawable.java
+++ b/lib/java/com/google/android/material/textfield/CutoutDrawable.java
@@ -18,17 +18,11 @@ package com.google.android.material.textfield;
 
 import android.annotation.TargetApi;
 import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.graphics.Paint.Style;
-import android.graphics.PorterDuff.Mode;
-import android.graphics.PorterDuffXfermode;
 import android.graphics.RectF;
 import android.graphics.Region.Op;
 import android.graphics.drawable.Drawable;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
-import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.material.shape.MaterialShapeDrawable;
@@ -48,9 +42,7 @@ class CutoutDrawable extends MaterialShapeDrawable {
   }
 
   private static CutoutDrawable create(@NonNull CutoutDrawableState drawableState) {
-    return VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2
-        ? new ImplApi18(drawableState)
-        : new ImplApi14(drawableState);
+    return new ImplApi18(drawableState);
   }
 
   private CutoutDrawable(@NonNull CutoutDrawableState drawableState) {
@@ -111,75 +103,6 @@ class CutoutDrawable extends MaterialShapeDrawable {
         super.drawStrokeShape(canvas);
         canvas.restore();
       }
-    }
-  }
-
-  // Workaround: Canvas.clipRect() had a bug before API 18 - bound.left didn't work correctly
-  //             with Region.Op.DIFFERENCE. "Paints out" the cutout area instead on lower APIs.
-  private static class ImplApi14 extends CutoutDrawable {
-    private Paint cutoutPaint;
-    private int savedLayer;
-
-    ImplApi14(@NonNull CutoutDrawableState drawableState) {
-      super(drawableState);
-    }
-
-    @Override
-    public void draw(@NonNull Canvas canvas) {
-      preDraw(canvas);
-      super.draw(canvas);
-      postDraw(canvas);
-    }
-
-    @Override
-    protected void drawStrokeShape(@NonNull Canvas canvas) {
-      super.drawStrokeShape(canvas);
-      canvas.drawRect(drawableState.cutoutBounds, getCutoutPaint());
-    }
-
-    private Paint getCutoutPaint() {
-      if (cutoutPaint == null) {
-        cutoutPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-        cutoutPaint.setStyle(Style.FILL_AND_STROKE);
-        cutoutPaint.setColor(Color.WHITE);
-        cutoutPaint.setXfermode(new PorterDuffXfermode(Mode.DST_OUT));
-      }
-      return cutoutPaint;
-    }
-
-    private void preDraw(@NonNull Canvas canvas) {
-      Callback callback = getCallback();
-
-      if (useHardwareLayer(callback)) {
-        View viewCallback = (View) callback;
-        // Make sure we're using a hardware layer.
-        if (viewCallback.getLayerType() != View.LAYER_TYPE_HARDWARE) {
-          viewCallback.setLayerType(View.LAYER_TYPE_HARDWARE, null);
-        }
-      } else {
-        // If we're not using a hardware layer, save the canvas layer.
-        saveCanvasLayer(canvas);
-      }
-    }
-
-    private void saveCanvasLayer(@NonNull Canvas canvas) {
-      if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
-        savedLayer = canvas.saveLayer(0, 0, canvas.getWidth(), canvas.getHeight(), null);
-      } else {
-        savedLayer =
-            canvas.saveLayer(
-                0, 0, canvas.getWidth(), canvas.getHeight(), null, Canvas.ALL_SAVE_FLAG);
-      }
-    }
-
-    private void postDraw(@NonNull Canvas canvas) {
-      if (!useHardwareLayer(getCallback())) {
-        canvas.restoreToCount(savedLayer);
-      }
-    }
-
-    private boolean useHardwareLayer(Callback callback) {
-      return callback instanceof View;
     }
   }
 

--- a/lib/java/com/google/android/material/textfield/CutoutDrawable.java
+++ b/lib/java/com/google/android/material/textfield/CutoutDrawable.java
@@ -16,7 +16,6 @@
 
 package com.google.android.material.textfield;
 
-import android.annotation.TargetApi;
 import android.graphics.Canvas;
 import android.graphics.RectF;
 import android.graphics.Region.Op;
@@ -82,7 +81,6 @@ class CutoutDrawable extends MaterialShapeDrawable {
     setCutout(0, 0, 0, 0);
   }
 
-  @TargetApi(VERSION_CODES.JELLY_BEAN_MR2)
   private static class ImplApi18 extends CutoutDrawable {
     ImplApi18(@NonNull CutoutDrawableState drawableState) {
       super(drawableState);

--- a/lib/java/com/google/android/material/textfield/IndicatorViewController.java
+++ b/lib/java/com/google/android/material/textfield/IndicatorViewController.java
@@ -29,8 +29,6 @@ import android.animation.TimeInterpolator;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Typeface;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import androidx.appcompat.widget.AppCompatTextView;
 import android.text.TextUtils;
 import android.view.View;
@@ -493,9 +491,7 @@ final class IndicatorViewController {
     if (enabled) {
       errorView = new AppCompatTextView(context);
       errorView.setId(R.id.textinput_error);
-      if (VERSION.SDK_INT >= 17) {
-        errorView.setTextAlignment(View.TEXT_ALIGNMENT_VIEW_START);
-      }
+      errorView.setTextAlignment(View.TEXT_ALIGNMENT_VIEW_START);
       if (typeface != null) {
         errorView.setTypeface(typeface);
       }
@@ -535,9 +531,7 @@ final class IndicatorViewController {
     if (enabled) {
       helperTextView = new AppCompatTextView(context);
       helperTextView.setId(R.id.textinput_helper_text);
-      if (VERSION.SDK_INT >= 17) {
-        helperTextView.setTextAlignment(View.TEXT_ALIGNMENT_VIEW_START);
-      }
+      helperTextView.setTextAlignment(View.TEXT_ALIGNMENT_VIEW_START);
       if (typeface != null) {
         helperTextView.setTypeface(typeface);
       }
@@ -547,20 +541,18 @@ final class IndicatorViewController {
       setHelperTextAppearance(helperTextTextAppearance);
       setHelperTextViewTextColor(helperTextViewTextColor);
       addIndicator(helperTextView, HELPER_INDEX);
-      if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
-        helperTextView.setAccessibilityDelegate(
-            new AccessibilityDelegate() {
-              @Override
-              public void onInitializeAccessibilityNodeInfo(
-                  View view, AccessibilityNodeInfo accessibilityNodeInfo) {
-                super.onInitializeAccessibilityNodeInfo(view, accessibilityNodeInfo);
-                View editText = textInputView.getEditText();
-                if (editText != null) {
-                  accessibilityNodeInfo.setLabeledBy(editText);
-                }
+      helperTextView.setAccessibilityDelegate(
+          new AccessibilityDelegate() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(
+                View view, AccessibilityNodeInfo accessibilityNodeInfo) {
+              super.onInitializeAccessibilityNodeInfo(view, accessibilityNodeInfo);
+              View editText = textInputView.getEditText();
+              if (editText != null) {
+                accessibilityNodeInfo.setLabeledBy(editText);
               }
-            });
-      }
+            }
+          });
     } else {
       hideHelperText();
       removeIndicator(helperTextView, HELPER_INDEX);

--- a/lib/java/com/google/android/material/textfield/MaterialAutoCompleteTextView.java
+++ b/lib/java/com/google/android/material/textfield/MaterialAutoCompleteTextView.java
@@ -162,7 +162,7 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
             Object selectedItem =
                 position < 0 ? modalListPopup.getSelectedItem() : getAdapter().getItem(position);
 
-            updateText(selectedItem);
+            setText(convertSelectionToString(selectedItem), false);
 
             OnItemClickListener userOnItemClickListener = getOnItemClickListener();
             if (userOnItemClickListener != null) {
@@ -521,18 +521,6 @@ public class MaterialAutoCompleteTextView extends AppCompatAutoCompleteTextView 
       parent = parent.getParent();
     }
     return null;
-  }
-
-  @SuppressWarnings("unchecked")
-  private <T extends ListAdapter & Filterable> void updateText(Object selectedItem) {
-    if (VERSION.SDK_INT >= 17) {
-      setText(convertSelectionToString(selectedItem), false);
-    } else {
-      ListAdapter adapter = getAdapter();
-      setAdapter(null);
-      setText(convertSelectionToString(selectedItem));
-      setAdapter((T) adapter);
-    }
   }
 
   /** ArrayAdapter for the {@link MaterialAutoCompleteTextView}. */

--- a/lib/java/com/google/android/material/textfield/TextInputEditText.java
+++ b/lib/java/com/google/android/material/textfield/TextInputEditText.java
@@ -25,6 +25,7 @@ import android.content.res.TypedArray;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import androidx.appcompat.widget.AppCompatEditText;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -210,7 +211,7 @@ public class TextInputEditText extends AppCompatEditText {
 
     // In APIs < 23, some things set in the parent TextInputLayout's AccessibilityDelegate get
     // overwritten, so we set them here so that announcements are as expected.
-    if (VERSION.SDK_INT < 23 && layout != null) {
+    if (VERSION.SDK_INT < VERSION_CODES.M && layout != null) {
       info.setText(getAccessibilityNodeInfoText(layout));
     }
   }

--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -722,11 +722,7 @@ public class TextInputLayout extends LinearLayout implements OnGlobalLayoutListe
 
   @Override
   public void onGlobalLayout() {
-    if (VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN) {
-      endLayout.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-    } else {
-      endLayout.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-    }
+    endLayout.getViewTreeObserver().removeOnGlobalLayoutListener(this);
     globalLayoutListenerAdded = false;
     boolean updatedHeight = updateEditTextHeightBasedOnIcon();
     boolean updatedIcon = updateDummyDrawables();
@@ -2532,9 +2528,7 @@ public class TextInputLayout extends LinearLayout implements OnGlobalLayoutListe
       TransitionManager.beginDelayedTransition(inputFrame, placeholderFadeIn);
       placeholderTextView.setVisibility(VISIBLE);
       placeholderTextView.bringToFront();
-      if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
-        announceForAccessibility(placeholderText);
-      }
+      announceForAccessibility(placeholderText);
     }
   }
 
@@ -2989,8 +2983,7 @@ public class TextInputLayout extends LinearLayout implements OnGlobalLayoutListe
   }
 
   private boolean isSingleLineFilledTextField() {
-    return boxBackgroundMode == BOX_BACKGROUND_FILLED
-        && (VERSION.SDK_INT < 16 || editText.getMinLines() <= 1);
+    return boxBackgroundMode == BOX_BACKGROUND_FILLED && editText.getMinLines() <= 1;
   }
 
   /*
@@ -4592,7 +4585,7 @@ public class TextInputLayout extends LinearLayout implements OnGlobalLayoutListe
       }
 
       if (!TextUtils.isEmpty(hint)) {
-        if (VERSION.SDK_INT >= 26) {
+        if (VERSION.SDK_INT >= VERSION_CODES.O) {
           info.setHintText(hint);
         } else {
           // Due to a TalkBack bug, setHintText has no effect in APIs < 26 so we append the hint to
@@ -4611,11 +4604,9 @@ public class TextInputLayout extends LinearLayout implements OnGlobalLayoutListe
         info.setError(showingError ? errorText : counterOverflowDesc);
       }
 
-      if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
-        View helperTextView = layout.indicatorViewController.getHelperTextView();
-        if (helperTextView != null) {
-          info.setLabelFor(helperTextView);
-        }
+      View helperTextView = layout.indicatorViewController.getHelperTextView();
+      if (helperTextView != null) {
+        info.setLabelFor(helperTextView);
       }
 
       layout.endLayout.getEndIconDelegate().onInitializeAccessibilityNodeInfo(host, info);

--- a/lib/java/com/google/android/material/theme/res/values/themes_base.xml
+++ b/lib/java/com/google/android/material/theme/res/values/themes_base.xml
@@ -223,7 +223,7 @@
     <!-- Default Framework Text styles. -->
     <item name="android:textAppearanceListItem">?attr/textAppearanceTitleMedium</item>
     <item name="android:textAppearanceListItemSmall">?attr/textAppearanceTitleMedium</item>
-    <item name="android:textAppearanceListItemSecondary" tools:targetApi="21">?attr/textAppearanceBodyMedium</item>
+    <item name="android:textAppearanceListItemSecondary" tools:targetApi="lollipop">?attr/textAppearanceBodyMedium</item>
     <item name="textAppearanceListItem">?attr/textAppearanceTitleMedium</item>
     <item name="textAppearanceListItemSmall">?attr/textAppearanceTitleMedium</item>
     <item name="textAppearanceListItemSecondary">?attr/textAppearanceBodyMedium</item>
@@ -488,7 +488,7 @@
     <!-- Default Framework Text styles. -->
     <item name="android:textAppearanceListItem">?attr/textAppearanceTitleMedium</item>
     <item name="android:textAppearanceListItemSmall">?attr/textAppearanceTitleMedium</item>
-    <item name="android:textAppearanceListItemSecondary" tools:targetApi="21">?attr/textAppearanceBodyMedium</item>
+    <item name="android:textAppearanceListItemSecondary" tools:targetApi="lollipop">?attr/textAppearanceBodyMedium</item>
     <item name="textAppearanceListItem">?attr/textAppearanceTitleMedium</item>
     <item name="textAppearanceListItemSmall">?attr/textAppearanceTitleMedium</item>
     <item name="textAppearanceListItemSecondary">?attr/textAppearanceBodyMedium</item>

--- a/lib/java/com/google/android/material/transformation/FabTransformationSheetBehavior.java
+++ b/lib/java/com/google/android/material/transformation/FabTransformationSheetBehavior.java
@@ -18,7 +18,6 @@ package com.google.android.material.transformation;
 import com.google.android.material.R;
 
 import android.content.Context;
-import android.os.Build;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.View;
@@ -88,7 +87,7 @@ public class FabTransformationSheetBehavior extends FabTransformationBehavior {
 
     CoordinatorLayout parent = (CoordinatorLayout) viewParent;
     final int childCount = parent.getChildCount();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && expanded) {
+    if (expanded) {
       importantForAccessibilityMap = new HashMap<>(childCount);
     }
 
@@ -112,9 +111,7 @@ public class FabTransformationSheetBehavior extends FabTransformationBehavior {
         }
       } else {
         // Saves the important for accessibility value of the child view.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-          importantForAccessibilityMap.put(child, child.getImportantForAccessibility());
-        }
+        importantForAccessibilityMap.put(child, child.getImportantForAccessibility());
 
         ViewCompat.setImportantForAccessibility(
             child, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);

--- a/lib/javatests/com/google/android/material/carousel/CarouselLayoutManagerRtlTest.java
+++ b/lib/javatests/com/google/android/material/carousel/CarouselLayoutManagerRtlTest.java
@@ -24,19 +24,16 @@ import static com.google.android.material.carousel.CarouselHelper.setAdapterItem
 import static com.google.android.material.carousel.CarouselHelper.setViewSize;
 import static com.google.android.material.testing.RtlTestUtils.applyRtlPseudoLocale;
 import static com.google.android.material.testing.RtlTestUtils.checkAppSupportsRtl;
-import static com.google.android.material.testing.RtlTestUtils.checkPlatformSupportsRtl;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
 import android.graphics.Rect;
 import android.graphics.RectF;
-import android.os.Build.VERSION_CODES;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.material.carousel.CarouselHelper.CarouselTestAdapter;
 import com.google.android.material.carousel.CarouselHelper.WrappedCarouselLayoutManager;
@@ -63,10 +60,8 @@ public class CarouselLayoutManagerRtlTest {
   WrappedCarouselLayoutManager layoutManager;
   CarouselTestAdapter adapter;
 
-  @RequiresApi(api = VERSION_CODES.JELLY_BEAN_MR1)
   @Before
   public void setUp() {
-    checkPlatformSupportsRtl();
     checkAppSupportsRtl();
     applyRtlPseudoLocale();
     createAndSetFixtures(DEFAULT_RECYCLER_VIEW_WIDTH, DEFAULT_ITEM_WIDTH);

--- a/lib/javatests/com/google/android/material/datepicker/CalendarStyleTest.java
+++ b/lib/javatests/com/google/android/material/datepicker/CalendarStyleTest.java
@@ -19,13 +19,11 @@ import com.google.android.material.test.R;
 
 import static org.junit.Assert.assertEquals;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.InsetDrawable;
 import android.graphics.drawable.LayerDrawable;
-import android.os.Build.VERSION_CODES;
 import androidx.appcompat.app.AppCompatActivity;
 import android.widget.TextView;
 import androidx.test.core.app.ApplicationProvider;
@@ -74,7 +72,6 @@ public class CalendarStyleTest {
   }
 
   @Test
-  @TargetApi(VERSION_CODES.KITKAT)
   public void testShapeStyling() {
     calendarStyle.day.styleItem(textView);
     Drawable backgroundDrawable;

--- a/lib/javatests/com/google/android/material/datepicker/CalendarStyleTest.java
+++ b/lib/javatests/com/google/android/material/datepicker/CalendarStyleTest.java
@@ -25,7 +25,6 @@ import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.InsetDrawable;
 import android.graphics.drawable.LayerDrawable;
-import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import androidx.appcompat.app.AppCompatActivity;
 import android.widget.TextView;
@@ -77,9 +76,6 @@ public class CalendarStyleTest {
   @Test
   @TargetApi(VERSION_CODES.KITKAT)
   public void testShapeStyling() {
-    if (VERSION.SDK_INT < VERSION_CODES.KITKAT) {
-      return;
-    }
     calendarStyle.day.styleItem(textView);
     Drawable backgroundDrawable;
     InsetDrawable drawableWrapper = (InsetDrawable) textView.getBackground();

--- a/lib/javatests/com/google/android/material/sidesheet/SideSheetBehaviorTest.java
+++ b/lib/javatests/com/google/android/material/sidesheet/SideSheetBehaviorTest.java
@@ -25,7 +25,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.annotation.TargetApi;
-import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Looper;
@@ -156,9 +155,6 @@ public class SideSheetBehaviorTest {
   @TargetApi(VERSION_CODES.KITKAT)
   @Test
   public void setAccessibilityPaneTitle_ofDefaultSheet_customTitleIsUsed() {
-    if (VERSION.SDK_INT < VERSION_CODES.KITKAT) {
-      return;
-    }
     String defaultAccessibilityPaneTitle =
         String.valueOf(ViewCompat.getAccessibilityPaneTitle(sideSheet));
     shadowOf(Looper.getMainLooper()).idle();

--- a/lib/javatests/com/google/android/material/sidesheet/SideSheetBehaviorTest.java
+++ b/lib/javatests/com/google/android/material/sidesheet/SideSheetBehaviorTest.java
@@ -24,8 +24,6 @@ import static com.google.android.material.sidesheet.Sheet.STATE_SETTLING;
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-import android.annotation.TargetApi;
-import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Looper;
 import androidx.appcompat.app.AppCompatActivity;
@@ -152,7 +150,6 @@ public class SideSheetBehaviorTest {
     assertThat(sideSheet.getVisibility()).isEqualTo(View.VISIBLE);
   }
 
-  @TargetApi(VERSION_CODES.KITKAT)
   @Test
   public void setAccessibilityPaneTitle_ofDefaultSheet_customTitleIsUsed() {
     String defaultAccessibilityPaneTitle =

--- a/lib/javatests/com/google/android/material/slider/SliderKeyTestRtl.java
+++ b/lib/javatests/com/google/android/material/slider/SliderKeyTestRtl.java
@@ -19,7 +19,6 @@ package com.google.android.material.slider;
 import static android.os.Looper.getMainLooper;
 import static com.google.android.material.testing.RtlTestUtils.applyRtlPseudoLocale;
 import static com.google.android.material.testing.RtlTestUtils.checkAppSupportsRtl;
-import static com.google.android.material.testing.RtlTestUtils.checkPlatformSupportsRtl;
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -43,7 +42,6 @@ public final class SliderKeyTestRtl extends SliderKeyTestCommon {
   @RequiresApi(api = VERSION_CODES.JELLY_BEAN_MR1)
   @Before
   public void checkRtl() {
-    checkPlatformSupportsRtl();
     checkAppSupportsRtl();
   }
 

--- a/lib/javatests/com/google/android/material/slider/SliderKeyTestRtl.java
+++ b/lib/javatests/com/google/android/material/slider/SliderKeyTestRtl.java
@@ -22,10 +22,8 @@ import static com.google.android.material.testing.RtlTestUtils.checkAppSupportsR
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-import android.os.Build.VERSION_CODES;
 import android.view.KeyEvent;
 import android.view.View;
-import androidx.annotation.RequiresApi;
 import com.google.android.material.slider.KeyUtils.KeyEventBuilder;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,13 +37,11 @@ import org.robolectric.RobolectricTestRunner;
 @org.junit.Ignore("(b/265311943) Fix RTL support for Robolectric tests.")
 public final class SliderKeyTestRtl extends SliderKeyTestCommon {
 
-  @RequiresApi(api = VERSION_CODES.JELLY_BEAN_MR1)
   @Before
   public void checkRtl() {
     checkAppSupportsRtl();
   }
 
-  @RequiresApi(api = VERSION_CODES.JELLY_BEAN_MR1)
   @Override
   public void createSlider() {
     applyRtlPseudoLocale();

--- a/lib/javatests/com/google/android/material/testing/ResourceNameLookup.java
+++ b/lib/javatests/com/google/android/material/testing/ResourceNameLookup.java
@@ -17,6 +17,7 @@
 package com.google.android.material.testing;
 
 import android.annotation.TargetApi;
+import android.os.Build;
 import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Field;
 
@@ -32,7 +33,7 @@ public final class ResourceNameLookup {
   private ResourceNameLookup() {}
 
   @SuppressWarnings("AndroidJdkLibsChecker")
-  @TargetApi(24)
+  @TargetApi(Build.VERSION_CODES.N)
   public static ImmutableMap<Integer, String> createResourceNameMap(Class<?>... resourceClasses) {
     ImmutableMap.Builder<Integer, String> resNameMapBuilder =
         ImmutableMap.<Integer, String>builder();

--- a/lib/javatests/com/google/android/material/testing/RtlTestUtils.java
+++ b/lib/javatests/com/google/android/material/testing/RtlTestUtils.java
@@ -16,7 +16,6 @@
 
 package com.google.android.material.testing;
 
-import static android.os.Build.VERSION.SDK_INT;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.annotation.SuppressLint;
@@ -36,10 +35,6 @@ public final class RtlTestUtils {
     boolean supportsRtl = (info.flags & ApplicationInfo.FLAG_SUPPORTS_RTL) != 0;
     assertThat(supportsRtl).isTrue();
     assertThat(info.targetSdkVersion).isGreaterThan(16);
-  }
-
-  public static void checkPlatformSupportsRtl() {
-    assertThat(SDK_INT).isGreaterThan(16);
   }
 
   public static void applyRtlPseudoLocale() {

--- a/testing/java/com/google/android/material/testapp/res/values/styles.xml
+++ b/testing/java/com/google/android/material/testapp/res/values/styles.xml
@@ -29,14 +29,14 @@
 
   <style name="Theme.TranslucentStatus"
     parent="Theme.AppCompat.Light.NoActionBar"
-    tools:targetApi="21">
+    tools:targetApi="lollipop">
     <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     <item name="android:statusBarColor">@android:color/transparent</item>
   </style>
 
   <style name="Theme.TranslucentNavBar"
     parent="Theme.AppCompat.Light.NoActionBar"
-    tools:targetApi="21">
+    tools:targetApi="lollipop">
     <item name="android:windowDrawsSystemBarBackgrounds">true</item>
   </style>
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -16,7 +16,7 @@ android {
   defaultConfig {
     testApplicationId "com.google.android.material.tests"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    minSdkVersion 14
+    minSdkVersion 19
     targetSdkVersion 33
   }
 

--- a/tests/javatests/com/google/android/material/animation/build.gradle
+++ b/tests/javatests/com/google/android/material/animation/build.gradle
@@ -30,7 +30,7 @@ android {
   defaultConfig {
     testApplicationId "com.google.android.material.tests"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    minSdkVersion 14
+    minSdkVersion 19
     targetSdkVersion 33
   }
 

--- a/tests/javatests/com/google/android/material/appbar/AppBarWithCollapsingToolbarTest.java
+++ b/tests/javatests/com/google/android/material/appbar/AppBarWithCollapsingToolbarTest.java
@@ -21,11 +21,9 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-import android.os.Build;
 import android.widget.ImageView;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.test.filters.LargeTest;
-import androidx.test.filters.SdkSuppress;
 import androidx.test.runner.AndroidJUnit4;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.testapp.R;
@@ -38,8 +36,6 @@ import org.junit.runner.RunWith;
 @SuppressWarnings("unchecked")
 public class AppBarWithCollapsingToolbarTest extends AppBarLayoutBaseTest {
   @Test
-  // Suppressed due to high % flakiness on API 15
-  @SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN)
   public void testPinnedToolbar() throws Throwable {
     configureContent(
         R.layout.design_appbar_toolbar_collapse_pin, R.string.design_appbar_collapsing_toolbar_pin);
@@ -161,8 +157,6 @@ public class AppBarWithCollapsingToolbarTest extends AppBarLayoutBaseTest {
   }
 
   @Test
-  // Suppressed due to high % flakiness on API 15
-  @SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN)
   public void testScrollingToolbar() throws Throwable {
     configureContent(
         R.layout.design_appbar_toolbar_collapse_scroll,

--- a/tests/javatests/com/google/android/material/navigation/NavigationViewTest.java
+++ b/tests/javatests/com/google/android/material/navigation/NavigationViewTest.java
@@ -732,11 +732,6 @@ public class NavigationViewTest {
 
   @Test
   public void testAccessibility() throws Throwable {
-    if (VERSION.SDK_INT < KITKAT) {
-      // CollectionInfo and CollectionItemInfo only available on API 19+.
-      return;
-    }
-
     // Open our drawer
     onView(withId(R.id.drawer_layout)).perform(openDrawer(GravityCompat.START));
 

--- a/tests/javatests/com/google/android/material/snackbar/CoordinatorSnackbarWithFabTest.java
+++ b/tests/javatests/com/google/android/material/snackbar/CoordinatorSnackbarWithFabTest.java
@@ -24,7 +24,6 @@ import static com.google.android.material.testutils.DesignViewActions.setVisibil
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import android.os.Build;
 import androidx.appcompat.widget.AppCompatTextView;
 import android.view.View;
 import android.view.ViewGroup;
@@ -86,19 +85,17 @@ public class CoordinatorSnackbarWithFabTest extends BaseDynamicCoordinatorLayout
    * Helper method that verifies that the passed view is above the snackbar in the activity window.
    */
   private static void verifySnackbarViewStacking(View view, int extraBottomMargin) {
-    if (Build.VERSION.SDK_INT >= 11) {
-      // Get location of snackbar in window
-      final int[] snackbarOnScreenXY = getSnackbarLocationOnScreen();
-      // Get location of passed view in window
-      final int[] viewOnScreenXY = new int[2];
-      view.getLocationOnScreen(viewOnScreenXY);
+    // Get location of snackbar in window
+    final int[] snackbarOnScreenXY = getSnackbarLocationOnScreen();
+    // Get location of passed view in window
+    final int[] viewOnScreenXY = new int[2];
+    view.getLocationOnScreen(viewOnScreenXY);
 
-      // Compute the bottom visible edge of the view
-      int viewBottom = viewOnScreenXY[1] + view.getHeight() - extraBottomMargin;
-      int snackbarTop = snackbarOnScreenXY[1];
-      // and verify that our view is above the snackbar
-      assertTrue(viewBottom <= snackbarTop);
-    }
+    // Compute the bottom visible edge of the view
+    int viewBottom = viewOnScreenXY[1] + view.getHeight() - extraBottomMargin;
+    int snackbarTop = snackbarOnScreenXY[1];
+    // and verify that our view is above the snackbar
+    assertTrue(viewBottom <= snackbarTop);
   }
 
   @Test

--- a/tests/javatests/com/google/android/material/tabs/TabLayoutTest.java
+++ b/tests/javatests/com/google/android/material/tabs/TabLayoutTest.java
@@ -364,7 +364,6 @@ public class TabLayoutTest {
     testSetScrollPosition(true);
   }
 
-  @SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN_MR1)
   @Test
   public void setScrollPositionRtl() throws Throwable {
     testSetScrollPosition(false);

--- a/tests/javatests/com/google/android/material/tabs/TabLayoutWithViewPagerTest.java
+++ b/tests/javatests/com/google/android/material/tabs/TabLayoutWithViewPagerTest.java
@@ -21,7 +21,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
-import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -30,19 +29,15 @@ import static com.google.android.material.testutils.TabLayoutActions.showBadgeOn
 import static com.google.android.material.testutils.ViewPagerActions.setAdapter;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 import android.content.res.Resources;
 import android.graphics.Color;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.util.Pair;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.FrameLayout;
 import android.widget.HorizontalScrollView;
 import android.widget.TextView;
 import androidx.annotation.DimenRes;
@@ -645,12 +640,6 @@ public class TabLayoutWithViewPagerTest {
                 isDescendantOfA(withId(R.id.tabs)),
                 not(withParent(isAssignableFrom(HorizontalScrollView.class))),
                 hasDescendant(withText(tabTitle)));
-        if (VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN_MR2) {
-          // Additional criteria is needed for Pre API-18 devices because an extra container
-          // FrameLayout was added for badging support.
-          tabMatcher = allOf(tabMatcher, not(withClassName(is(FrameLayout.class.getName()))));
-        }
-
         if (minTabWidth >= 0) {
           onView(tabMatcher).check(matches(TestUtilsMatchers.isNotNarrowerThan(minTabWidth)));
         }

--- a/tests/javatests/com/google/android/material/testutils/TestDrawable.java
+++ b/tests/javatests/com/google/android/material/testutils/TestDrawable.java
@@ -21,11 +21,9 @@ import androidx.annotation.ColorInt;
 
 /**
  * Custom drawable class that provides a reliable way for testing various tinting scenarios across a
- * range of platform versions. ColorDrawable doesn't support tinting on Kitkat, and
- * BitmapDrawable (PNG sources) appears to slightly alter green and blue channels by a few units on
- * some of the older platform versions (Gingerbread). Using GradientDrawable allows doing reliable
- * tests at the level of individual channels (alpha / red / green / blue) for tinted and untinted
- * icons in the testIconTinting method.
+ * range of platform versions. ColorDrawable doesn't support tinting on Kitkat. Using
+ * GradientDrawable allows doing reliable tests at the level of individual channels
+ * (alpha / red / green / blue) for tinted and untinted icons in the testIconTinting method.
  */
 public class TestDrawable extends GradientDrawable {
   private int width;

--- a/tests/javatests/com/google/android/material/testutils/TestDrawable.java
+++ b/tests/javatests/com/google/android/material/testutils/TestDrawable.java
@@ -21,7 +21,7 @@ import androidx.annotation.ColorInt;
 
 /**
  * Custom drawable class that provides a reliable way for testing various tinting scenarios across a
- * range of platform versions. ColorDrawable doesn't support tinting on Kitkat and below, and
+ * range of platform versions. ColorDrawable doesn't support tinting on Kitkat, and
  * BitmapDrawable (PNG sources) appears to slightly alter green and blue channels by a few units on
  * some of the older platform versions (Gingerbread). Using GradientDrawable allows doing reliable
  * tests at the level of individual channels (alpha / red / green / blue) for tinted and untinted

--- a/tests/javatests/com/google/android/material/textfield/TextInputLayoutPseudoLocaleTest.java
+++ b/tests/javatests/com/google/android/material/textfield/TextInputLayoutPseudoLocaleTest.java
@@ -21,7 +21,6 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -47,7 +46,6 @@ public class TextInputLayoutPseudoLocaleTest {
   private static final String ORIGINAL_LANGUAGE = Locale.getDefault().getLanguage();
   private static final String ORIGINAL_COUNTRY = Locale.getDefault().getLanguage();
 
-  @TargetApi(17)
   private static void setLocale(String language, String country, Context context) {
     context = context.getApplicationContext();
     Resources resources = context.getResources();

--- a/tests/javatests/com/google/android/material/textfield/TextInputLayoutPseudoLocaleTest.java
+++ b/tests/javatests/com/google/android/material/textfield/TextInputLayoutPseudoLocaleTest.java
@@ -26,7 +26,6 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import androidx.test.filters.MediumTest;
-import androidx.test.filters.SdkSuppress;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import com.google.android.material.testapp.R;
@@ -39,7 +38,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @MediumTest
-@SdkSuppress(minSdkVersion = 17) // Needed for Configuration#setLocale
 @RunWith(AndroidJUnit4.class)
 public class TextInputLayoutPseudoLocaleTest {
   @Rule

--- a/tests/javatests/com/google/android/material/theme/build.gradle
+++ b/tests/javatests/com/google/android/material/theme/build.gradle
@@ -38,7 +38,7 @@ android {
     multiDexEnabled true
     testApplicationId "com.google.android.material.tests"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    minSdkVersion 14
+    minSdkVersion 19
     targetSdkVersion 33
   }
 


### PR DESCRIPTION
Now that the minimum SDK version of Material Components is 19, there was a lot of code that could be simplified or removed.
