### PR TITLE
[Docs] Detailed description of code example for collapsing toolbar style

### DIFF
--- a/docs/components/TopAppBar.md
+++ b/docs/components/TopAppBar.md
@@ -496,6 +496,8 @@ In the layout:
 
             <com.google.android.material.appbar.MaterialToolbar
                 ...
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
                 android:elevation="0dp" />
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>
@@ -533,6 +535,8 @@ In the layout:
             android:layout_height="?attr/collapsingToolbarLayoutLargeSize">
 
             <com.google.android.material.appbar.MaterialToolbar
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
                 ...
                 android:elevation="0dp" />
 
@@ -580,6 +584,8 @@ In the layout:
                 android:contentDescription="@string/content_description_media" />
 
             <com.google.android.material.appbar.MaterialToolbar
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
                 ...
                 android:background="@android:color/transparent" />
 
@@ -623,6 +629,7 @@ In the layout:
 
             <com.google.android.material.appbar.MaterialToolbar
                 ...
+                android:layout_height="?attr/actionBarSize"
                 app:layout_collapseMode="pin"
                 />
 


### PR DESCRIPTION
I think it is necessary to add the specific `topAppBar` primary key description code to the code instance of collapsing toolbar style. Although this hint appeared in the normal toolbar style, it wasn't obvious enough that it took me hours to figure out what the problem was. Setting `layout_height` to another option causes the component to not work properly and the title to not display properly. Hopefully this new description will help others avoid this problem.

> ### Thanks for starting a pull request on Material Components!
> 
> #### Don't forget:
> 
> - [x] Identify the component the PR relates to in brackets in the title.
>   `[Buttons] Updated documentation`
> - [ ] Link to GitHub issues it solves. `closes #1234`
> - [x] Sign the CLA bot. You can do this once the pull request is opened.
> 
> [Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
> has more information and tips for a great pull request.
