### PR TITLE
[TextField] Match cursor error color to text field state

### DIFF
--- a/lib/java/com/google/android/material/textfield/TextInputLayout.java
+++ b/lib/java/com/google/android/material/textfield/TextInputLayout.java
@@ -4577,7 +4577,10 @@ public class TextInputLayout extends LinearLayout implements OnGlobalLayoutListe
 
     Drawable cursorDrawable = DrawableCompat.wrap(editText.getTextCursorDrawable()).mutate();
     if (isOnError() && cursorErrorColor != null) {
-      color = cursorErrorColor;
+      int defaultCursorErrorColor = cursorErrorColor.getDefaultColor();
+      int targetCursorErrorColor = cursorErrorColor.getColorForState(
+          editText.getDrawableState(), defaultCursorErrorColor);
+      color = ColorStateList.valueOf(targetCursorErrorColor);
     }
     cursorDrawable.setTintList(color);
   }


### PR DESCRIPTION
Also fixes https://github.com/material-components/material-components-android/issues/5022