### PR TITLE
Preserve custom long-click listeners on navigation items

### DIFF
--- a/lib/java/com/google/android/material/navigation/NavigationBarItemView.java
+++ b/lib/java/com/google/android/material/navigation/NavigationBarItemView.java
@@ -46,6 +46,7 @@ import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.FrameLayout;
@@ -161,6 +162,9 @@ public abstract class NavigationBarItemView extends FrameLayout
   private int activeIndicatorExpandedMarginHorizontal = 0;
 
   @Nullable private BadgeDrawable badgeDrawable;
+  @Nullable private CharSequence tooltipText;
+  @Nullable private OnLongClickListener customOnLongClickListener;
+  private boolean settingTooltipCompatLongClickListener;
 
   @ItemIconGravity private int itemIconGravity;
   private int badgeFixedEdge = BadgeDrawable.BADGE_FIXED_EDGE_START;
@@ -291,10 +295,7 @@ public abstract class NavigationBarItemView extends FrameLayout
             ? itemData.getTooltipText()
             : itemData.getTitle();
 
-    // Avoid calling tooltip for L and M devices because long pressing twice may freeze devices.
-    if (VERSION.SDK_INT > VERSION_CODES.M) {
-      TooltipCompat.setTooltipText(this, tooltipText);
-    }
+    setItemTooltipText(tooltipText);
     updateVisibility();
     this.initialized = true;
   }
@@ -482,9 +483,41 @@ public abstract class NavigationBarItemView extends FrameLayout
         itemData == null || TextUtils.isEmpty(itemData.getTooltipText())
             ? title
             : itemData.getTooltipText();
+    setItemTooltipText(tooltipText);
+  }
+
+  @Override
+  public void setOnLongClickListener(@Nullable OnLongClickListener listener) {
+    if (settingTooltipCompatLongClickListener) {
+      super.setOnLongClickListener(listener);
+      return;
+    }
+
+    customOnLongClickListener = listener;
+    super.setOnLongClickListener(listener);
+    updateTooltipText();
+  }
+
+  private void setItemTooltipText(@Nullable CharSequence tooltipText) {
+    this.tooltipText = tooltipText;
+    updateTooltipText();
+  }
+
+  private void updateTooltipText() {
     // Avoid calling tooltip for L and M devices because long pressing twice may freeze devices.
-    if (VERSION.SDK_INT > VERSION_CODES.M) {
-      TooltipCompat.setTooltipText(this, tooltipText);
+    if (VERSION.SDK_INT <= VERSION_CODES.M) {
+      return;
+    }
+
+    if (VERSION.SDK_INT >= VERSION_CODES.O) {
+      setTooltipText(tooltipText);
+    } else if (customOnLongClickListener == null) {
+      settingTooltipCompatLongClickListener = true;
+      try {
+        TooltipCompat.setTooltipText(this, tooltipText);
+      } finally {
+        settingTooltipCompatLongClickListener = false;
+      }
     }
   }
 

--- a/lib/javatests/com/google/android/material/navigation/NavigationBarItemViewTest.java
+++ b/lib/javatests/com/google/android/material/navigation/NavigationBarItemViewTest.java
@@ -17,6 +17,7 @@ package com.google.android.material.navigation;
 
 import com.google.android.material.test.R;
 
+import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.O;
 import static com.google.common.truth.Truth.assertThat;
 
@@ -78,6 +79,25 @@ public final class NavigationBarItemViewTest {
     itemView.setTitle(updatedTitle);
 
     assertThat(itemView.getTooltipText().toString()).isEqualTo(updatedTitle);
+  }
+
+  @Test
+  @Config(sdk = N)
+  public void testPreOLongClickListener_preservedAfterTitleUpdate() {
+    MenuItemImpl menuItem = createMenuItemImpl("menu item title", null);
+    NavigationBarItemView itemView = new NavigationBarItemTestView(context);
+    itemView.initialize(menuItem, MENU_TYPE);
+    final boolean[] longClicked = new boolean[1];
+    itemView.setOnLongClickListener(
+        v -> {
+          longClicked[0] = true;
+          return true;
+        });
+
+    itemView.setTitle("menu item title updated");
+
+    assertThat(itemView.performLongClick()).isTrue();
+    assertThat(longClicked[0]).isTrue();
   }
 
   private MenuItemImpl createMenuItemImpl(CharSequence title, CharSequence tooltip) {


### PR DESCRIPTION
## Summary
- avoid re-installing pre-O TooltipCompat long-click handling when a custom NavigationBarItemView long-click listener is present
- keep the existing L/M tooltip guard and platform tooltip behavior on O+
- add a Robolectric regression for a custom listener surviving a title refresh on API 24

Fixes #1368.

## Test plan
- ./gradlew :lib:testDebugUnitTest --tests com.google.android.material.navigation.NavigationBarItemViewTest
- ./gradlew :lib:lintDebug
- git diff --check