### PR TITLE
[BottomSheet] Fix velocity-based dismiss through nested scroll path

### DIFF
--- a/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
+++ b/lib/java/com/google/android/material/bottomsheet/BottomSheetBehavior.java
@@ -326,6 +326,8 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
 
   private int lastNestedScrollDy;
 
+  private float lastNestedFlingVelocityY;
+
   private boolean nestedScrolled;
 
   private float hideFriction = HIDE_FRICTION;
@@ -775,6 +777,7 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
       int type) {
     lastNestedScrollDy = 0;
     nestedScrolled = false;
+    lastNestedFlingVelocityY = 0;
     return (axes & ViewCompat.SCROLL_AXIS_VERTICAL) != 0;
   }
 
@@ -884,7 +887,10 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
           targetState = STATE_EXPANDED;
         }
       }
-    } else if (hideable && shouldHide(child, getYVelocity())) {
+    } else if (hideable
+        && shouldHide(
+            child,
+            lastNestedFlingVelocityY != 0 ? lastNestedFlingVelocityY : getYVelocity())) {
       targetState = STATE_HIDDEN;
     } else if (lastNestedScrollDy == 0) {
       int currentTop = child.getTop();
@@ -953,9 +959,15 @@ public class BottomSheetBehavior<V extends View> extends CoordinatorLayout.Behav
       float velocityY) {
 
     if (isNestedScrollingCheckEnabled() && hasScrollingChild()) {
-      return isViewScrollingChild(target)
-          && ((state != STATE_EXPANDED && !draggableOnNestedScrollLastDragIgnored)
-              || super.onNestedPreFling(coordinatorLayout, child, target, velocityX, velocityY));
+      boolean consumed =
+          isViewScrollingChild(target)
+              && ((state != STATE_EXPANDED && !draggableOnNestedScrollLastDragIgnored)
+                  || super.onNestedPreFling(
+                      coordinatorLayout, child, target, velocityX, velocityY));
+      if (consumed) {
+        lastNestedFlingVelocityY = velocityY;
+      }
+      return consumed;
     } else {
       return false;
     }


### PR DESCRIPTION
closes https://github.com/material-components/material-components-android/issues/5076

`onStopNestedScroll` called `getYVelocity()` which returned `0` because `activePointerId` was already reset by `onInterceptTouchEvent(ACTION_UP)`. Store the fling velocity from `onNestedPreFling` and use it in `onStopNestedScroll` so `shouldHide()` receives the real velocity.

## Changes
- Added `lastNestedFlingVelocityY` field to capture fling velocity from the nested scroll path
- In `onNestedPreFling`, store `velocityY` when the fling is consumed
- In `onStopNestedScroll`, prefer the stored fling velocity over `getYVelocity()` (which returns `0` due to the invalid pointer ID)
- Reset the stored velocity in `onStartNestedScroll` at the beginning of each gesture

### Thanks for starting a pull request on Material Components!

#### Don't forget:

- [x] Identify the component the PR relates to in brackets in the title.
  `[Buttons] Updated documentation`
- [x] Link to GitHub issues it solves. `closes #1234`
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-android/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
