### PR TITLE
[BottomSheetDialog] `initializeViewTreeOwners()` wasn't  triggered when `set/addContentView` so `AbstractComposeView` is not supported.

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetDialog.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetDialog.java
@@ -121,6 +121,7 @@ public class BottomSheetDialog extends AppCompatDialog {
 
   @Override
   public void setContentView(@LayoutRes int layoutResId) {
+    initializeViewTreeOwners();
     super.setContentView(wrapInBottomSheet(layoutResId, null, null));
   }
 
@@ -147,12 +148,20 @@ public class BottomSheetDialog extends AppCompatDialog {
 
   @Override
   public void setContentView(View view) {
+    initializeViewTreeOwners();
     super.setContentView(wrapInBottomSheet(0, view, null));
   }
 
   @Override
   public void setContentView(View view, ViewGroup.LayoutParams params) {
+    initializeViewTreeOwners();
     super.setContentView(wrapInBottomSheet(0, view, params));
+  }
+
+  @Override
+  public void addContentView(@NonNull View view, ViewGroup.LayoutParams params) {
+    initializeViewTreeOwners();
+    super.addContentView(view, params);
   }
 
   @Override


### PR DESCRIPTION
Close #4207.

Because of `getDelegate(): AppCompatDelegate`, the calling chain of `ButtomSheetDialog#add/setContentView` -> `AppCompatDialog#add/setContentView` -> `ComponentDialog#add/setContentView` was broken. So `initializeViewTreeOwners()` wasn't triggered, then `BottomSheetDialog#decorView` has no `LifecycleOwner`. So when `AbstractComposeView` was inserted into the view hierarchy of `BotomSheetDialog`, the extension function below will return null.

```
fun View.findViewTreeLifecycleOwner(): LifecycleOwner? {
    return generateSequence(this) { currentView ->
        currentView.parent as? View
    }.mapNotNull { viewParent ->
        viewParent.getTag(R.id.view_tree_lifecycle_owner) as? LifecycleOwner
    }.firstOrNull()
}
```
So the code below is triggered:

```
val viewTreeLifecycle =
        checkNotNull(lifecycle ?: findViewTreeLifecycleOwner()?.lifecycle) {
            "ViewTreeLifecycleOwner not found from $this"
        }
```

And it's exactly what the log is mentioning.