### PR TITLE
[Catalog][Search] search bar scrolls away with content

### DIFF
--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_fragment.xml
@@ -40,13 +40,15 @@
       android:id="@+id/app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:fitsSystemWindows="true">
+      android:fitsSystemWindows="true"
+      app:liftOnScroll="false">
 
     <com.google.android.material.search.SearchBar
         android:id="@+id/cat_search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint">
+        android:hint="@string/cat_searchbar_hint"
+        app:layout_scrollEffect="compress">
     </com.google.android.material.search.SearchBar>
   </com.google.android.material.appbar.AppBarLayout>
 

--- a/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
+++ b/catalog/java/io/material/catalog/search/res/layout/cat_search_recycler_fragment.xml
@@ -37,19 +37,20 @@
       android:id="@+id/app_bar_layout"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:fitsSystemWindows="true">
+      android:fitsSystemWindows="true"
+      app:liftOnScroll="false">
 
     <com.google.android.material.search.SearchBar
         android:id="@+id/open_search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/cat_searchbar_hint">
+        android:hint="@string/cat_searchbar_hint"
+        app:layout_scrollEffect="compress">
     </com.google.android.material.search.SearchBar>
 
     <com.google.android.material.tabs.TabLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@android:color/transparent">
+        android:layout_height="wrap_content">
 
       <com.google.android.material.tabs.TabItem
           android:text="@string/cat_searchbar_tabs_label_explore"


### PR DESCRIPTION
#3103 
The search bar scrolls away with content (#3875 or #3852) or remains fixed at the top of the screen (#3853 or #3868).
https://m3.material.io/components/search/guidelines#b340d738-9c8a-4258-876e-b4ac892616c1
![Screenshot_20231129_171224](https://github.com/material-components/material-components-android/assets/71050561/7e2eb267-d3ae-4af8-ac3f-e391791714e2)
![Screenshot_20231129_171239](https://github.com/material-components/material-components-android/assets/71050561/66bf3c1f-46a8-49ed-bdb8-3a69d0d0304b)