### PR TITLE
Fixed password_toggle visibility is reversed

### DIFF
--- a/lib/java/com/google/android/material/textfield/res/drawable/design_password_eye.xml
+++ b/lib/java/com/google/android/material/textfield/res/drawable/design_password_eye.xml
@@ -22,7 +22,7 @@
     <item
         android:id="@+id/visible"
         android:drawable="@drawable/design_ic_visibility_off"
-        android:state_checked="true"/>
+        android:state_checked="false"/>
 
     <item
         android:id="@+id/masked"

--- a/lib/java/com/google/android/material/textfield/res/drawable/m3_password_eye.xml
+++ b/lib/java/com/google/android/material/textfield/res/drawable/m3_password_eye.xml
@@ -22,7 +22,7 @@
     <item
         android:id="@+id/visible"
         android:drawable="@drawable/design_ic_visibility_off"
-        android:state_checked="true"/>
+        android:state_checked="false"/>
 
     <item
         android:id="@+id/masked"


### PR DESCRIPTION
Currently, when using app:endIconMode="password_toggle">, the visibility of password is swapped, when eye is open: pasword is not visible and when eye is closed password is hidden.

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [ ] Link to GitHub issues it solves. `closes #1234`
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
