### PR TITLE
[Catalog] make buttons tonal instead of outlined

### DIFF
--- a/catalog/java/io/material/catalog/preferences/res/layout/mtrl_preferences_dialog_option_button.xml
+++ b/catalog/java/io/material/catalog/preferences/res/layout/mtrl_preferences_dialog_option_button.xml
@@ -16,10 +16,11 @@
 <Button
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  style="?attr/materialButtonOutlinedStyle"
+  style="?attr/materialButtonTonalStyle"
   android:layout_width="wrap_content"
   android:layout_height="wrap_content"
   android:paddingLeft="8dp"
   android:paddingRight="12dp"
   android:minWidth="0dp"
-  app:iconPadding="4dp"/>
+  app:iconPadding="4dp"
+  app:materialSizeOverlay="@style/SizeOverlay.Material3Expressive.Button.Xsmall"/>


### PR DESCRIPTION
https://m3.material.io/components/button-groups/overview
![Screenshot_20250526_183458](https://github.com/user-attachments/assets/e608b7ec-db5f-4ff2-a2fd-99a5c7066fd9)
⬇️
![Screenshot_20250526_184016](https://github.com/user-attachments/assets/134d1767-100b-4dc7-ad4f-412d7fa3a758)