### PR TITLE
[FloatingActionButton] Fix the width calculation in the wrap_content extend strategy

### DIFF
--- a/lib/java/com/google/android/material/floatingactionbutton/ExtendedFloatingActionButton.java
+++ b/lib/java/com/google/android/material/floatingactionbutton/ExtendedFloatingActionButton.java
@@ -293,7 +293,8 @@ public class ExtendedFloatingActionButton extends MaterialButton implements Atta
           @Override
           public int getWidth() {
             return getMeasuredWidth()
-                - getCollapsedPadding() * 2
+                - ExtendedFloatingActionButton.this.getPaddingStart()
+                - ExtendedFloatingActionButton.this.getPaddingEnd()
                 + extendedPaddingStart
                 + extendedPaddingEnd;
           }


### PR DESCRIPTION
Fixes https://github.com/material-components/material-components-android/issues/4630.

--

_P.S. Originally posted by @pubiqq in https://github.com/material-components/material-components-android/issues/4596#issuecomment-2688859561_.
            