### PR TITLE
[SideSheet] Prevent NullPointerException when viewRef was nullified and only then accessed by runAfterLayout lambda

### DIFF
--- a/lib/java/com/google/android/material/sidesheet/SideSheetBehavior.java
+++ b/lib/java/com/google/android/material/sidesheet/SideSheetBehavior.java
@@ -645,7 +645,7 @@ public class SideSheetBehavior<V extends View> extends CoordinatorLayout.Behavio
       runAfterLayout(
           viewRef.get(),
           () -> {
-            V child = viewRef.get();
+            V child = viewRef != null ? viewRef.get() : null;
             if (child != null) {
               startSettling(child, finalState, false);
             }


### PR DESCRIPTION
Prevent NullPointerException when viewRef was nullified as part of SideSheetBehavior.onDetachedFromLayoutParams() and only then accessed by runAfterLayout lambda. Similar nearby checks outside of lambda are not enough, as all of them are executed immediately, and access in lambda is done later, after layout.
