### PR TITLE
BaseSlider Tooltip Stroke width

### DIFF
--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -329,6 +329,7 @@ abstract class BaseSlider<
   private boolean forceDrawCompatHalo;
   private boolean isLongPress = false;
   private boolean dirtyConfig;
+  private int tooltipStrokeWidth;
 
   @NonNull private ColorStateList haloColor;
   @NonNull private ColorStateList tickColorActive;
@@ -827,10 +828,16 @@ abstract class BaseSlider<
     }
 
     // Add a stroke if there is more than one label for when they overlap.
-    int strokeWidth = labels.size() == 1 ? 0 : 1;
+    int strokeWidth = tooltipStrokeWidth;
     for (TooltipDrawable label : labels) {
       label.setStrokeWidth(strokeWidth);
     }
+  }
+  public void setOverlapTooptipStrokeWidth(int strokeWidth){
+    tooltipStrokeWidth = strokeWidth
+  }
+  public int getOverlapTooptipStrokeWidth(){
+    return tooltipStrokeWidth;
   }
 
   /**


### PR DESCRIPTION
Added api to set and get tooltip width size

-  `[RangeSlider] Tooltip Stroke width api added `
- [RangeSlider] Tooltip Stroke visible for two values `closes #4241`

