### PR TITLE
[FloatingActionButton] Use the current labelOpacity as the initial animation value

### DIFF
--- a/lib/java/com/google/android/material/floatingactionbutton/ExtendedFloatingActionButton.java
+++ b/lib/java/com/google/android/material/floatingactionbutton/ExtendedFloatingActionButton.java
@@ -43,6 +43,7 @@ import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewGroup.MarginLayoutParams;
 import androidx.annotation.AnimatorRes;
+import androidx.annotation.ColorInt;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -458,6 +459,15 @@ public class ExtendedFloatingActionButton extends MaterialButton implements Atta
 
   private void saveOriginalTextCsl() {
     originalTextCsl = getTextColors();
+  }
+
+  ColorStateList getOriginalTextColor() {
+    return originalTextCsl;
+  }
+
+  @ColorInt
+  int getCurrentOriginalTextColor() {
+    return originalTextCsl.getColorForState(getDrawableState(), 0);
   }
 
   /**
@@ -1417,7 +1427,9 @@ public class ExtendedFloatingActionButton extends MaterialButton implements Atta
 
       if (spec.hasPropertyValues("labelOpacity")) {
         PropertyValuesHolder[] labelOpacityValues = spec.getPropertyValues("labelOpacity");
-        float startValue = extending ? 0F : 1F;
+        final int originalAlpha = Color.alpha(getCurrentOriginalTextColor());
+        final int currentAlpha = Color.alpha(getCurrentTextColor());
+        float startValue = originalAlpha != 0 ? (float) currentAlpha / originalAlpha : 0f;
         float endValue = extending ? 1F : 0F;
         labelOpacityValues[0].setFloatValues(startValue, endValue);
         spec.setPropertyValues("labelOpacity", labelOpacityValues);


### PR DESCRIPTION
The PR makes `labelOpacity` animate from the FAB's current opacity value, rather than a value that is opposite the target value. This change fixes the blink that occurs when a button is animated from an intermediate state.

--

_P.S. Originally posted by @pubiqq in https://github.com/material-components/material-components-android/issues/4595#issuecomment-2688913973_.