### PR TITLE
[HideViewOnScrollBehavior] Add a method to get the HideViewOnScrollBehavior associated with the view

### DIFF
--- a/lib/java/com/google/android/material/behavior/HideViewOnScrollBehavior.java
+++ b/lib/java/com/google/android/material/behavior/HideViewOnScrollBehavior.java
@@ -421,4 +421,24 @@ public class HideViewOnScrollBehavior<V extends View> extends Behavior<V> {
   public boolean isDisabledOnTouchExploration() {
     return disableOnTouchExploration;
   }
+
+  /**
+   * A utility function to get the {@link HideViewOnScrollBehavior} associated with the {@code view}.
+   *
+   * @param view The {@link View} with {@link HideViewOnScrollBehavior}.
+   * @return The {@link HideViewOnScrollBehavior} associated with the {@code view}.
+   */
+  @NonNull
+  @SuppressWarnings("unchecked")
+  public static <V extends View> HideViewOnScrollBehavior<V> from(@NonNull V view) {
+    ViewGroup.LayoutParams params = view.getLayoutParams();
+    if (!(params instanceof LayoutParams)) {
+      throw new IllegalArgumentException("The view is not a child of CoordinatorLayout");
+    }
+    CoordinatorLayout.Behavior<?> behavior = ((LayoutParams) params).getBehavior();
+    if (!(behavior instanceof HideViewOnScrollBehavior)) {
+      throw new IllegalArgumentException("The view is not associated with HideViewOnScrollBehavior");
+    }
+    return (HideViewOnScrollBehavior<V>) behavior;
+  }
 }


### PR DESCRIPTION
The PR adds a method to get the HideViewOnScrollBehavior associated with the view, similar to [`BottomSheetBehavior#from(V)`](https://developer.android.com/reference/com/google/android/material/bottomsheet/BottomSheetBehavior#from(V)) and [`SideSheetBehavior#from(V)`](https://developer.android.com/reference/com/google/android/material/sidesheet/SideSheetBehavior#from(V)).