### PR TITLE
[Docs][BottomSheet] not app:enableEdgeToEdge but enableEdgeToEdge

### DIFF
--- a/docs/components/BottomSheet.md
+++ b/docs/components/BottomSheet.md
@@ -204,9 +204,9 @@ specifying any of these to true on the view:
 *   `app:paddingTopSystemWindowInsets`
 
 On API 21 and above the modal bottom sheet will be rendered fullscreen (edge to
-edge) if the navigation bar is transparent and `app:enableEdgeToEdge` is true.
+edge) if the navigation bar is transparent and `enableEdgeToEdge` is true.
 To enable edge-to-edge by default for modal bottom sheets, you can override
-`?attr/bottomSheetDialogTheme` like the below example:
+`?attr/bottomSheetDialogTheme` like the below example (`enableEdgeToEdge` is already true in `ThemeOverlay.Material3.BottomSheetDialog`):
 
 ```xml
 <style name="AppTheme" parent="Theme.Material3.*">


### PR DESCRIPTION
closes #4253
```
<style name="ThemeOverlay.Material3.BottomSheetDialog" parent="Base.ThemeOverlay.Material3.BottomSheetDialog"/>

<style name="Base.ThemeOverlay.Material3.BottomSheetDialog" parent="Base.V21.ThemeOverlay.Material3.BottomSheetDialog"/>

<style name="Base.V21.ThemeOverlay.Material3.BottomSheetDialog"
  parent="Base.V14.ThemeOverlay.Material3.BottomSheetDialog">
  <item name="android:statusBarColor">@android:color/transparent</item>
</style>

<style name="Base.V14.ThemeOverlay.Material3.BottomSheetDialog" parent="Base.ThemeOverlay.Material3.Dialog">
  <item name="android:windowIsFloating">false</item>
  <item name="android:windowSoftInputMode">adjustResize</item>
  <item name="android:windowBackground">@android:color/transparent</item>
  <item name="android:windowAnimationStyle">@style/Animation.Material3.BottomSheetDialog</item>
  <item name="bottomSheetStyle">@style/Widget.Material3.BottomSheet.Modal</item>
  <item name="enableEdgeToEdge">true</item>                                                                 <=====
</style>
```