### PR TITLE
[ProgressIndicator] Fix corner radius calculation

### DIFF
--- a/catalog/java/io/material/catalog/progressindicator/ProgressIndicatorMainDemoFragment.java
+++ b/catalog/java/io/material/catalog/progressindicator/ProgressIndicatorMainDemoFragment.java
@@ -78,7 +78,7 @@ public class ProgressIndicatorMainDemoFragment extends ProgressIndicatorDemoFrag
     Slider thicknessSlider = view.findViewById(R.id.thicknessSlider);
     thicknessSlider.addOnChangeListener(
         (slider, value, fromUser) -> {
-          int newThickness = (int) (value * pixelsInDp);
+          int newThickness = Math.round(value * pixelsInDp);
           if (linearIndicator.getTrackThickness() != newThickness) {
             linearIndicator.setTrackThickness(newThickness);
           }
@@ -90,7 +90,7 @@ public class ProgressIndicatorMainDemoFragment extends ProgressIndicatorDemoFrag
     Slider cornerSlider = view.findViewById(R.id.cornerSlider);
     cornerSlider.addOnChangeListener(
         (slider, value, fromUser) -> {
-          int newCornerRadius = (int) (value * pixelsInDp);
+          int newCornerRadius = Math.round(value * pixelsInDp);
           if (linearIndicator.getTrackCornerRadius() != newCornerRadius) {
             linearIndicator.setTrackCornerRadius(newCornerRadius);
           }
@@ -102,7 +102,7 @@ public class ProgressIndicatorMainDemoFragment extends ProgressIndicatorDemoFrag
     Slider gapSlider = view.findViewById(R.id.gapSlider);
     gapSlider.addOnChangeListener(
         (slider, value, fromUser) -> {
-          int newGapSize = (int) (value * pixelsInDp);
+          int newGapSize = Math.round(value * pixelsInDp);
           if (linearIndicator.getIndicatorTrackGapSize() != newGapSize) {
             linearIndicator.setIndicatorTrackGapSize(newGapSize);
           }
@@ -123,7 +123,7 @@ public class ProgressIndicatorMainDemoFragment extends ProgressIndicatorDemoFrag
     Slider linearStopIndicatorSlider = view.findViewById(R.id.linearStopIndicatorSizeSlider);
     linearStopIndicatorSlider.addOnChangeListener(
         (slider, value, fromUser) -> {
-          int newStopIndicatorSize = (int) (value * pixelsInDp);
+          int newStopIndicatorSize = Math.round(value * pixelsInDp);
           if (linearIndicator.getTrackStopIndicatorSize() != newStopIndicatorSize) {
             linearIndicator.setTrackStopIndicatorSize(newStopIndicatorSize);
           }
@@ -132,7 +132,7 @@ public class ProgressIndicatorMainDemoFragment extends ProgressIndicatorDemoFrag
     Slider circularSizeSlider = view.findViewById(R.id.circularSizeSlider);
     circularSizeSlider.addOnChangeListener(
         (slider, value, fromUser) -> {
-          int newCornerRadius = (int) (value * pixelsInDp);
+          int newCornerRadius = Math.round(value * pixelsInDp);
           if (circularIndicator.getIndicatorSize() != newCornerRadius) {
             circularIndicator.setIndicatorSize(newCornerRadius);
           }

--- a/lib/java/com/google/android/material/progressindicator/BaseProgressIndicator.java
+++ b/lib/java/com/google/android/material/progressindicator/BaseProgressIndicator.java
@@ -645,7 +645,7 @@ public abstract class BaseProgressIndicator<S extends BaseProgressIndicatorSpec>
    */
   public void setTrackCornerRadius(@Px int trackCornerRadius) {
     if (spec.trackCornerRadius != trackCornerRadius) {
-      spec.trackCornerRadius = min(trackCornerRadius, spec.trackThickness / 2);
+      spec.trackCornerRadius = Math.round(min(trackCornerRadius, spec.trackThickness / 2f));
       invalidate();
     }
   }

--- a/lib/java/com/google/android/material/progressindicator/BaseProgressIndicatorSpec.java
+++ b/lib/java/com/google/android/material/progressindicator/BaseProgressIndicatorSpec.java
@@ -108,7 +108,7 @@ public abstract class BaseProgressIndicatorSpec {
         min(
             getDimensionPixelSize(
                 context, a, R.styleable.BaseProgressIndicator_trackCornerRadius, 0),
-            trackThickness / 2);
+            Math.round(trackThickness / 2f));
     showAnimationBehavior =
         a.getInt(
             R.styleable.BaseProgressIndicator_showAnimationBehavior,

--- a/lib/java/com/google/android/material/progressindicator/CircularDrawingDelegate.java
+++ b/lib/java/com/google/android/material/progressindicator/CircularDrawingDelegate.java
@@ -133,10 +133,10 @@ final class CircularDrawingDelegate extends DrawingDelegate<CircularProgressIndi
         -outerRadiusWithInset, -outerRadiusWithInset, outerRadiusWithInset, outerRadiusWithInset);
 
     // These are used when drawing the indicator and track.
-    useStrokeCap = spec.trackThickness / 2 <= spec.trackCornerRadius;
+    useStrokeCap = spec.trackThickness / 2f <= spec.trackCornerRadius;
     displayedTrackThickness = spec.trackThickness * trackThicknessFraction;
     displayedCornerRadius =
-        min(spec.trackThickness / 2, spec.trackCornerRadius) * trackThicknessFraction;
+        min(spec.trackThickness / 2f, spec.trackCornerRadius) * trackThicknessFraction;
     displayedAmplitude = spec.amplitude * trackThicknessFraction;
 
     // Further adjusts the radius for animated visibility change.

--- a/lib/java/com/google/android/material/progressindicator/LinearDrawingDelegate.java
+++ b/lib/java/com/google/android/material/progressindicator/LinearDrawingDelegate.java
@@ -117,10 +117,10 @@ final class LinearDrawingDelegate extends DrawingDelegate<LinearProgressIndicato
     canvas.clipRect(-halfTrackLength, -halfTrackSize, halfTrackLength, halfTrackSize);
 
     // These are set for the drawing the indicator and track.
-    useStrokeCap = spec.trackThickness / 2 == spec.trackCornerRadius;
+    useStrokeCap = spec.trackThickness / 2f <= spec.trackCornerRadius;
     displayedTrackThickness = spec.trackThickness * trackThicknessFraction;
     displayedCornerRadius =
-        min(spec.trackThickness / 2, spec.trackCornerRadius) * trackThicknessFraction;
+        min(spec.trackThickness / 2f, spec.trackCornerRadius) * trackThicknessFraction;
     displayedAmplitude = spec.amplitude * trackThicknessFraction;
 
     // Further adjusts the canvas for animated visibility change.


### PR DESCRIPTION
Because `trackCornerRadius` is passed as an int and not a float, rounded corners may not be displayed correctly with a certain combination of screen size, `trackThickness`, and `trackCornerRadius`.
In my case, `view.getResources().getDisplayMetrics().density = 2.25`. So `trackThickness = 4dp = 9px` and `trackCornerRadius = 2dp = 4.5px`. Because of type casting, the 0.5f fraction is lost and the corners are rounded incorrectly.

<details>
  <summary>Comparison</summary>

Before | After
-|-
![before](https://github.com/material-components/material-components-android/assets/11145503/841b6ca8-8191-47e5-b52a-ceecd2f23f96)  |  ![after](https://github.com/material-components/material-components-android/assets/11145503/68fcf972-d968-4146-9045-e43af3d38ee5)
</details>