### PR TITLE
[CircularProgressIndicator] Fix full circle track seam artifact

### DIFF
--- a/lib/java/com/google/android/material/progressindicator/CircularDrawingDelegate.java
+++ b/lib/java/com/google/android/material/progressindicator/CircularDrawingDelegate.java
@@ -313,6 +313,18 @@ final class CircularDrawingDelegate extends DrawingDelegate<CircularProgressIndi
             && shouldDrawActiveIndicator
             && amplitudeFraction > 0f;
 
+    // Full circle: use drawOval to avoid seam artifact at the start/end point where caps overlap.
+    if (arcDegree >= 360f && !shouldDrawWavyPath) {
+      paint.setAntiAlias(true);
+      paint.setColor(paintColor);
+      paint.setStrokeWidth(displayedTrackThickness);
+      paint.setStyle(Style.STROKE);
+      paint.setStrokeCap(Cap.BUTT);
+      arcBounds.set(-adjustedRadius, -adjustedRadius, adjustedRadius, adjustedRadius);
+      canvas.drawOval(arcBounds, paint);
+      return;
+    }
+
     // Sets up the paint.
     paint.setAntiAlias(true);
     paint.setColor(paintColor);


### PR DESCRIPTION
## Summary
- When `CircularDrawingDelegate.drawArc()` renders a full circle (360°) track with `trackCornerRadius > 0`, the start/end caps or rounded blocks overlap at 0°, producing a visible seam artifact
- Replace `drawArc()` with `drawOval()` for full circle tracks — `drawOval` has no start/end point, so the seam is eliminated entirely
- Partial arcs (active indicators) continue to use the existing `drawArc()` logic unchanged

https://github.com/user-attachments/assets/c2d03b49-2d80-4c36-af28-25f48528a249


## Demo branch

A separate branch with catalog app changes to reproduce and verify the fix:
[`demo/circular-indicator-seam-reproduction`](https://github.com/Nanamare/material-components-android/tree/demo/circular-indicator-seam-reproduction)

It includes:
- Catalog theme switched to `Theme.Material3.DayNight.NoActionBar`
- Custom `CircularProgressIndicator` style with `trackCornerRadius=8dp` to make the artifact visible
- [Full diff against this PR](https://github.com/Nanamare/material-components-android/compare/fix/circular-indicator-full-circle-seam...demo/circular-indicator-seam-reproduction)

## Test plan
- [ ] Verify `CircularProgressIndicator` with `trackCornerRadius > 0` renders a seamless full circle track
- [ ] Verify determinate indicator (partial arc) still draws correctly with rounded corners
- [ ] Verify indeterminate animation renders correctly
- [ ] Verify wavy effect paths are unaffected (bypass the `drawOval` path)
- [ ] Run `./gradlew test` — JVM tests pass

Fixes #5027