### PR TITLE
Update design_password_eye.xml

### DIFF
--- a/lib/java/com/google/android/material/textfield/res/drawable/design_password_eye.xml
+++ b/lib/java/com/google/android/material/textfield/res/drawable/design_password_eye.xml
@@ -20,13 +20,13 @@
     tools:ignore="NewApi">
 
     <item
-        android:id="@+id/visible"
-        android:drawable="@drawable/design_ic_visibility_off"
-        android:state_checked="true"/>
-
-    <item
         android:id="@+id/masked"
-        android:drawable="@drawable/design_ic_visibility"/>
+        android:drawable="@drawable/design_ic_visibility"
+        android:state_checked="true" />
+  
+    <item
+        android:id="@+id/visible"
+        android:drawable="@drawable/design_ic_visibility_off" />
 
     <transition
         android:drawable="@drawable/avd_hide_password"


### PR DESCRIPTION
Fixed reversed behavior of this drawable with passwordToggleEnabled attribute of TextInputLayout of material design.
previously happens,
Eye close = password shows as text
Eye open = password shows as dot dot
NOW (fixed),
Eye close = password shows as dot dot
Eye open = password shows as text