### PR TITLE
[Catalog] workaround for #4139 ([TopAppBar] Color of ActionBar overflow menu background is incorrect)

### DIFF
--- a/catalog/java/io/material/catalog/AndroidManifest.xml
+++ b/catalog/java/io/material/catalog/AndroidManifest.xml
@@ -59,7 +59,7 @@
       android:name=".topappbar.TopAppBarActionBarDemoActivity"
       android:exported="true"
       android:label="@string/cat_topappbar_action_bar_title"
-      android:theme="@style/Theme.Material3.DayNight"/>
+      android:theme="@style/Theme.Catalog.DayNight"/>
     <activity
       android:name=".topappbar.TopAppBarScrollingTransparentStatusDemoActivity"
       android:exported="true"

--- a/catalog/java/io/material/catalog/application/theme/res/values/themes.xml
+++ b/catalog/java/io/material/catalog/application/theme/res/values/themes.xml
@@ -29,6 +29,10 @@
     <item name="android:statusBarColor">@android:color/transparent</item>
   </style>
 
+  <style name="Theme.Catalog.DayNight" parent="Theme.Material3.DayNight">
+    <item name="actionBarPopupTheme">@null</item>
+  </style>
+
   <style name="CatalogPreferenceThemeOverlay" parent="PreferenceThemeOverlay">
     <item name="switchPreferenceCompatStyle">@style/Preference.SwitchPreferenceCompat.Catalog</item>
   </style>

--- a/catalog/java/io/material/catalog/topappbar/res/menu/cat_topappbar_menu.xml
+++ b/catalog/java/io/material/catalog/topappbar/res/menu/cat_topappbar_menu.xml
@@ -28,4 +28,10 @@
       android:icon="@drawable/ic_favorite_vd_theme_24px"
       android:title="@string/cat_topappbar_favorite_menu_item_title"
       app:showAsAction="ifRoom"/>
+  <item
+    android:title="@string/cat_topappbar_settings_menu_item_title"
+    app:showAsAction="never"/>
+  <item
+    android:title="@string/cat_topappbar_help_and_feedback_menu_item_title"
+    app:showAsAction="never"/>
 </menu>


### PR DESCRIPTION
closes #4139 (precisely, doesn't close #4139)
https://github.com/material-components/material-components-android/issues/4139#issuecomment-2597439479