### PR TITLE
[Catalog] workaround for #4350 ([Standard Bottom Sheet] Clicks pass through standard bottom sheet to the view behind it)

### DIFF
--- a/catalog/java/io/material/catalog/bottomappbar/res/layout/cat_bottomappbar_fragment.xml
+++ b/catalog/java/io/material/catalog/bottomappbar/res/layout/cat_bottomappbar_fragment.xml
@@ -47,6 +47,7 @@
       style="@style/Widget.Material3.BottomSheet"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:clickable="true"
       android:orientation="vertical"
       app:behavior_hideable="true"
       app:layout_behavior="@string/bottom_sheet_behavior">

--- a/catalog/java/io/material/catalog/bottomsheet/res/layout/cat_bottomsheet_standard.xml
+++ b/catalog/java/io/material/catalog/bottomsheet/res/layout/cat_bottomsheet_standard.xml
@@ -21,6 +21,7 @@
     style="@style/Widget.Material3.BottomSheet"
     android:layout_width="match_parent"
     android:layout_height="400dp"
+    android:clickable="true"
     app:behavior_hideable="false"
     app:behavior_peekHeight="200dp"
     app:layout_behavior="@string/bottom_sheet_behavior">


### PR DESCRIPTION
closes #4350 (precisely, doesn't close #4350)