### PR TITLE
[MaterialTimePicker] set time wrongly in TimeFormat.CLOCK_12H

### DIFF
--- a/lib/java/com/google/android/material/timepicker/MaterialTimePicker.java
+++ b/lib/java/com/google/android/material/timepicker/MaterialTimePicker.java
@@ -170,7 +170,7 @@ public final class MaterialTimePicker extends DialogFragment implements OnDouble
 
   /** Sets the hour of day in the range [0, 23]. */
   public void setHour(@IntRange(from = 0, to = 23) int hour) {
-    time.setHour(hour);
+    time.setHourOfDay(hour);
     if (activePresenter != null) {
       activePresenter.invalidate();
     }


### PR DESCRIPTION
val picker = MaterialTimePicker.Builder()
.setTimeFormat(TimeFormat.CLOCK_12H)
.setHour(7)
.setMinute(0)
.setTitleText("Select Time")
.build()
picker.show(supportFragmentManager, null)

picker.hour = 20
(this will set time to 8 am not 8 pm)

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
