### PR TITLE
[Catalog] workaround for #3988 ([Slider] ripple is not transparent in dark theme on API 33)

### DIFF
--- a/catalog/java/io/material/catalog/application/theme/res/values-night/styles.xml
+++ b/catalog/java/io/material/catalog/application/theme/res/values-night/styles.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2025 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<resources>
+
+  <style name="Widget.Catalog.Slider" parent="Widget.Material3.Slider">
+    <item name="haloColor">@android:color/transparent</item>
+  </style>
+
+</resources>

--- a/catalog/java/io/material/catalog/application/theme/res/values/styles.xml
+++ b/catalog/java/io/material/catalog/application/theme/res/values/styles.xml
@@ -32,4 +32,8 @@
     <item name="android:background">?attr/actionBarItemBackground</item>
   </style>
 
+  <style name="Widget.Catalog.Slider" parent="Widget.Material3.Slider">
+    <item name="haloColor">#00FFFFFF</item>
+  </style>
+
 </resources>

--- a/catalog/java/io/material/catalog/application/theme/res/values/themes.xml
+++ b/catalog/java/io/material/catalog/application/theme/res/values/themes.xml
@@ -22,6 +22,7 @@
     <item name="catalogToolbarWithCloseButtonStyle">@style/Widget.Catalog.Toolbar.WithCloseButton</item>
     <item name="textInputSignInStyle">@style/Widget.Material3.TextInputLayout.OutlinedBox</item>
     <item name="windowActionModeOverlay">true</item>
+    <item name="sliderStyle">@style/Widget.Catalog.Slider</item>
   </style>
 
   <!-- A theme which sets the status bar color to transparent -->


### PR DESCRIPTION
https://github.com/material-components/material-components-android/issues/3988#issuecomment-1931776315
closes #3988 (precisely, doesn't close #3988)