### PR TITLE
[Slider] label is gone with slider

### DIFF
--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -426,8 +426,6 @@ abstract class BaseSlider<
 
     scaledTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
 
-    isVisible = isShown();
-
     accessibilityHelper = new AccessibilityHelper(this);
     ViewCompat.setAccessibilityDelegate(this, accessibilityHelper);
 
@@ -1890,6 +1888,7 @@ abstract class BaseSlider<
   @Override
   protected void onAttachedToWindow() {
     super.onAttachedToWindow();
+    isVisible = isShown();
     getViewTreeObserver().addOnScrollChangedListener(onScrollChangedListener);
     getViewTreeObserver().addOnGlobalLayoutListener(onGlobalLayoutListener);
     // The label is attached on the Overlay relative to the content.

--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -354,8 +354,6 @@ abstract class BaseSlider<
   private final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener =
       this::updateLabels;
 
-  private boolean isVisible = true;
-
   /**
    * Determines the behavior of the label which can be any of the following.
    *
@@ -2683,7 +2681,7 @@ abstract class BaseSlider<
   private boolean isSliderVisibleOnScreen() {
     final Rect contentViewBounds = new Rect();
     ViewUtils.getContentView(this).getHitRect(contentViewBounds);
-    return getLocalVisibleRect(contentViewBounds) && isVisible;
+    return getLocalVisibleRect(contentViewBounds) && isShown();
   }
 
   private void ensureLabelsRemoved() {
@@ -3153,12 +3151,6 @@ abstract class BaseSlider<
     if (sliderState.hasFocus) {
       requestFocus();
     }
-  }
-
-  @Override
-  public void onVisibilityAggregated(boolean isVisible) {
-    super.onVisibilityAggregated(isVisible);
-    this.isVisible = isVisible;
   }
 
   static class SliderState extends BaseSavedState {

--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -354,7 +354,7 @@ abstract class BaseSlider<
   private final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener =
       this::updateLabels;
 
-  private boolean isVisible = isShown();
+  private boolean isVisible;
 
   /**
    * Determines the behavior of the label which can be any of the following.
@@ -425,6 +425,8 @@ abstract class BaseSlider<
         MaterialShapeDrawable.SHADOW_COMPAT_MODE_ALWAYS);
 
     scaledTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
+
+    isVisible = isShown();
 
     accessibilityHelper = new AccessibilityHelper(this);
     ViewCompat.setAccessibilityDelegate(this, accessibilityHelper);

--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -354,6 +354,8 @@ abstract class BaseSlider<
   private final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener =
       this::updateLabels;
 
+  private boolean isVisible = true;
+
   /**
    * Determines the behavior of the label which can be any of the following.
    *
@@ -2681,7 +2683,7 @@ abstract class BaseSlider<
   private boolean isSliderVisibleOnScreen() {
     final Rect contentViewBounds = new Rect();
     ViewUtils.getContentView(this).getHitRect(contentViewBounds);
-    return getLocalVisibleRect(contentViewBounds);
+    return getLocalVisibleRect(contentViewBounds) && isVisible;
   }
 
   private void ensureLabelsRemoved() {
@@ -3151,6 +3153,12 @@ abstract class BaseSlider<
     if (sliderState.hasFocus) {
       requestFocus();
     }
+  }
+
+  @Override
+  public void onVisibilityAggregated(boolean isVisible) {
+    super.onVisibilityAggregated(isVisible);
+    this.isVisible = isVisible;
   }
 
   static class SliderState extends BaseSavedState {

--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -354,6 +354,8 @@ abstract class BaseSlider<
   private final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener =
       this::updateLabels;
 
+  private boolean isVisible = isShown();
+
   /**
    * Determines the behavior of the label which can be any of the following.
    *
@@ -2681,7 +2683,17 @@ abstract class BaseSlider<
   private boolean isSliderVisibleOnScreen() {
     final Rect contentViewBounds = new Rect();
     ViewUtils.getContentView(this).getHitRect(contentViewBounds);
-    return getLocalVisibleRect(contentViewBounds) && isShown();
+    return getLocalVisibleRect(contentViewBounds) && isVisible();
+  }
+
+  private boolean isVisible() {
+    return (VERSION.SDK_INT >= VERSION_CODES.N) ? isVisible : isShown();
+  }
+
+  @Override
+  public void onVisibilityAggregated(boolean isVisible) {
+    super.onVisibilityAggregated(isVisible);
+    this.isVisible = isVisible;
   }
 
   private void ensureLabelsRemoved() {


### PR DESCRIPTION
closes #4319
I'm worried about performance:
```
  private boolean isVisible() {
    if (getVisibility() != VISIBLE) {
      return false;
    }
    for (ViewParent viewParent = getParent(); viewParent instanceof View; viewParent = viewParent.getParent()) {
      if (((View) viewParent).getVisibility() != VISIBLE) {
        return false;
      }
    }
    return true;
  }
```