### PR TITLE
[Catalog][DatePicker] Make datepicker fullscreen

### DIFF
--- a/catalog/java/io/material/catalog/application/theme/res/values-v29/themes.xml
+++ b/catalog/java/io/material/catalog/application/theme/res/values-v29/themes.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<resources>
+
+  <style name="Theme.Catalog" parent="Theme.CatalogOriginal">
+    <item name="android:enforceNavigationBarContrast">false</item>
+  </style>
+
+</resources>

--- a/catalog/java/io/material/catalog/application/theme/res/values/themes.xml
+++ b/catalog/java/io/material/catalog/application/theme/res/values/themes.xml
@@ -16,13 +16,15 @@
   -->
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-  <style name="Theme.Catalog" parent="Theme.Material3.DayNight.NoActionBar">
+  <style name="Theme.CatalogOriginal" parent="Theme.Material3.DayNight.NoActionBar">
     <item name="preferenceTheme">@style/CatalogPreferenceThemeOverlay</item>
     <item name="catalogToolbarStyle">@style/Widget.Catalog.Toolbar</item>
     <item name="catalogToolbarWithCloseButtonStyle">@style/Widget.Catalog.Toolbar.WithCloseButton</item>
     <item name="textInputSignInStyle">@style/Widget.Material3.TextInputLayout.OutlinedBox</item>
     <item name="windowActionModeOverlay">true</item>
   </style>
+
+  <style name="Theme.Catalog" parent="Theme.CatalogOriginal"/>
 
   <!-- A theme which sets the status bar color to transparent -->
   <style name="Theme.Catalog.TransparentStatus">


### PR DESCRIPTION
closes #3956
(before)
![301695512-6437e6ea-8150-4c4d-ab02-063b5e65d68e](https://github.com/user-attachments/assets/ff08a594-495d-4f72-b6c7-a1503f9712ac)
The date input button can not be used.
![301695533-2e7059e6-5803-4e1d-b57f-e16a6c797c3b](https://github.com/user-attachments/assets/8548222d-fd2a-455c-a626-730f812f128b)
The close button can not be used.
(after)
![Screenshot_20240909_143906](https://github.com/user-attachments/assets/07dace68-fe88-4977-94cd-a0e0954faca5)
The date input button can not be used.
![Screenshot_20240909_143940](https://github.com/user-attachments/assets/55c91008-98a6-44e8-9548-7d16e1f82016)
The close button can not be used.