### PR TITLE
[Catalog][Search] search bar remains fixed at top of screen

### DIFF
--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
@@ -20,37 +20,40 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-  <androidx.core.widget.NestedScrollView
-      android:id="@+id/nested_scroll_view"
+  <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      app:layout_behavior="@string/appbar_scrolling_view_behavior">
+      android:orientation="vertical">
 
-    <TextView
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="16dp"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:lineSpacingMultiplier="1.2"
-        android:text="@string/cat_searchbar_lorem_ipsum"/>
-  </androidx.core.widget.NestedScrollView>
+        android:fitsSystemWindows="true">
 
-  <com.google.android.material.appbar.AppBarLayout
-      android:id="@+id/app_bar_layout"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:fitsSystemWindows="true"
-      app:liftOnScroll="false">
+      <com.google.android.material.search.SearchBar
+          android:id="@+id/cat_search_bar"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:hint="@string/cat_searchbar_hint">
+      </com.google.android.material.search.SearchBar>
+    </com.google.android.material.appbar.AppBarLayout>
 
-    <com.google.android.material.search.SearchBar
-        android:id="@+id/cat_search_bar"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/nested_scroll_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint"
-        app:layout_scrollFlags="enterAlways">
-    </com.google.android.material.search.SearchBar>
-  </com.google.android.material.appbar.AppBarLayout>
+        android:layout_height="match_parent">
+
+      <TextView
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:paddingBottom="16dp"
+          android:paddingLeft="16dp"
+          android:paddingRight="16dp"
+          android:lineSpacingMultiplier="1.2"
+          android:text="@string/cat_searchbar_lorem_ipsum"/>
+    </androidx.core.widget.NestedScrollView>
+  </LinearLayout>
 
   <com.google.android.material.search.SearchView
       android:id="@+id/cat_search_view"

--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
@@ -40,13 +40,15 @@
       android:id="@+id/app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:fitsSystemWindows="true">
+      android:fitsSystemWindows="true"
+      app:liftOnScroll="false">
 
     <com.google.android.material.search.SearchBar
         android:id="@+id/cat_search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint">
+        android:hint="@string/cat_searchbar_hint"
+        app:layout_scrollFlags="enterAlways">
     </com.google.android.material.search.SearchBar>
   </com.google.android.material.appbar.AppBarLayout>
 

--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
@@ -37,19 +37,20 @@
       android:id="@+id/app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:fitsSystemWindows="true">
+      android:fitsSystemWindows="true"
+      app:liftOnScroll="false">
 
     <com.google.android.material.search.SearchBar
         android:id="@+id/open_search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint">
+        android:hint="@string/cat_searchbar_hint"
+        app:layout_scrollFlags="enterAlways">
     </com.google.android.material.search.SearchBar>
 
     <com.google.android.material.tabs.TabLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@android:color/transparent">
+        android:layout_height="wrap_content">
 
       <com.google.android.material.tabs.TabItem
           android:text="@string/cat_searchbar_tabs_label_explore"

--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
@@ -21,48 +21,48 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-  <!-- Use AppBarLayout scrolling behavior instead of SearchBar
-       scrolling behavior since this demo uses an opaque AppBarLayout
-       and a non-floating SearchBar. -->
-  <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/recycler_view"
+  <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:paddingTop="8dp"
-      android:paddingBottom="8dp"
-      android:clipToPadding="false"
-      app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+      android:orientation="vertical">
 
-  <com.google.android.material.appbar.AppBarLayout
-      android:id="@+id/app_bar_layout"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:fitsSystemWindows="true"
-      app:liftOnScroll="false">
-
-    <com.google.android.material.search.SearchBar
-        android:id="@+id/open_search_bar"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint"
-        app:layout_scrollFlags="enterAlways">
-    </com.google.android.material.search.SearchBar>
+        android:fitsSystemWindows="true">
 
-    <com.google.android.material.tabs.TabLayout
+      <com.google.android.material.search.SearchBar
+          android:id="@+id/open_search_bar"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:hint="@string/cat_searchbar_hint">
+      </com.google.android.material.search.SearchBar>
+
+      <com.google.android.material.tabs.TabLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content">
+
+        <com.google.android.material.tabs.TabItem
+            android:text="@string/cat_searchbar_tabs_label_explore"
+            tools:ignore="RequiredSize"/>
+        <com.google.android.material.tabs.TabItem
+            android:text="@string/cat_searchbar_tabs_label_flights"
+            tools:ignore="RequiredSize"/>
+        <com.google.android.material.tabs.TabItem
+            android:text="@string/cat_searchbar_tabs_label_trips"
+            tools:ignore="RequiredSize"/>
+      </com.google.android.material.tabs.TabLayout>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-      <com.google.android.material.tabs.TabItem
-          android:text="@string/cat_searchbar_tabs_label_explore"
-          tools:ignore="RequiredSize"/>
-      <com.google.android.material.tabs.TabItem
-          android:text="@string/cat_searchbar_tabs_label_flights"
-          tools:ignore="RequiredSize"/>
-      <com.google.android.material.tabs.TabItem
-          android:text="@string/cat_searchbar_tabs_label_trips"
-          tools:ignore="RequiredSize"/>
-    </com.google.android.material.tabs.TabLayout>
-  </com.google.android.material.appbar.AppBarLayout>
+        android:layout_height="match_parent"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:clipToPadding="false"/>
+  </LinearLayout>
 
   <!-- Elevation needs to be greater than AppBarLayout's elevation;
        otherwise for some reason when the AppBarLayout's background


### PR DESCRIPTION
#3103
The search bar remains fixed at the top of the screen (#3868 or #3853) or scrolls away with content (#3852 or #3875).
https://m3.material.io/components/search/guidelines#b340d738-9c8a-4258-876e-b4ac892616c1
![Screenshot_20231124_113957](https://github.com/material-components/material-components-android/assets/71050561/60b095e2-3b7d-401f-bcf8-a9223a4fa913)
![Screenshot_20231124_114357](https://github.com/material-components/material-components-android/assets/71050561/8d691f97-dd75-4857-97b0-db52198d6277)