### PR TITLE
[Slider] Fix slider label not moving

### DIFF
--- a/lib/java/com/google/android/material/slider/BaseSlider.java
+++ b/lib/java/com/google/android/material/slider/BaseSlider.java
@@ -375,11 +375,7 @@ abstract class BaseSlider<
   private final int tooltipTimeoutMillis;
 
   @NonNull
-  private final ViewTreeObserver.OnScrollChangedListener onScrollChangedListener =
-      this::updateLabels;
-
-  @NonNull
-  private final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = this::updateLabels;
+  private final ViewTreeObserver.OnDrawListener onDrawListener = this::updateLabels;
 
   @NonNull
   private final Runnable resetActiveThumbIndex =
@@ -2173,8 +2169,7 @@ abstract class BaseSlider<
     // Update factoring in the visibility of all ancestors.
     thisAndAncestorsVisible = isShown();
 
-    getViewTreeObserver().addOnScrollChangedListener(onScrollChangedListener);
-    getViewTreeObserver().addOnGlobalLayoutListener(onGlobalLayoutListener);
+    getViewTreeObserver().addOnDrawListener(onDrawListener);
     // The label is attached on the Overlay relative to the content.
     for (TooltipDrawable label : labels) {
       attachLabelToContentView(label);
@@ -2195,8 +2190,7 @@ abstract class BaseSlider<
     for (TooltipDrawable label : labels) {
       detachLabelFromContentView(label);
     }
-    getViewTreeObserver().removeOnScrollChangedListener(onScrollChangedListener);
-    getViewTreeObserver().removeOnGlobalLayoutListener(onGlobalLayoutListener);
+    getViewTreeObserver().removeOnDrawListener(onDrawListener);
     super.onDetachedFromWindow();
   }
 
@@ -3034,8 +3028,10 @@ abstract class BaseSlider<
             public void onAnimationEnd(Animator animation) {
               super.onAnimationEnd(animation);
               ViewOverlayImpl contentViewOverlay = ViewUtils.getContentViewOverlay(BaseSlider.this);
-              for (TooltipDrawable label : labels) {
-                contentViewOverlay.remove(label);
+              if (contentViewOverlay != null) {
+                for (TooltipDrawable label : labels) {
+                  contentViewOverlay.remove(label);
+                }
               }
             }
           });


### PR DESCRIPTION
closes #4342

https://github.com/material-components/material-components-android/commit/967dcd5e071773c2d54ab499065b6690524b5752 is incomplete (https://github.com/material-components/material-components-android/issues/2869#issuecomment-1821123500 is not fixed). If the switch statement in the updateStateTextView() method (https://github.com/material-components/material-components-android/blob/master/catalog/java/io/material/catalog/bottomsheet/BottomSheetMainDemoFragment.java#L272-L292) is commented out, the slider label doesn't move. I want to use OnDrawListener instead of OnScrollChangedListener (https://github.com/material-components/material-components-android/commit/5e5eee01bd11f14cf5fbccd17bc18c5926d74774) and OnGlobalLayoutListener (https://github.com/material-components/material-components-android/commit/967dcd5e071773c2d54ab499065b6690524b5752). Does BaseSlider have a better hook?