### PR TITLE
[Tab] Skip calling ViewPager2#setCurrentItem() when the active page i…

### DIFF
--- a/lib/java/com/google/android/material/tabs/TabLayoutMediator.java
+++ b/lib/java/com/google/android/material/tabs/TabLayoutMediator.java
@@ -270,7 +270,9 @@ public final class TabLayoutMediator {
 
     @Override
     public void onTabSelected(@NonNull TabLayout.Tab tab) {
-      viewPager.setCurrentItem(tab.getPosition(), smoothScroll);
+      if (viewPager.getCurrentItem() != tab.getPosition()) {
+        viewPager.setCurrentItem(tab.getPosition(), smoothScroll);
+      }
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-android/issues/1865.

The current TabLayoutMediator implementation has an issue that it invokes ViewPager2#setCurrentItem() when a user navigates between pages by a swipe operation. The method call aborts the scrolling animation that the user made and starts a new scroll animation when smoothScroll = true, or stops scrolling immediately when smoothScroll = false.
Don't forget:

- [x] dentify the component the PR relates to in brackets in the title.
Link to GitHub issues it solves. (closes
- [x] https://github.com/material-components/material-components-android/issues/1865)
- [x] Sign the CLA bot. You can do this once the pull request is opened.