### PR TITLE
[Slider] After slider in scrolling container is touched, label and state layer are displayed

### DIFF
--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -2357,10 +2357,19 @@ abstract class BaseSlider<
         }
 
         if (activeThumbIdx != -1) {
+          thumbIsPressed = true;
           snapTouchPosition();
           updateHaloHotspot();
-          activeThumbIdx = -1;
           onStopTrackingTouch();
+          postDelayed(() -> {
+            thumbIsPressed = false;
+            activeThumbIdx = -1;
+            invalidate();
+            setPressed(thumbIsPressed);
+          }, MotionUtils.resolveThemeDuration(
+              getContext(),
+              LABEL_ANIMATION_EXIT_DURATION_ATTR,
+              DEFAULT_LABEL_ANIMATION_EXIT_DURATION));
         }
         invalidate();
         break;


### PR DESCRIPTION
#3509

**After** you **touch** the slider that is in the scroll container, the label and the state layer appear.


**When** you **touch** the slider that is **not** in the scroll container, the label and the state layer appear. **When** you **drag** the slider, regardless of whether it is in the scroll container or not, the label and the state layer appear.

By deleting the following code, **after** you **touch** the slider, regardless of whether it is in the scroll container or not, the label and the state layer appear:
https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/slider/BaseSlider.java#L2320-L2324
```
thumbIsPressed = true;
snapTouchPosition();
updateHaloHotspot();
invalidate();
onStartTrackingTouch();
```