### PR TITLE
[DatePicker] Make the month buttons navigate through months, not pages

### DIFF
--- a/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
+++ b/lib/java/com/google/android/material/datepicker/MaterialCalendar.java
@@ -587,24 +587,16 @@ public final class MaterialCalendar<S> extends PickerFragment<S> {
           }
         });
 
-    monthNext.setOnClickListener(
-        new OnClickListener() {
-          @Override
-          public void onClick(View view) {
-            int currentItem = getLayoutManager().findFirstVisibleItemPosition();
-            monthsPagerAdapter.setKeyboardFocusDirection(View.FOCUS_FORWARD);
-            setCurrentMonth(monthsPagerAdapter.getPageMonth(currentItem + 1));
-          }
-        });
-    monthPrev.setOnClickListener(
-        new OnClickListener() {
-          @Override
-          public void onClick(View view) {
-            int currentItem = getLayoutManager().findLastVisibleItemPosition();
-            monthsPagerAdapter.setKeyboardFocusDirection(View.FOCUS_BACKWARD);
-            setCurrentMonth(monthsPagerAdapter.getPageMonth(currentItem - 1));
-          }
-        });
+    monthNext.setOnClickListener(view -> {
+      monthsPagerAdapter.setKeyboardFocusDirection(View.FOCUS_FORWARD);
+      Month currentMonth = getCurrentMonth();
+      setCurrentMonth(currentMonth.monthsLater(1));
+    });
+    monthPrev.setOnClickListener(view -> {
+      monthsPagerAdapter.setKeyboardFocusDirection(View.FOCUS_BACKWARD);
+      Month currentMonth = getCurrentMonth();
+      setCurrentMonth(currentMonth.monthsLater(-1));
+    });
 
     int currentMonthPosition = monthsPagerAdapter.getPosition(current);
     updateNavigationButtonsEnabled(currentMonthPosition);


### PR DESCRIPTION
ℹ️ This PR also slightly improves the responsiveness of the prev/next month buttons (related to https://github.com/material-components/material-components-android/issues/4552).