### PR TITLE
[TimePicker] Make the dial selector discrete

### DIFF
--- a/lib/java/com/google/android/material/timepicker/ClockFaceView.java
+++ b/lib/java/com/google/android/material/timepicker/ClockFaceView.java
@@ -91,7 +91,8 @@ class ClockFaceView extends RadialViewGroup implements OnRotateListener {
 
   private String[] values;
 
-  private float currentHandRotation;
+  private float currentHandDegrees;
+  private float currentHandLevel;
 
   private final ColorStateList textColor;
 
@@ -366,11 +367,14 @@ class ClockFaceView extends RadialViewGroup implements OnRotateListener {
   }
 
   @Override
-  public void onRotate(float rotation, boolean animating) {
-    if (abs(currentHandRotation - rotation) > EPSILON) {
-      currentHandRotation = rotation;
-      findIntersectingTextView();
+  public void onRotate(float degrees, int level, boolean animating) {
+    if (currentHandDegrees == degrees && currentHandLevel == level) {
+      return;
     }
+
+    currentHandDegrees = degrees;
+    currentHandLevel = level;
+    findIntersectingTextView();
   }
 
   @Override

--- a/lib/java/com/google/android/material/timepicker/TimePickerView.java
+++ b/lib/java/com/google/android/material/timepicker/TimePickerView.java
@@ -192,6 +192,10 @@ class TimePickerView extends ConstraintLayout implements TimePickerControls {
     clockFace.setValues(values, contentDescription);
   }
 
+  void setStopParams(int stopCount, int numberStopCount, int stopOffset) {
+    clockHandView.setStopParams(stopCount, numberStopCount, stopOffset);
+  }
+
   @Override
   public void setHandRotation(float rotation) {
     clockHandView.setHandRotation(rotation);


### PR DESCRIPTION
The PR modifies the behavior of the dial selector so that it better matches the m3 guideline and the expected behavior specified in [this](https://github.com/material-components/material-components-android/pull/4766) thread.

In particular, this PR makes it so that the time [never changes when the selector is released](https://github.com/material-components/material-components-android/pull/4766#issuecomment-3058603637), and also fixes click detection for the dial selector (supercedes https://github.com/material-components/material-components-android/pull/4766).