### PR TITLE
[Internal][CollapsingTextHelper] Fix letter spacing for collapsed text

### DIFF
--- a/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
+++ b/lib/java/com/google/android/material/internal/CollapsingTextHelper.java
@@ -1088,8 +1088,7 @@ public final class CollapsingTextHelper {
 
     if (isClose(fraction, /* targetValue= */ 1)) {
       newTextSize = shouldTruncateCollapsedToSingleLine() ? collapsedTextSize : expandedTextSize;
-      newLetterSpacing =
-          shouldTruncateCollapsedToSingleLine() ? collapsedLetterSpacing : expandedLetterSpacing;
+      newLetterSpacing = collapsedLetterSpacing;
       scale =
           shouldTruncateCollapsedToSingleLine()
               ? 1f


### PR DESCRIPTION
Collapsed text must have a letter spacing value of `collapsedLetterSpacing`, regardless of whether the text is scaled or not.