### PR TITLE
[ButtonGroup] Implement height change animation in vertical MaterialButtonGroup

### DIFF
--- a/lib/java/com/google/android/material/button/MaterialButton.java
+++ b/lib/java/com/google/android/material/button/MaterialButton.java
@@ -246,8 +246,11 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
 
   private int orientation = UNSET;
   private float originalWidth = UNSET;
+  private float originalHeight = UNSET;
   @Px private int originalPaddingStart = UNSET;
+  @Px private int originalPaddingTop = UNSET;
   @Px private int originalPaddingEnd = UNSET;
+  @Px private int originalPaddingBottom = UNSET;
 
   @Nullable private LayoutParams originalLayoutParams;
 
@@ -258,11 +261,16 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
 
   // Fields for size morphing.
   @Px int allowedWidthDecrease = UNSET;
+  @Px int allowedHeightDecrease = UNSET;
   @Nullable StateListSizeChange sizeChange;
   @Px int widthChangeMax;
+  @Px int heightChangeMax;
   private float displayedWidthIncrease;
   private float displayedWidthDecrease;
+  private float displayedHeightIncrease;
+  private float displayedHeightDecrease;
   @Nullable private SpringAnimation widthIncreaseSpringAnimation;
+  @Nullable private SpringAnimation heightIncreaseSpringAnimation;
 
   public MaterialButton(@NonNull Context context) {
     this(context, null /* attrs */);
@@ -324,9 +332,14 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
     updateIcon(/* needsIconReset= */ icon != null);
   }
 
-  private void initializeSizeAnimation() {
+  private void initializeWidthAnimation() {
     widthIncreaseSpringAnimation = new SpringAnimation(this, WIDTH_INCREASE);
     widthIncreaseSpringAnimation.setSpring(createSpringForce());
+  }
+
+  private void initializeHeightAnimation() {
+    heightIncreaseSpringAnimation = new SpringAnimation(this, HEIGHT_INCREASE);
+    heightIncreaseSpringAnimation.setSpring(createSpringForce());
   }
 
   private SpringForce createSpringForce() {
@@ -544,6 +557,7 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
     if (orientation != curOrientation) {
       orientation = curOrientation;
       originalWidth = UNSET;
+      originalHeight = UNSET;
     }
     if (originalWidth == UNSET) {
       originalWidth = getMeasuredWidth();
@@ -560,6 +574,21 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
         setLayoutParams(newLayoutParams);
       }
     }
+    if (originalHeight == UNSET) {
+      originalHeight = getMeasuredHeight();
+      // The height morph leverage the height of the layout params. However, it's not available if
+      // layout_weight is used. We need to hardcode the height here. The original layout params will
+      // be preserved for the correctness of distribution when buttons are added or removed into the
+      // group programmatically.
+      if (originalLayoutParams == null
+          && getParent() instanceof MaterialButtonGroup
+          && ((MaterialButtonGroup) getParent()).getButtonSizeChange() != null) {
+        originalLayoutParams = (LayoutParams) getLayoutParams();
+        LayoutParams newLayoutParams = new LayoutParams(originalLayoutParams);
+        newLayoutParams.height = (int) originalHeight;
+        setLayoutParams(newLayoutParams);
+      }
+    }
 
     if (allowedWidthDecrease == UNSET) {
       int localIconSizeAndPadding =
@@ -568,12 +597,25 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
               : getIconPadding() + (iconSize == 0 ? icon.getIntrinsicWidth() : iconSize);
       allowedWidthDecrease = getMeasuredWidth() - getTextLayoutWidth() - localIconSizeAndPadding;
     }
+    if (allowedHeightDecrease == UNSET) {
+      int localIconSizeAndPadding =
+          icon == null
+              ? 0
+              : getIconPadding() + (iconSize == 0 ? icon.getIntrinsicHeight() : iconSize);
+      allowedHeightDecrease = getMeasuredHeight() - getTextLayoutHeight() - localIconSizeAndPadding;
+    }
 
     if (originalPaddingStart == UNSET) {
       originalPaddingStart = getPaddingStart();
     }
+    if (originalPaddingTop == UNSET) {
+      originalPaddingTop = getPaddingTop();
+    }
     if (originalPaddingEnd == UNSET) {
       originalPaddingEnd = getPaddingEnd();
+    }
+    if (originalPaddingBottom == UNSET) {
+      originalPaddingBottom = getPaddingBottom();
     }
     isInHorizontalButtonGroup = isInHorizontalButtonGroup();
   }
@@ -583,6 +625,7 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
       setLayoutParams(originalLayoutParams);
       originalLayoutParams = null;
       originalWidth = UNSET;
+      originalHeight = UNSET;
     }
   }
 
@@ -590,6 +633,12 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
   public void setWidth(@Px int pixels) {
     originalWidth = UNSET;
     super.setWidth(pixels);
+  }
+
+  @Override
+  public void setHeight(@Px int pixels) {
+    originalHeight = UNSET;
+    super.setHeight(pixels);
   }
 
   @Override
@@ -754,6 +803,16 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
       maxWidth = max(maxWidth, getLayout().getLineWidth(line));
     }
     return (int) ceil(maxWidth);
+  }
+
+  private int getTextLayoutHeight() {
+    float maxHeight = 0;
+    int lineCount = getLineCount();
+    for (int line = 0; line < lineCount; line++) {
+      int height = getLayout().getLineBottom(line) - getLayout().getLineTop(line);
+      maxHeight = max(maxHeight, height);
+    }
+    return (int) ceil(maxHeight);
   }
 
   private int getTextHeight() {
@@ -1520,9 +1579,14 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
     if (sizeChange == null) {
       return;
     }
+
     if (widthIncreaseSpringAnimation == null) {
-      initializeSizeAnimation();
+      initializeWidthAnimation();
     }
+    if (heightIncreaseSpringAnimation == null) {
+      initializeHeightAnimation();
+    }
+
     if (isInHorizontalButtonGroup) {
       // Animate width.
       int widthChange =
@@ -1535,6 +1599,19 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
       widthIncreaseSpringAnimation.animateToFinalPosition(widthChange);
       if (skipAnimation) {
         widthIncreaseSpringAnimation.skipToEnd();
+      }
+    } else {
+      // Animate height.
+      int heightChange =
+          min(
+              heightChangeMax,
+              sizeChange
+                  .getSizeChangeForState(getDrawableState())
+                  .heightChange
+                  .getChange(getHeight()));
+      heightIncreaseSpringAnimation.animateToFinalPosition(heightChange);
+      if (skipAnimation) {
+        heightIncreaseSpringAnimation.skipToEnd();
       }
     }
   }
@@ -1583,6 +1660,41 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
   void setDisplayedWidthDecrease(int widthDecrease) {
     displayedWidthDecrease = min(widthDecrease, allowedWidthDecrease);
     updatePaddingsAndSizeForWidthAnimation();
+    invalidate();
+  }
+
+  void setHeightChangeMax(@Px int heightChangeMax) {
+    if (this.heightChangeMax != heightChangeMax) {
+      this.heightChangeMax = heightChangeMax;
+      maybeAnimateSize(/* skipAnimation= */ true);
+    }
+  }
+
+  @Px
+  int getAllowedHeightDecrease() {
+    return allowedHeightDecrease;
+  }
+
+  private float getDisplayedHeightIncrease() {
+    return displayedHeightIncrease;
+  }
+
+  private void setDisplayedHeightIncrease(float heightIncrease) {
+    if (displayedHeightIncrease != heightIncrease) {
+      displayedHeightIncrease = heightIncrease;
+      updatePaddingsAndSizeForHeightAnimation();
+      invalidate();
+      // Report width changed to the parent group.
+      if (getParent() instanceof MaterialButtonGroup) {
+        ((MaterialButtonGroup) getParent())
+            .onButtonHeightChanged(this, (int) displayedHeightIncrease);
+      }
+    }
+  }
+
+  void setDisplayedHeightDecrease(int heightDecrease) {
+    displayedHeightDecrease = min(heightDecrease, allowedHeightDecrease);
+    updatePaddingsAndSizeForHeightAnimation();
     invalidate();
   }
 
@@ -1639,6 +1751,17 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
         getPaddingBottom());
   }
 
+  private void updatePaddingsAndSizeForHeightAnimation() {
+    int heightChange = (int) (displayedHeightIncrease - displayedHeightDecrease);
+    int paddingTopChange = heightChange / 2;
+    getLayoutParams().height = (int) (originalHeight + heightChange);
+    setPaddingRelative(
+        originalPaddingStart,
+        originalPaddingTop + paddingTopChange,
+        originalPaddingEnd,
+        originalPaddingBottom + heightChange - paddingTopChange);
+  }
+
   private int getOpticalCenterShift() {
     if (opticalCenterEnabled && isInHorizontalButtonGroup) {
       MaterialShapeDrawable materialShapeDrawable = materialButtonHelper.getMaterialShapeDrawable();
@@ -1661,6 +1784,18 @@ public class MaterialButton extends AppCompatButton implements Checkable, Shapea
         @Override
         public void setValue(MaterialButton button, float value) {
           button.setDisplayedWidthIncrease(value);
+        }
+      };
+  private static final FloatPropertyCompat<MaterialButton> HEIGHT_INCREASE =
+      new FloatPropertyCompat<MaterialButton>("heightIncrease") {
+        @Override
+        public float getValue(MaterialButton button) {
+          return button.getDisplayedHeightIncrease();
+        }
+
+        @Override
+        public void setValue(MaterialButton button, float value) {
+          button.setDisplayedHeightIncrease(value);
         }
       };
 

--- a/lib/java/com/google/android/material/button/res/xml/m3_button_group_child_size_change.xml
+++ b/lib/java/com/google/android/material/button/res/xml/m3_button_group_child_size_change.xml
@@ -16,6 +16,6 @@
     -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-  <item android:state_pressed="true" app:widthChange="15%"/>
-  <item app:widthChange="0%"/>
+  <item android:state_pressed="true" app:widthChange="15%" app:heightChange="15%"/>
+  <item app:widthChange="0%" app:heightChange="0%"/>
 </selector>

--- a/lib/java/com/google/android/material/shape/StateListSizeChange.java
+++ b/lib/java/com/google/android/material/shape/StateListSizeChange.java
@@ -129,6 +129,19 @@ public class StateListSizeChange {
     return maxWidthChange;
   }
 
+  public int getMaxHeightChange(@Px int baseHeight) {
+    int maxHeightChange = -baseHeight;
+    for (int i = 0; i < stateCount; i++) {
+      SizeChange sizeChange = sizeChanges[i];
+      if (sizeChange.heightChange.type == SizeChangeType.PIXELS) {
+        maxHeightChange = (int) max(maxHeightChange, sizeChange.heightChange.amount);
+      } else if (sizeChange.widthChange.type == SizeChangeType.PERCENT) {
+        maxHeightChange = (int) max(maxHeightChange, baseHeight * sizeChange.heightChange.amount);
+      }
+    }
+    return maxHeightChange;
+  }
+
   private int indexOfStateSet(int[] stateSet) {
     final int[][] stateSpecs = this.stateSpecs;
     for (int i = 0; i < stateCount; i++) {
@@ -165,6 +178,8 @@ public class StateListSizeChange {
 
       SizeChangeAmount widthChangeAmount =
           getSizeChangeAmount(a, R.styleable.StateListSizeChange_widthChange, null);
+      SizeChangeAmount heightChangeAmount =
+          getSizeChangeAmount(a, R.styleable.StateListSizeChange_heightChange, null);
 
       a.recycle();
 
@@ -174,12 +189,12 @@ public class StateListSizeChange {
       int[] stateSpec = new int[numAttrs];
       for (int i = 0; i < numAttrs; i++) {
         final int stateResId = attrs.getAttributeNameResource(i);
-        if (stateResId != R.attr.widthChange) {
+        if (stateResId != R.attr.widthChange && stateResId != R.attr.heightChange) {
           stateSpec[j++] = attrs.getAttributeBooleanValue(i, false) ? stateResId : -stateResId;
         }
       }
       stateSpec = StateSet.trimStateSet(stateSpec, j);
-      addStateSizeChange(stateSpec, new SizeChange(widthChangeAmount));
+      addStateSizeChange(stateSpec, new SizeChange(widthChangeAmount, heightChangeAmount));
     }
   }
 
@@ -226,13 +241,16 @@ public class StateListSizeChange {
   /** A collection of all values needed in a size change. */
   public static class SizeChange {
     @Nullable public SizeChangeAmount widthChange;
+    @Nullable public SizeChangeAmount heightChange;
 
-    SizeChange(@Nullable SizeChangeAmount widthChange) {
+    SizeChange(@Nullable SizeChangeAmount widthChange, @Nullable SizeChangeAmount heightChange) {
       this.widthChange = widthChange;
+      this.heightChange = heightChange;
     }
 
     SizeChange(@NonNull SizeChange other) {
       this.widthChange = new SizeChangeAmount(other.widthChange.type, other.widthChange.amount);
+      this.heightChange = new SizeChangeAmount(other.heightChange.type, other.heightChange.amount);
     }
   }
 

--- a/lib/java/com/google/android/material/shape/res/values/attrs.xml
+++ b/lib/java/com/google/android/material/shape/res/values/attrs.xml
@@ -72,6 +72,8 @@
   <declare-styleable name="StateListSizeChange">
     <!-- The change on width. Dimension for absolute value; fraction for relative value. -->
     <attr name="widthChange" format="dimension|fraction"/>
+    <!-- The change on height. Dimension for absolute value; fraction for relative value. -->
+    <attr name="heightChange" format="dimension|fraction"/>
   </declare-styleable>
 
   <!-- The size of extra small corners. -->

--- a/lib/javatests/com/google/android/material/shape/StateListSizeChangeTest.java
+++ b/lib/javatests/com/google/android/material/shape/StateListSizeChangeTest.java
@@ -67,11 +67,17 @@ public class StateListSizeChangeTest {
     SizeChange defaultSizeChange = stateListSizeChange.getDefaultSizeChange();
 
     assertEquals(PERCENT, pressedSizeChange.widthChange.type);
+    assertEquals(PERCENT, pressedSizeChange.heightChange.type);
     assertEquals(0.15, pressedSizeChange.widthChange.amount, FLOAT_TOLERANCE);
+    assertEquals(0.15, pressedSizeChange.heightChange.amount, FLOAT_TOLERANCE);
     assertEquals(PIXELS, unspecifiedStateSizeChange.widthChange.type);
+    assertEquals(PIXELS, unspecifiedStateSizeChange.heightChange.type);
     assertEquals(0, unspecifiedStateSizeChange.widthChange.amount, FLOAT_TOLERANCE);
+    assertEquals(0, unspecifiedStateSizeChange.heightChange.amount, FLOAT_TOLERANCE);
     assertEquals(PIXELS, defaultSizeChange.widthChange.type);
+    assertEquals(PIXELS, defaultSizeChange.heightChange.type);
     assertEquals(0, defaultSizeChange.widthChange.amount, FLOAT_TOLERANCE);
+    assertEquals(0, defaultSizeChange.heightChange.amount, FLOAT_TOLERANCE);
   }
 
   @Test
@@ -91,11 +97,17 @@ public class StateListSizeChangeTest {
     SizeChange defaultSizeChange = stateListSizeChange.getDefaultSizeChange();
 
     assertEquals(PERCENT, pressedSizeChange.widthChange.type);
+    assertEquals(PERCENT, pressedSizeChange.heightChange.type);
     assertEquals(0.15, pressedSizeChange.widthChange.amount, FLOAT_TOLERANCE);
+    assertEquals(0.15, pressedSizeChange.heightChange.amount, FLOAT_TOLERANCE);
     assertEquals(PERCENT, unspecifiedStateSizeChange.widthChange.type);
+    assertEquals(PERCENT, unspecifiedStateSizeChange.heightChange.type);
     assertEquals(0.15, unspecifiedStateSizeChange.widthChange.amount, FLOAT_TOLERANCE);
+    assertEquals(0.15, unspecifiedStateSizeChange.heightChange.amount, FLOAT_TOLERANCE);
     assertEquals(PERCENT, defaultSizeChange.widthChange.type);
+    assertEquals(PERCENT, defaultSizeChange.heightChange.type);
     assertEquals(0.15, defaultSizeChange.widthChange.amount, FLOAT_TOLERANCE);
+    assertEquals(0.15, defaultSizeChange.heightChange.amount, FLOAT_TOLERANCE);
   }
 
   private AttributeSet setupAttributeSetForTest() {

--- a/lib/javatests/com/google/android/material/shape/res/xml/state_list_size_change.xml
+++ b/lib/javatests/com/google/android/material/shape/res/xml/state_list_size_change.xml
@@ -16,6 +16,6 @@
   -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
-  <item android:state_pressed="true" app:widthChange="15%" />
-  <item app:widthChange="0dp" />
+  <item android:state_pressed="true" app:widthChange="15%" app:heightChange="15%" />
+  <item app:widthChange="0dp" app:heightChange="0dp" />
 </selector>

--- a/lib/javatests/com/google/android/material/shape/res/xml/state_list_size_change_without_default.xml
+++ b/lib/javatests/com/google/android/material/shape/res/xml/state_list_size_change_without_default.xml
@@ -16,5 +16,5 @@
   -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
-  <item android:state_pressed="true" app:widthChange="15%" />
+  <item android:state_pressed="true" app:widthChange="15%" app:heightChange="15%" />
 </selector>


### PR DESCRIPTION
Hi all, let me know if I should open an issue first for a pull request like this: I wrote on Mastodon with Liam Spradlin from the design team who helped designing the button groups behavior, my question was whether a vertical button group also should animate the height of the button neighbors like it animates the width in horizontal orientation:

> [@iamliam](https://androiddev.social/@iamliam@mastodon.design) Hi Liam, one specific question regarding button groups: in the next expressive update of my metronome app I would like to use vertical button groups of MDC Android with large icon buttons. The view library doesn't animate the height of the buttons on tap as it would animate the width in a horizontal button group and I think there aren't any specs for vertical button groups in the docs. Should the height also be animated or are vertical button groups generally not intended?

> [@patzly](https://androiddev.social/@patzly) the height should be animated in both orientations, because the design intent is to affect the surrounding buttons on interaction. If it's not supported, I can pass that along to the team working on the library!

I found no open or closed issue for that so I implemented it on my own, I hope it's all correct! Tests are green and the catalog button group animations are working now in vertical orientation like Liam said.