### PR TITLE
Make highlight text colour respect the the rather than M3 default

### DIFF
--- a/lib/java/com/google/android/material/color/res/color/m3_highlighted_text.xml
+++ b/lib/java/com/google/android/material/color/res/color/m3_highlighted_text.xml
@@ -16,5 +16,5 @@
 -->
 <!-- Material3 alternative to textColorHighlight for light theme -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:alpha="@dimen/material_emphasis_medium" android:color="@color/m3_sys_color_light_primary" />
+    <item android:alpha="@dimen/material_emphasis_medium" android:color="?colorPrimary" />
 </selector>


### PR DESCRIPTION
### Thanks for starting a pull request on Material Components!

Currently when you set your the primary colors like this:

```XML
        <item name="colorPrimary">@color/myColorPrimary</item>
        <item name="colorOnPrimary">@color/myColorOnPrimary</item>
        <item name="colorPrimaryContainer">@color/myColorPrimaryContainer</item>
        <item name="colorOnPrimaryContainer">@color/myColorOnPrimaryContainer</item>
```      

The primary color changes for most M3 views. One thing that glaringly doesn't change is the text highlight color as it hard-code to `@color/m3_sys_color_light_primary` rather than pointing at a theme token such as `?colorPrimary`.

In my app my primary color is blue but the text is highlighting in a shade of purple.

Before:

<img width="354" alt="image" src="https://github.com/user-attachments/assets/c58382e3-c3e3-476b-b544-c8bb2e2c05d9">

After:

<img width="356" alt="image" src="https://github.com/user-attachments/assets/99726279-4228-4e6e-8726-e660d64a643f">

#### Don't forget:

- [ ] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
