### PR TITLE
[MaterialContainerTransform] Add copyViewImage to decrease cost

### DIFF
--- a/lib/java/com/google/android/material/transition/MaterialContainerTransform.java
+++ b/lib/java/com/google/android/material/transition/MaterialContainerTransform.java
@@ -22,6 +22,7 @@ import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 import static androidx.core.util.Preconditions.checkNotNull;
 import static com.google.android.material.transition.TransitionUtils.calculateArea;
 import static com.google.android.material.transition.TransitionUtils.convertToRelativeCornerSizes;
+import static com.google.android.material.transition.TransitionUtils.copyViewImage;
 import static com.google.android.material.transition.TransitionUtils.createColorShader;
 import static com.google.android.material.transition.TransitionUtils.defaultIfNull;
 import static com.google.android.material.transition.TransitionUtils.findAncestorById;
@@ -935,11 +936,11 @@ public final class MaterialContainerTransform extends Transition {
     final TransitionDrawable transitionDrawable =
         new TransitionDrawable(
             getPathMotion(),
-            startView,
+            copyViewImage(sceneRoot, startView, startView.getParent() != null ? startView.getParent() : startView),
             startBounds,
             startShapeAppearanceModel,
             getElevationOrDefault(startElevation, startView),
-            endView,
+            copyViewImage(sceneRoot, endView, endView.getParent() != null ? endView.getParent() : endView),
             endBounds,
             endShapeAppearanceModel,
             getElevationOrDefault(endElevation, endView),

--- a/lib/java/com/google/android/material/transition/TransitionUtils.java
+++ b/lib/java/com/google/android/material/transition/TransitionUtils.java
@@ -18,7 +18,9 @@ package com.google.android.material.transition;
 
 import android.animation.TimeInterpolator;
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Matrix;
 import android.graphics.LinearGradient;
 import android.graphics.Rect;
 import android.graphics.RectF;
@@ -26,6 +28,7 @@ import android.graphics.Shader;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewParent;
+import android.widget.ImageView;
 import androidx.annotation.AttrRes;
 import androidx.annotation.ColorInt;
 import androidx.annotation.FloatRange;
@@ -49,12 +52,96 @@ class TransitionUtils {
   static final int NO_DURATION = -1;
   @AttrRes static final int NO_ATTR_RES_ID = 0;
 
+  private static final int MAX_IMAGE_SIZE = 1024 * 1024;
+  
   // Constants corresponding to motionPath theme attr enum values.
   private static final int PATH_TYPE_LINEAR = 0;
   private static final int PATH_TYPE_ARC = 1;
 
   private TransitionUtils() {}
 
+  /**
+     * Creates a View using the bitmap copy of <code>view</code>. If <code>view</code> is large,
+     * the copy will use a scaled bitmap of the given view.
+     *
+     * @param sceneRoot The ViewGroup in which the view copy will be displayed.
+     * @param view The view to create a copy of.
+     * @param parent The parent of view.
+     */
+    public static View copyViewImage(ViewGroup sceneRoot, View view, View parent) {
+        Matrix matrix = new Matrix();
+        matrix.setTranslate(-parent.getScrollX(), -parent.getScrollY());
+        view.transformMatrixToGlobal(matrix);
+        sceneRoot.transformMatrixToLocal(matrix);
+        RectF bounds = new RectF(0, 0, view.getWidth(), view.getHeight());
+        matrix.mapRect(bounds);
+        int left = Math.round(bounds.left);
+        int top = Math.round(bounds.top);
+        int right = Math.round(bounds.right);
+        int bottom = Math.round(bounds.bottom);
+        ImageView copy = new ImageView(view.getContext());
+        copy.setScaleType(ImageView.ScaleType.CENTER_CROP);
+        Bitmap bitmap = createViewBitmap(view, matrix, bounds, sceneRoot);
+        if (bitmap != null) {
+            copy.setImageBitmap(bitmap);
+        }
+        int widthSpec = View.MeasureSpec.makeMeasureSpec(right - left, View.MeasureSpec.EXACTLY);
+        int heightSpec = View.MeasureSpec.makeMeasureSpec(bottom - top, View.MeasureSpec.EXACTLY);
+        copy.measure(widthSpec, heightSpec);
+        copy.layout(left, top, right, bottom);
+        return copy;
+    }
+    /**
+     * Creates a Bitmap of the given view, using the Matrix matrix to transform to the local
+     * coordinates. <code>matrix</code> will be modified during the bitmap creation.
+     *
+     * <p>If the bitmap is large, it will be scaled uniformly down to at most 1MB size.</p>
+     * @param view The view to create a bitmap for.
+     * @param matrix The matrix converting the view local coordinates to the coordinates that
+     *               the bitmap will be displayed in. <code>matrix</code> will be modified before
+     *               returning.
+     * @param bounds The bounds of the bitmap in the destination coordinate system (where the
+     *               view should be presented. Typically, this is matrix.mapRect(viewBounds);
+     * @param sceneRoot A ViewGroup that is attached to the window to temporarily contain the view
+     *                  if it isn't attached to the window.
+     * @return A bitmap of the given view or null if bounds has no width or height.
+     */
+    public static Bitmap createViewBitmap(View view, Matrix matrix, RectF bounds,
+            ViewGroup sceneRoot) {
+        final boolean addToOverlay = !view.isAttachedToWindow();
+        ViewGroup parent = null;
+        int indexInParent = 0;
+        if (addToOverlay) {
+            if (sceneRoot == null || !sceneRoot.isAttachedToWindow()) {
+                return null;
+            }
+            parent = (ViewGroup) view.getParent();
+            indexInParent = parent.indexOfChild(view);
+            sceneRoot.getOverlay().add(view);
+        }
+        Bitmap bitmap = null;
+        int bitmapWidth = Math.round(bounds.width());
+        int bitmapHeight = Math.round(bounds.height());
+        if (bitmapWidth > 0 && bitmapHeight > 0) {
+            float scale = Math.min(1f, ((float) MAX_IMAGE_SIZE) / (bitmapWidth * bitmapHeight));
+            bitmapWidth *= scale;
+            bitmapHeight *= scale;
+            matrix.postTranslate(-bounds.left, -bounds.top);
+            matrix.postScale(scale, scale);
+            final Picture picture = new Picture();
+            final Canvas canvas = picture.beginRecording(bitmapWidth, bitmapHeight);
+            canvas.concat(matrix);
+            view.draw(canvas);
+            picture.endRecording();
+            bitmap = Bitmap.createBitmap(picture);
+        }
+        if (addToOverlay) {
+            sceneRoot.getOverlay().remove(view);
+            parent.addView(view, indexInParent);
+        }
+        return bitmap;
+    }
+  
   static boolean maybeApplyThemeInterpolator(
       Transition transition,
       Context context,


### PR DESCRIPTION
### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.

In developing, I found that the MaterialContainerTransform costs more than MaterialSharedAxis, which is has set low-bitmap enough to decrease cost.

Digging deeper, the MaterialSharedAxis is extended from androidx.transition, which has set copyViewToImage to set low-bitmap.

So, I added it into TransitionUtils and MaterialContainerTransform to increase performance.

After 
<img width="1080" height="2460" alt="Screenshot_20250501-145511_Hydrogen" src="https://github.com/user-attachments/assets/dd9d8b10-e36f-40c7-9c20-4fc63f490821" />

Before 
<img width="1080" height="2460" alt="Screenshot_20250419-192242_Hydrogen" src="https://github.com/user-attachments/assets/5c028e99-c695-44af-bd40-a338d41133da" />
