### PR TITLE
Create STALE_ISSUES_WORKFLOW.yml

### DIFF
--- a/.github/workflow/STALE_ISSUES_WORKFLOW.yml
+++ b/.github/workflow/STALE_ISSUES_WORKFLOW.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Leverage GitHub Actions to mark old issues as stale after 30 days and close stale issues after 14 days of inactivity.

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [ ] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
