### PR TITLE
[Catalog][Search] search bar scrolls away with content

### DIFF
--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
@@ -46,7 +46,8 @@
         android:id="@+id/cat_search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint">
+        android:hint="@string/cat_searchbar_hint"
+        app:layout_scrollEffect="compress">
     </com.google.android.material.search.SearchBar>
   </com.google.android.material.appbar.AppBarLayout>
 

--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
@@ -43,7 +43,8 @@
         android:id="@+id/open_search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint">
+        android:hint="@string/cat_searchbar_hint"
+        app:layout_scrollEffect="compress">
     </com.google.android.material.search.SearchBar>
 
     <com.google.android.material.tabs.TabLayout


### PR DESCRIPTION
#3103 
The search bar scrolls away with content (#3852 or #3875) or remains fixed at the top of the screen (#3853 or #3868).
https://m3.material.io/components/search/guidelines#b340d738-9c8a-4258-876e-b4ac892616c1
![Screenshot_20231119_145626](https://github.com/material-components/material-components-android/assets/71050561/e57cc29c-a103-4665-8f82-2877d8e25105)
![Screenshot_20231124_130231](https://github.com/material-components/material-components-android/assets/71050561/ddf1ab51-1ed2-46a3-92cb-45b29ec75ca1)