### PR TITLE
[Catalog][Search] search bar remains fixed at top of screen

### DIFF
--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
@@ -46,7 +46,8 @@
         android:id="@+id/cat_search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint">
+        android:hint="@string/cat_searchbar_hint"
+        app:layout_scrollFlags="enterAlways">
     </com.google.android.material.search.SearchBar>
   </com.google.android.material.appbar.AppBarLayout>
 

--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
@@ -43,7 +43,8 @@
         android:id="@+id/open_search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint">
+        android:hint="@string/cat_searchbar_hint"
+        app:layout_scrollFlags="enterAlways">
     </com.google.android.material.search.SearchBar>
 
     <com.google.android.material.tabs.TabLayout


### PR DESCRIPTION
#3103
The search bar remains fixed at the top of the screen (#3853 or #3868) or scrolls away with content (#3852 or #3875).
https://m3.material.io/components/search/guidelines#b340d738-9c8a-4258-876e-b4ac892616c1
![Screenshot_20231119_150225](https://github.com/material-components/material-components-android/assets/71050561/cea524ef-0d5e-41a3-aaec-a0775cf7f7f7)
![Screenshot_20231124_130308](https://github.com/material-components/material-components-android/assets/71050561/bedd20da-4698-45ad-a97f-6910b1fcc56e)