### PR TITLE
[Internal][CollapsingTextHelper] Fix letter spacing not updating correctly

### DIFF
--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -696,17 +696,6 @@ public final class CollapsingTextHelper {
       currentDrawY = lerp(expandedDrawY, collapsedDrawY, fraction, positionInterpolator);
 
       setInterpolatedTextSize(fraction);
-
-      if (collapsedLetterSpacing != expandedLetterSpacing) {
-        textPaint.setLetterSpacing(
-            lerp(
-                expandedLetterSpacing,
-                collapsedLetterSpacing,
-                fraction,
-                AnimationUtils.FAST_OUT_SLOW_IN_INTERPOLATOR));
-      } else {
-        textPaint.setLetterSpacing(collapsedLetterSpacing);
-      }
     }
 
     setCollapsedTextBlend(
@@ -1099,7 +1088,11 @@ public final class CollapsingTextHelper {
       newTypeface = collapsedTypeface;
     } else {
       newTextSize = expandedTextSize;
-      newLetterSpacing = expandedLetterSpacing;
+      newLetterSpacing = lerp(
+          expandedLetterSpacing,
+          collapsedLetterSpacing,
+          fraction,
+          AnimationUtils.FAST_OUT_SLOW_IN_INTERPOLATOR);
       newTypeface = expandedTypeface;
       if (isClose(fraction, /* targetValue= */ 0)) {
         // If we're close to the expanded text size, snap to it and use a scale of 1


### PR DESCRIPTION
In the current implementation, when [the letter spacing is changed](https://github.com/material-components/material-components-android/blob/4b26950d6cb1de90b512d641c5357c498755dc03/lib/java/com/google/android/material/internal/CollapsingTextHelper.java#L700-L709), neither [`currentLetterSpacing`](https://github.com/material-components/material-components-android/blob/4b26950d6cb1de90b512d641c5357c498755dc03/lib/java/com/google/android/material/internal/CollapsingTextHelper.java#L165) nor the [text layout](https://github.com/material-components/material-components-android/blob/4b26950d6cb1de90b512d641c5357c498755dc03/lib/java/com/google/android/material/internal/CollapsingTextHelper.java#L167) is updated, and this PR fixes that.

Also it fixes https://github.com/material-components/material-components-android/issues/5014.