### PR TITLE
[Catalog] Use app:overflowMode="wrap"

### DIFF
--- a/catalog/java/io/material/catalog/preferences/res/layout/mtrl_preferences_dialog_option_button.xml
+++ b/catalog/java/io/material/catalog/preferences/res/layout/mtrl_preferences_dialog_option_button.xml
@@ -15,12 +15,6 @@
   -->
 <Button
   xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   style="?attr/materialButtonTonalStyle"
   android:layout_width="wrap_content"
-  android:layout_height="wrap_content"
-  android:paddingLeft="8dp"
-  android:paddingRight="12dp"
-  android:minWidth="0dp"
-  app:iconPadding="4dp"
-  app:materialSizeOverlay="@style/SizeOverlay.Material3Expressive.Button.Xsmall"/>
+  android:layout_height="wrap_content"/>

--- a/catalog/java/io/material/catalog/preferences/res/layout/mtrl_preferences_dialog_preference.xml
+++ b/catalog/java/io/material/catalog/preferences/res/layout/mtrl_preferences_dialog_preference.xml
@@ -32,10 +32,11 @@
 
   <com.google.android.material.button.MaterialButtonToggleGroup
     android:id="@+id/preference_options"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="8dp"
     app:selectionRequired="true"
-    app:singleSelection="true" />
+    app:singleSelection="true"
+    app:overflowMode="wrap"/>
 
 </LinearLayout>


### PR DESCRIPTION
#4884:
> Hi! According to our designers / spec, when using toggle buttons it's best to wrap them to the next line as opposed to putting toggle buttons into an overflow. This is because toggle buttons in a group are all very related to each other, and it's important to show them all together on screen.
```
<com.google.android.material.button.MaterialButtonToggleGroup
    />
```
![](https://github.com/user-attachments/assets/1b466967-97de-41b7-9afd-e214b3751ef5)
⬇️
```
<com.google.android.material.button.MaterialButtonToggleGroup
    app:overflowMode="wrap"/>
```
![](https://github.com/user-attachments/assets/710a43ce-49f1-4837-95db-e6fa55d33199)

https://github.com/material-components/material-components-android/blob/master/docs/components/ToggleButtonGroup.md:

> Note: Segmented buttons are being deprecated in the Material 3 expressive update. For those who have updated, use the [connected button group](https://github.com/material-components/material-components-android/blob/master/docs/components/ButtonGroup.md) instead, which has mostly the same functionality but with an updated visual design.

What are being deprecated in the Material 3 expressive update?