### PR TITLE
[DrawerLayout NavigationView] bugfix: submenu item checked state is not correctly persisted and restored when device changes configurations (e.g., on tablet rotation)

### DIFF
--- a/lib/java/com/google/android/material/internal/NavigationMenuPresenter.java
+++ b/lib/java/com/google/android/material/internal/NavigationMenuPresenter.java
@@ -731,8 +731,8 @@ public class NavigationMenuPresenter implements MenuPresenter {
                 if (subMenuItem.isCheckable()) {
                   subMenuItem.setExclusiveCheckable(false);
                 }
-                if (item.isChecked()) {
-                  setCheckedItem(item);
+                if (subMenuItem.isChecked()) {
+                  setCheckedItem(subMenuItem);
                 }
                 items.add(new NavigationMenuTextItem(subMenuItem));
               }


### PR DESCRIPTION
bugfix: submenu item checked state is not correctly persisted and restored when device changes configurations (e.g., on tablet rotation)

- `item` is the entire SubMenu, whereas `subMenuItem` is the individual item in the SubMenu