### PR TITLE
[ButtonToggleGroup] Fix broken corner morph animation by skipping redundant updates

### DIFF
--- a/lib/java/com/google/android/material/button/MaterialButtonGroup.java
+++ b/lib/java/com/google/android/material/button/MaterialButtonGroup.java
@@ -693,11 +693,40 @@ public class MaterialButtonGroup extends LinearLayout {
           originalStateListShapeBuilder
               .setCornerSizeOverride(innerCornerSize, cornerPositionBitsToOverride)
               .build();
+
+      // Pre-calculate the default shape to compare with the current one.
+      ShapeAppearanceModel newModel = newStateListShape.getDefaultShape(/* withCornerSizeOverrides= */ true);
+
+      // Get the current shape of the button.
+      ShapeAppearanceModel currentModel = button.getShapeAppearanceModel();
+
+      // If the corner sizes are effectively the same, skip the update.
+      // This prevents the MaterialShapeDrawable from resetting its state,
+      // which would otherwise interrupt the corner morph animation.
+      if (areCornerSizesEqual(currentModel, newModel)) {
+        continue;
+      }
+
+      // Apply the new shape if it has changed.
       button.setShapeAppearance(
           newStateListShape.isStateful()
               ? newStateListShape
               : newStateListShape.getDefaultShape(/* withCornerSizeOverrides= */ true));
     }
+  }
+
+  /**
+   * Returns true if the corner sizes of the two {@link ShapeAppearanceModel}s are equal.
+   *
+   * <p>This is used to determine if a shape update is necessary, avoiding redundant updates that
+   * could interrupt ongoing animations.
+   */
+  private static boolean areCornerSizesEqual(
+      @NonNull ShapeAppearanceModel s1, @NonNull ShapeAppearanceModel s2) {
+    return s1.getTopLeftCornerSize().equals(s2.getTopLeftCornerSize())
+        && s1.getTopRightCornerSize().equals(s2.getTopRightCornerSize())
+        && s1.getBottomLeftCornerSize().equals(s2.getBottomLeftCornerSize())
+        && s1.getBottomRightCornerSize().equals(s2.getBottomRightCornerSize());
   }
 
   /**


### PR DESCRIPTION
### Description
This PR fixes a regression where the corner morph animation in `MaterialButtonToggleGroup` was abrupt or interrupted in recent versions (1.14.0-alpha07+).

### Cause Analysis
The issue was caused by unconditional calls to `setShapeAppearanceModel()` in `updateChildShapes()` during layout updates.
Due to stricter checks introduced in recent `MaterialShapeDrawable` optimizations (likely related to skipping animation on bounds change), re-setting the shape triggered a reset in the drawable, cancelling the ongoing morph animation.

### Fix
I added a check to compare the calculated `ShapeAppearanceModel` (specifically corner sizes) with the button's current shape using a helper method `areCornerSizesEqual`. If they are effectively equal, the update is skipped.
This prevents the redundant reset and allows the `MaterialShapeDrawable` to complete its morphing animation smoothly.

### Issue
Closes #4990

### Tests
- [x] Verified manually in the Catalog app -> Buttons -> Button Toggle Group.
- [x] Confirmed that the animation is smooth again (matches behavior in `1.14.0-alpha06`).

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.